### PR TITLE
docs: Add smartergpt-structure-v1 specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,21 +104,46 @@ This shared vocabulary is what lets Lex answer:
 ```bash
 npm install @guffawaffle/lex
 
-# Initialize working files (creates .smartergpt.local/lex/ with policy and DB)
-npm run setup-local
+# Initialize workspace structure
+npx lex init
 ```
+
+This creates the `.smartergpt.local/` workspace:
+```
+.smartergpt.local/
+├── profile.yml              # Workspace metadata
+├── lex/
+│   ├── lexmap.policy.json   # Module dependency policy
+│   └── memory.db            # Frame database (created on first use)
+├── runner/                  # lex-pr-runner artifacts
+└── prompts/                 # Local prompt overlays
+```
+
+**See:** [`docs/specs/smartergpt-structure-v1.md`](./docs/specs/smartergpt-structure-v1.md) for complete specification.
+
+#### Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `LEX_CANON_DIR` | Override canonical resources root | (package defaults) |
+| `LEX_DB_PATH` | Database location | `.smartergpt.local/lex/memory.db` |
+| `SMARTERGPT_PROFILE` | Profile configuration path | `.smartergpt.local/profile.yml` |
 
 The package includes:
 - **`prompts/`**: Default prompt templates (customizable via `.smartergpt.local/prompts/`)
-- **`schemas/`**: JSON Schemas for validation (customizable via `.smartergpt.local/schemas/`)
+- **`schemas/`**: JSON Schemas for validation (tracked in `.smartergpt/schemas/`)
 - **`dist/`**: Compiled TypeScript modules
 
-#### Customizing Prompts/Schemas
+#### Customizing Prompts
 
-1. **Local overlay:** Create `.smartergpt.local/prompts/` or `.smartergpt.local/schemas/` to override defaults
-2. **Environment override:** Set `LEX_PROMPTS_DIR=/custom/prompts` and/or `LEX_SCHEMAS_DIR=/custom/schemas` (highest precedence)
+1. **Local overlay:** Copy prompts to `.smartergpt.local/prompts/` and customize
+   ```bash
+   cp prompts/remember.md .smartergpt.local/prompts/
+   vim .smartergpt.local/prompts/remember.md
+   ```
+2. **Environment override:** Set `LEX_CANON_DIR=/custom/canon` for highest precedence
 
-**Precedence chain:** `LEX_PROMPTS_DIR`/`LEX_SCHEMAS_DIR` → `.smartergpt.local/` → package defaults
+**Precedence chain:** `LEX_CANON_DIR/prompts/` → `.smartergpt.local/prompts/` → package `prompts/`
 
 ### Quick Start
 

--- a/docs/specs/smartergpt-structure-v1.md
+++ b/docs/specs/smartergpt-structure-v1.md
@@ -1,0 +1,183 @@
+# .smartergpt Structure Specification v1
+
+**Status:** Accepted  
+**Version:** 1.0.0  
+**Last Updated:** 2025-11-13
+
+## Overview
+
+The `.smartergpt.local/` structure provides a standardized, portable workspace for Lex and lex-pr-runner tooling. This specification defines the directory layout, precedence chains, and environment variable expansion rules.
+
+## Directory Structure
+
+### Tracked (`.smartergpt/`)
+Repository-tracked canonical resources:
+
+```
+.smartergpt/
+├── schemas/          # JSON Schemas for configuration files
+│   ├── profile.schema.json
+│   ├── policy.schema.json
+│   └── ...
+└── prompts/          # Canonical prompt templates (tracked)
+    ├── remember.md
+    ├── recall.md
+    └── ...
+```
+
+**Purpose:** Version-controlled defaults and schemas  
+**Git:** Tracked  
+**Precedence:** Lowest (fallback when no local override exists)
+
+### Local (`.smartergpt.local/`)
+User workspace for local development and overrides:
+
+```
+.smartergpt.local/
+├── profile.yml       # Workspace profile metadata
+├── lex/              # Lex-specific working files
+│   ├── lexmap.policy.json  # Module dependency policy
+│   └── memory.db           # Episodic memory database
+├── runner/           # lex-pr-runner artifacts
+│   ├── plan.json
+│   ├── cache/
+│   └── deliverables/
+└── prompts/          # Local prompt overlays
+    └── custom-prompt.md
+```
+
+**Purpose:** Local development, working state, user customizations  
+**Git:** Ignored (`.gitignore`)  
+**Precedence:** Highest (overrides canonical)
+
+## Precedence Chains
+
+### Prompts
+```
+1. LEX_CANON_DIR/prompts/        (if LEX_CANON_DIR set)
+2. .smartergpt.local/prompts/    (local overlays)
+3. prompts/                      (package canonical)
+```
+
+### Schemas
+```
+1. .smartergpt/schemas/          (repo tracked)
+2. node_modules/@guffawaffle/lex/schemas/  (package)
+```
+
+### Configuration
+```
+1. .smartergpt.local/profile.yml (local)
+2. .smartergpt/profile.yml       (repo default, if exists)
+```
+
+## Environment Variables
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `LEX_CANON_DIR` | Override canonical resource root | `/path/to/custom/canon` |
+| `SMARTERGPT_PROFILE` | Specify profile path | `.smartergpt.local/profile.yml` |
+| `LEX_DB_PATH` | Override database location | `.smartergpt.local/lex/memory.db` |
+
+## Token Expansion
+
+Configuration files support token expansion:
+
+| Token | Expands To | Example |
+|-------|------------|---------|
+| `$HOME` | User home directory | `/home/user` |
+| `$PWD` | Current working directory | `/srv/lex-mcp/lex` |
+| `${VAR}` | Environment variable | `${LEX_CANON_DIR}/prompts` |
+
+**Example `profile.yml`:**
+```yaml
+role: local
+name: Local Dev
+paths:
+  canon: ${LEX_CANON_DIR:-$PWD/.smartergpt}
+  database: .smartergpt.local/lex/memory.db
+```
+
+## Platform-Specific Considerations
+
+### Windows
+- Use forward slashes in YAML: `path: .smartergpt.local/lex/memory.db`
+- Environment variables: `%USERPROFILE%` becomes `$HOME`
+
+### WSL
+- Windows paths must be converted: `/mnt/c/Users/...`
+- Use WSL-native paths in configuration
+
+### macOS/Linux
+- Standard POSIX paths work without conversion
+
+## Migration Guide
+
+### From Legacy Structure
+
+**Before:**
+```
+.smartergpt/
+├── runner/
+│   ├── intent.md
+│   ├── plan.json
+│   └── cache/
+└── lex-brain.db
+```
+
+**After:**
+```
+.smartergpt.local/
+├── profile.yml
+├── lex/
+│   ├── lexmap.policy.json
+│   └── memory.db
+└── runner/
+    ├── plan.json
+    └── cache/
+```
+
+**Migration Steps:**
+1. Run `npx lex init` to create new structure
+2. Copy `lex-brain.db` → `.smartergpt.local/lex/memory.db`
+3. Move runner artifacts to `.smartergpt.local/runner/`
+4. Update `.gitignore` to exclude `.smartergpt.local/`
+
+## Usage Examples
+
+### Initialize Workspace
+```bash
+npx lex init
+```
+
+### Create Local Prompt Override
+```bash
+cp prompts/remember.md .smartergpt.local/prompts/
+vim .smartergpt.local/prompts/remember.md
+```
+
+### Validate Configuration
+```bash
+npx lex validate-profile .smartergpt.local/profile.yml
+```
+
+## Schema Validation
+
+All configuration files SHOULD include a `$schema` reference:
+
+```yaml
+# .smartergpt.local/profile.yml
+$schema: ../.smartergpt/schemas/profile.schema.json
+role: local
+```
+
+This enables:
+- IDE autocomplete
+- Real-time validation
+- Documentation tooltips
+
+## References
+
+- **Implementation:** [Issue #183](https://github.com/Guffawaffle/lex/issues/183)
+- **Init Command:** [Issue #230](https://github.com/Guffawaffle/lex/issues/230)
+- **Related:** `DIRECTORY_ALIGNMENT.md`


### PR DESCRIPTION
Closes #188

## Changes
- Created comprehensive specification at `docs/specs/smartergpt-structure-v1.md`
- Updated README.md with workspace structure section
- Documented `npx lex init` workflow

## Specification Includes
- Complete directory structure (tracked vs local)
- Precedence chains for all resources
- Environment variable reference
- Platform-specific considerations
- Migration guide from legacy structure
- Schema validation examples

## Verification
```bash
cat docs/specs/smartergpt-structure-v1.md
```