### PR TITLE
fix: Support scoped package names in repo root detection

### DIFF
--- a/src/memory/store/db.ts
+++ b/src/memory/store/db.ts
@@ -65,7 +65,7 @@ export function getDefaultDbPath(): string {
 }
 
 /**
- * Find repository root by looking for package.json with name "lex"
+ * Find repository root by looking for package.json with name "lex" or "@smartergpt/lex"
  */
 function findRepoRoot(startPath: string): string {
   let currentPath = startPath;
@@ -75,7 +75,7 @@ function findRepoRoot(startPath: string): string {
     if (existsSync(packageJsonPath)) {
       try {
         const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-        if (packageJson.name === "lex") {
+        if (packageJson.name === "lex" || packageJson.name === "@smartergpt/lex") {
           return currentPath;
         }
       } catch {

--- a/src/shared/policy/loader.ts
+++ b/src/shared/policy/loader.ts
@@ -46,15 +46,17 @@ function findRepoRoot(startPath: string): string {
     const packageJsonPath = join(currentPath, "package.json");
     if (existsSync(packageJsonPath)) {
       const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-      // Check if this is the lex root package
-      if (packageJson.name === "lex") {
+      // Check if this is the lex root package (with or without scope)
+      if (packageJson.name === "lex" || packageJson.name === "@smartergpt/lex") {
         return currentPath;
       }
     }
     currentPath = dirname(currentPath);
   }
 
-  throw new Error('Could not find repository root (looking for package.json with name "lex")');
+  throw new Error(
+    'Could not find repository root (looking for package.json with name "lex" or "@smartergpt/lex")'
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes CLI commands failing with scoped package names like `@smartergpt/lex`.

## Problem
`lex remember` and `lex recall` commands failed with:
```
Error: Could not find repository root (looking for package.json with name "lex")
```

## Solution
Updated repo root detection to accept both:
- Unscoped: `"name": "lex"`
- Scoped: `"name": "@smartergpt/lex"`

## Changes
- `src/shared/policy/loader.ts`: Update findRepoRoot()
- `src/memory/store/db.ts`: Update findRepoRoot()

## Testing
Verified with:
```bash
lex remember --reference-point "test" --summary "test" --modules "memory"
lex recall "test"
```

Both commands now work correctly with scoped package name.

## Release
Target: 0.4.5-alpha