### PR TITLE
fix: Add .vscode/mcp.json for Lex MCP server registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ Thumbs.db
 
 # IDEs
 .vscode/
+!.vscode/mcp.json
 .idea/
 
 # Testing

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,14 @@
+{
+    "servers": {
+        "lex": {
+            "type": "stdio",
+            "command": "node",
+            "args": ["src/memory/mcp_server/frame-mcp.mjs"],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "LEX_WORKSPACE_ROOT": "${workspaceFolder}",
+                "LEX_MEMORY_DB": "${workspaceFolder}/.smartergpt/lex/lex.db"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #509 - Lex MCP tools not available in VS Code Copilot.

## Root Cause

VS Code Copilot requires a `.vscode/mcp.json` file to discover and start MCP servers. This file was missing from the Lex repo.

The MCP server implementation (`frame-mcp.mjs`) was already working correctly - only the registration configuration was missing.

## Changes

- Add `.vscode/mcp.json` with Lex MCP server configuration
- Update `.gitignore` to track `mcp.json` while ignoring other `.vscode/` files

## Testing

- `LEX_DEBUG=1 node src/memory/mcp_server/frame-mcp.mjs` starts successfully
- All 1515 tests pass

## How to Verify

After merging, VS Code Copilot should automatically detect and start the Lex MCP server when opening the workspace. The Lex tools (`lex.remember`, `lex.recall`, etc.) should appear in the available tool list.

**Note:** A VS Code reload may be required after merging for the MCP server to be detected.