### PR TITLE
docs: avoid stale/future-dated wording

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -287,7 +287,7 @@ On non-tag branches or manual dispatch:
 
 ## Catch-Up Releases (One-Time)
 
-As of 2025-11-27, there is drift between existing Git tags and GitHub releases:
+If `npm run check:release-drift` reports drift between existing Git tags and GitHub releases, use this one-time catch-up table:
 
 | Version | Git Tag | GitHub Release | Status |
 |---------|---------|----------------|--------|

--- a/src/shared/aliases/MAINTENANCE_GUIDE.md
+++ b/src/shared/aliases/MAINTENANCE_GUIDE.md
@@ -224,7 +224,7 @@ After a grace period (e.g., 6 months):
 ```json
 {
   "added_date": "2025-11-05",
-  "deprecated_date": "2026-05-05"
+  "deprecated_date": "2025-12-01"
 }
 ```
 

--- a/src/shared/aliases/MIGRATION_GUIDE.md
+++ b/src/shared/aliases/MIGRATION_GUIDE.md
@@ -153,8 +153,7 @@ Mark the alias as deprecated:
       "confidence": 1.0,
       "reason": "refactored 2025-10-15",
       "deprecated": true,
-      "deprecated_date": "2025-11-05",
-      "removal_planned": "2026-05-05"
+      "deprecated_date": "2025-11-05"
     }
   }
 }
@@ -165,7 +164,7 @@ Users typing the old name will see:
 ```
 ⚠️  Warning: Alias 'services/user-access-api' is deprecated.
    Use 'api/user-access' instead.
-   This alias will be removed on 2026-05-05.
+  This alias may be removed after the grace period if usage drops to near zero.
 ```
 
 ### Step 4: Remove (If Safe)


### PR DESCRIPTION
This PR removes date-stamped phrasing that will drift over time and softens a deprecation example that read like a firm future removal promise.

Changes:
- RELEASE.md: replace "As of YYYY-MM-DD" phrasing with a npm run check:release-drift driven condition.
- src/shared/aliases/MIGRATION_GUIDE.md: remove a hard future removal date from the user-facing warning (removal is conditional on usage dropping).
- src/shared/aliases/MAINTENANCE_GUIDE.md: switch example deprecated_date to a historical date (avoid future-date implications).

How to verify:
- Read the updated sections; wording should no longer require periodic date refresh.
- No runtime behavior changes (docs-only).