### PR TITLE
feat(mcp): Rename tools to canonical mcp_lex_{category}_{action} pattern

### DIFF
--- a/src/memory/mcp_server/server.ts
+++ b/src/memory/mcp_server/server.ts
@@ -325,41 +325,48 @@ export class MCPServer {
     const { name, arguments: args } = params;
 
     switch (name) {
-      case "lex.remember":
+      // Canonical names (mcp_lex_{category}_{action})
+      case "mcp_lex_frame_remember":
+      case "lex.remember": // Deprecated alias
         return await this.handleRemember(args);
 
-      case "lex.recall":
+      case "mcp_lex_frame_recall":
+      case "lex.recall": // Deprecated alias
         return await this.handleRecall(args);
 
-      case "lex.list_frames":
+      case "mcp_lex_frame_list":
+      case "lex.list_frames": // Deprecated alias
         return await this.handleListFrames(args);
 
-      case "lex.policy_check":
+      case "mcp_lex_policy_check":
+      case "lex.policy_check": // Deprecated alias
         return await this.handlePolicyCheck(args);
 
-      case "lex.timeline":
+      case "mcp_lex_frame_timeline":
+      case "lex.timeline": // Deprecated alias
         return await this.handleTimeline(args);
 
-      case "lex.code_atlas":
+      case "mcp_lex_atlas_analyze":
+      case "lex.code_atlas": // Deprecated alias
         return await this.handleCodeAtlas(args);
 
       default:
         throw new MCPError(MCPErrorCode.INTERNAL_UNKNOWN_TOOL, `Unknown tool: ${name}`, {
           requestedTool: name,
           availableTools: [
-            "lex.remember",
-            "lex.recall",
-            "lex.list_frames",
-            "lex.policy_check",
-            "lex.timeline",
-            "lex.code_atlas",
+            "mcp_lex_frame_remember",
+            "mcp_lex_frame_recall",
+            "mcp_lex_frame_list",
+            "mcp_lex_policy_check",
+            "mcp_lex_frame_timeline",
+            "mcp_lex_atlas_analyze",
           ],
         });
     }
   }
 
   /**
-   * Handle lex.remember tool - create new Frame
+   * Handle mcp_lex_frame_remember tool - create new Frame
    *
    * Validates module IDs against policy with alias resolution before creating Frame (THE CRITICAL RULE)
    */
@@ -442,7 +449,7 @@ export class MCPServer {
     } else if (this.repoRoot || process.env.LEX_DEFAULT_BRANCH) {
       frameBranch = getCurrentBranch();
       // Log branch detection for debugging
-      logger.info(`[lex.remember] Auto-detected branch: ${frameBranch}`);
+      logger.info(`[mcp_lex_frame_remember] Auto-detected branch: ${frameBranch}`);
     } else {
       // When no repoRoot is provided and no env override, avoid auto-detecting
       // from the runner's repository; use 'unknown' to indicate no branch context.
@@ -524,7 +531,7 @@ export class MCPServer {
   }
 
   /**
-   * Handle lex.recall tool - search Frames with Atlas Frame
+   * Handle mcp_lex_frame_recall tool - search Frames with Atlas Frame
    */
   private async handleRecall(args: Record<string, unknown>): Promise<MCPResponse> {
     const { reference_point, jira, branch, limit = 10 } = args as unknown as RecallArgs;
@@ -633,7 +640,7 @@ export class MCPServer {
   }
 
   /**
-   * Handle lex.list_frames tool - list recent Frames
+   * Handle mcp_lex_frame_list tool - list recent Frames
    */
   private async handleListFrames(args: Record<string, unknown>): Promise<MCPResponse> {
     const { branch, module, limit = 10, since } = args as unknown as ListFramesArgs;
@@ -700,7 +707,7 @@ export class MCPServer {
   }
 
   /**
-   * Handle lex.policy_check tool - validate policy file
+   * Handle mcp_lex_policy_check tool - validate policy file
    */
   private async handlePolicyCheck(args: Record<string, unknown>): Promise<MCPResponse> {
     const { path: checkPath, policyPath, strict = false } = args as unknown as PolicyCheckArgs;
@@ -784,7 +791,7 @@ export class MCPServer {
   }
 
   /**
-   * Handle lex.timeline tool - show timeline of Frame evolution
+   * Handle mcp_lex_frame_timeline tool - show timeline of Frame evolution
    */
   private async handleTimeline(args: Record<string, unknown>): Promise<MCPResponse> {
     const { ticketOrBranch, since, until, format = "text" } = args as unknown as TimelineArgs;
@@ -830,7 +837,7 @@ export class MCPServer {
               text:
                 `🔍 No frames found for: "${ticketOrBranch}"\n\n` +
                 "Try using a Jira ticket ID (e.g., TICKET-123) or a branch name.\n" +
-                "Run 'lex.remember' to create a frame first.",
+                "Run 'mcp_lex_frame_remember' to create a frame first.",
             },
           ],
         };
@@ -903,7 +910,7 @@ export class MCPServer {
   }
 
   /**
-   * Handle lex.code_atlas tool - analyze code structure and dependencies
+   * Handle mcp_lex_atlas_analyze tool - analyze code structure and dependencies
    */
   private async handleCodeAtlas(args: Record<string, unknown>): Promise<MCPResponse> {
     const {

--- a/src/memory/mcp_server/tools.ts
+++ b/src/memory/mcp_server/tools.ts
@@ -20,7 +20,7 @@ export interface MCPTool {
  */
 export const MCP_TOOLS: MCPTool[] = [
   {
-    name: "lex.remember",
+    name: "mcp_lex_frame_remember",
     description: "Store a Frame (episodic memory snapshot)",
     inputSchema: {
       type: "object",
@@ -91,7 +91,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex.recall",
+    name: "mcp_lex_frame_recall",
     description:
       "Search Frames by reference point, branch, or Jira ticket. Returns Frame + Atlas Frame neighborhood.",
     inputSchema: {
@@ -118,7 +118,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex.list_frames",
+    name: "mcp_lex_frame_list",
     description:
       "List recent Frames, optionally filtered by branch or module. Returns Frame + Atlas Frame for each result.",
     inputSchema: {
@@ -145,7 +145,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex.policy_check",
+    name: "mcp_lex_policy_check",
     description: "Validate code against policy rules from lexmap.policy.json",
     inputSchema: {
       type: "object",
@@ -166,7 +166,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex.timeline",
+    name: "mcp_lex_frame_timeline",
     description: "Show visual timeline of Frame evolution for a ticket or branch",
     inputSchema: {
       type: "object",
@@ -194,7 +194,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex.code_atlas",
+    name: "mcp_lex_atlas_analyze",
     description: "Analyze code structure and dependencies across modules",
     inputSchema: {
       type: "object",

--- a/test/memory/mcp_server/integration.test.ts
+++ b/test/memory/mcp_server/integration.test.ts
@@ -593,12 +593,12 @@ describe("MCP Server Integration Tests", () => {
         assert.strictEqual(response.tools.length, 6, "Should have 6 tools");
 
         const toolNames = response.tools.map((t) => t.name);
-        assert.ok(toolNames.includes("lex.remember"));
-        assert.ok(toolNames.includes("lex.recall"));
-        assert.ok(toolNames.includes("lex.list_frames"));
-        assert.ok(toolNames.includes("lex.policy_check"));
-        assert.ok(toolNames.includes("lex.timeline"));
-        assert.ok(toolNames.includes("lex.code_atlas"));
+        assert.ok(toolNames.includes("mcp_lex_frame_remember"));
+        assert.ok(toolNames.includes("mcp_lex_frame_recall"));
+        assert.ok(toolNames.includes("mcp_lex_frame_list"));
+        assert.ok(toolNames.includes("mcp_lex_policy_check"));
+        assert.ok(toolNames.includes("mcp_lex_frame_timeline"));
+        assert.ok(toolNames.includes("mcp_lex_atlas_analyze"));
       } finally {
         await teardown();
       }
@@ -611,8 +611,8 @@ describe("MCP Server Integration Tests", () => {
           method: "tools/list",
         });
 
-        const rememberTool = response.tools?.find((t) => t.name === "lex.remember");
-        assert.ok(rememberTool, "Should include lex.remember");
+        const rememberTool = response.tools?.find((t) => t.name === "mcp_lex_frame_remember");
+        assert.ok(rememberTool, "Should include mcp_lex_frame_remember");
         assert.ok(rememberTool.inputSchema, "Should include input schema");
         assert.ok(rememberTool.inputSchema.properties, "Schema should have properties");
       } finally {

--- a/test/memory/mcp_server/policy-check.test.ts
+++ b/test/memory/mcp_server/policy-check.test.ts
@@ -213,7 +213,7 @@ describe("MCP Server - lex.policy_check", () => {
     }
   });
 
-  test("tools/list includes lex.policy_check", async () => {
+  test("tools/list includes mcp_lex_policy_check", async () => {
     const srv = setup();
     try {
       const response = await srv.handleRequest({ method: "tools/list" });
@@ -221,12 +221,12 @@ describe("MCP Server - lex.policy_check", () => {
       assert.ok(response.tools, "Response should have tools array");
       const toolNames = response.tools.map((t: any) => t.name);
       assert.ok(
-        toolNames.includes("lex.policy_check"),
-        "Should include lex.policy_check tool"
+        toolNames.includes("mcp_lex_policy_check"),
+        "Should include mcp_lex_policy_check tool"
       );
 
       // Find the policy_check tool and verify its schema
-      const policyCheckTool = response.tools.find((t: any) => t.name === "lex.policy_check");
+      const policyCheckTool = response.tools.find((t: any) => t.name === "mcp_lex_policy_check");
       assert.ok(policyCheckTool, "Should find policy_check tool");
       assert.ok(policyCheckTool.description, "Tool should have description");
       assert.ok(policyCheckTool.inputSchema, "Tool should have input schema");

--- a/test/memory/mcp_server/server.test.ts
+++ b/test/memory/mcp_server/server.test.ts
@@ -47,12 +47,21 @@ describe("MCP Server - Protocol", () => {
       assert.strictEqual(response.tools.length, 6, "Should have 6 tools");
 
       const toolNames = response.tools.map((t) => t.name);
-      assert.ok(toolNames.includes("lex.remember"), "Should include lex.remember");
-      assert.ok(toolNames.includes("lex.recall"), "Should include lex.recall");
-      assert.ok(toolNames.includes("lex.list_frames"), "Should include lex.list_frames");
-      assert.ok(toolNames.includes("lex.policy_check"), "Should include lex.policy_check");
-      assert.ok(toolNames.includes("lex.timeline"), "Should include lex.timeline");
-      assert.ok(toolNames.includes("lex.code_atlas"), "Should include lex.code_atlas");
+      assert.ok(
+        toolNames.includes("mcp_lex_frame_remember"),
+        "Should include mcp_lex_frame_remember"
+      );
+      assert.ok(toolNames.includes("mcp_lex_frame_recall"), "Should include mcp_lex_frame_recall");
+      assert.ok(toolNames.includes("mcp_lex_frame_list"), "Should include mcp_lex_frame_list");
+      assert.ok(toolNames.includes("mcp_lex_policy_check"), "Should include mcp_lex_policy_check");
+      assert.ok(
+        toolNames.includes("mcp_lex_frame_timeline"),
+        "Should include mcp_lex_frame_timeline"
+      );
+      assert.ok(
+        toolNames.includes("mcp_lex_atlas_analyze"),
+        "Should include mcp_lex_atlas_analyze"
+      );
     } finally {
       await teardown();
     }

--- a/test/memory/mcp_server/timeline.test.ts
+++ b/test/memory/mcp_server/timeline.test.ts
@@ -38,17 +38,17 @@ describe("MCP Server - Timeline Tool", () => {
     }
   }
 
-  test("lex.timeline tool is listed in tools/list", async () => {
+  test("mcp_lex_frame_timeline tool is listed in tools/list", async () => {
     const srv = setup();
     try {
       const response = await srv.handleRequest({ method: "tools/list" });
 
       assert.ok(response.tools, "Response should have tools array");
       const toolNames = response.tools.map((t: { name: string }) => t.name);
-      assert.ok(toolNames.includes("lex.timeline"), "Should include lex.timeline");
+      assert.ok(toolNames.includes("mcp_lex_frame_timeline"), "Should include mcp_lex_frame_timeline");
 
       // Find the timeline tool and check its schema
-      const timelineTool = response.tools.find((t: { name: string }) => t.name === "lex.timeline");
+      const timelineTool = response.tools.find((t: { name: string }) => t.name === "mcp_lex_frame_timeline");
       assert.ok(timelineTool, "Timeline tool should exist");
       assert.ok(timelineTool.inputSchema, "Timeline tool should have inputSchema");
       assert.ok(


### PR DESCRIPTION
## Summary

Implements the canonical MCP tool naming convention per [NAMING_CONVENTIONS.md](docs/NAMING_CONVENTIONS.md).

All 6 Lex MCP tools renamed to follow `mcp_lex_{category}_{action}` pattern.

## Tool Renames

| Old Name | New Canonical Name |
|----------|-------------------|
| `lex.remember` | `mcp_lex_frame_remember` |
| `lex.recall` | `mcp_lex_frame_recall` |
| `lex.list_frames` | `mcp_lex_frame_list` |
| `lex.policy_check` | `mcp_lex_policy_check` |
| `lex.timeline` | `mcp_lex_frame_timeline` |
| `lex.code_atlas` | `mcp_lex_atlas_analyze` |

## Categories

| Category | Tools |
|----------|-------|
| `frame` | remember, recall, list, timeline |
| `policy` | check |
| `atlas` | analyze |

## Backwards Compatibility

**Old names are preserved as deprecated aliases.** Existing integrations will continue to work.

Switch statement includes fallthrough patterns:
```typescript
case 'mcp_lex_frame_remember':
case 'lex.remember': // Deprecated alias
  return await this.handleRemember(args);
```

## Files Changed

- `src/memory/mcp_server/tools.ts` - Tool definitions
- `src/memory/mcp_server/server.ts` - Switch statement + method comments
- `test/memory/mcp_server/*.ts` - Updated test assertions

## Testing

- ✅ Build passes
- ✅ MCP-related tests pass
- ⚠️ 3 unrelated receipt schema test failures (pre-existing)

Closes #556