### PR TITLE
fix(mcp): Remove namespace prefix from tool names (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,38 @@ _No unreleased changes._
 
 ---
 
+## [2.1.0] - 2025-12-16
+
+### ⚠️ BREAKING CHANGE: MCP Tool Names
+
+**VS Code automatically adds `mcp_{servername}_` prefix to all tool names.** Our previous naming included redundant prefixes, causing tools to appear as `mcp_lex_lex_remember` instead of `mcp_lex_remember`.
+
+This release removes the namespace prefix from tool definitions to match the GitHub MCP pattern.
+
+#### Migration Guide
+
+| v2.0.x Tool Name | v2.1.x Tool Name | VS Code Display |
+|------------------|------------------|-----------------|
+| `lex_remember` | `remember` | `mcp_lex_remember` |
+| `lex_recall` | `recall` | `mcp_lex_recall` |
+| `lex_list_frames` | `list_frames` | `mcp_lex_list_frames` |
+| `lex_timeline` | `timeline` | `mcp_lex_timeline` |
+| `lex_policy_check` | `policy_check` | `mcp_lex_policy_check` |
+| `lex_code_atlas` | `code_atlas` | `mcp_lex_code_atlas` |
+
+**Backwards Compatibility:** The old `lex_*` names are preserved as deprecated aliases and will continue to work. They will be removed in v3.0.0.
+
+### Changed
+
+- MCP tool names no longer include namespace prefix (GitHub MCP pattern)
+- Updated `docs/NAMING_CONVENTIONS.md` with correct VS Code prefix behavior
+
+### Fixed
+
+- Tools now display correctly in VS Code as `mcp_lex_{action}` instead of `mcp_lex_lex_{action}`
+
+---
+
 ## [2.0.3] - 2025-12-16
 
 ### Added

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -10,29 +10,46 @@ This document defines the naming conventions for all tools, commands, and identi
 
 ## MCP Tool Names
 
+### Key Insight: VS Code Prefix Behavior
+
+**VS Code automatically adds `mcp_{servername}_` prefix to ALL tool names.**
+
+This means tool names in source code should **NOT include a namespace prefix**. The prefix is added by VS Code at display time.
+
 ### Pattern (in source code)
 
 ```
-{namespace}_{category}_{action}
+{action}              # Simple action
+{category}_{action}   # Categorized action (when disambiguation needed)
 ```
-
-VS Code's MCP client automatically adds the `mcp_{servername}_` prefix when exposing tools.
-So a tool named `lex_remember` in code appears as `mcp_lex_lex_remember` in VS Code.
-
-**Important:** To avoid duplication, tool names in code should use just `{namespace}_{action}` without the `mcp_` prefix.
 
 | Component | Description | Constraints |
 |-----------|-------------|-------------|
-| `namespace` | Tool owner | Required. One of: `lex`, `lexsona`, `lexrunner` |
 | `category` | Domain/subsystem | Optional. Use when disambiguation needed |
-| `action` | Verb describing operation | Required. Lowercase, no separators |
+| `action` | Verb describing operation | Required. Lowercase snake_case |
+
+### How It Works
+
+| Source Name | Server | VS Code Display |
+|-------------|--------|-----------------|
+| `remember` | `lex` | `mcp_lex_remember` |
+| `start_run` | `lexrunner` | `mcp_lexrunner_start_run` |
+| `persona_activate` | `lexsona` | `mcp_lexsona_persona_activate` |
+
+### Reference: GitHub MCP Pattern
+
+GitHub's MCP server defines tools like `create_pull_request` (not `github_create_pull_request`).
+VS Code displays these as `mcp_github_create_pull_request`.
+
+**We follow this same pattern.**
 
 ### Rules
 
-1. **All lowercase** — no camelCase, no PascalCase
-2. **Underscore only** — no hyphens, no dots
-3. **No abbreviations** — prefer `discover` over `disc`
-4. **Verb last** — `gate_run` not `run_gate`
+1. **No namespace prefix** — VS Code adds `mcp_{server}_` automatically
+2. **All lowercase** — no camelCase, no PascalCase
+3. **Underscore only** — no hyphens, no dots (snake_case)
+4. **No abbreviations** — prefer `discover` over `disc`
+5. **Action-oriented** — name should describe what the tool does
 
 ### Rationale
 
@@ -48,55 +65,45 @@ Keep the category set **small and stable**:
 
 | Category | Domain | Examples |
 |----------|--------|----------|
-| `core` | Cross-cutting / no clear domain | `mcp_lexrunner_core_health` |
-| `weave` | Merge-weave orchestration | `mcp_lexrunner_weave_discover` |
-| `gate` | CI/gate execution | `mcp_lexrunner_gate_run` |
-| `plan` | Plan creation/validation | `mcp_lexrunner_plan_create` |
-| `workspace` | Local workspace management | `mcp_lexrunner_workspace_init` |
-| `run` | Run lifecycle management | `mcp_lexrunner_run_start` |
-| `persona` | Persona management | `mcp_lexsona_persona_activate` |
-| `rules` | Behavioral rules | `mcp_lexsona_rules_learn` |
-| `constraints` | Constraint derivation | `mcp_lexsona_constraints_derive` |
-| `memory` | Frame/memory operations | `mcp_lex_memory_recall` |
-| `policy` | Policy validation | `mcp_lex_policy_check` |
+| `run` | Run lifecycle management | `start_run`, `get_status` |
+| `gate` | CI/gate execution | `gates_run` |
+| `plan` | Plan creation/validation | `plan_create` |
+| `persona` | Persona management | `persona_activate` |
+| `rules` | Behavioral rules | `rules_learn` |
+| `constraints` | Constraint derivation | `constraints_derive` |
 
 New categories require justification and should be added sparingly.
 
 ### Examples
 
-**LexRunner:**
+**Lex (displayed as `mcp_lex_{name}`):**
 ```
-lexrunner_weave_discover
-lexrunner_weave_plan
-lexrunner_weave_status
-lexrunner_gate_run
-lexrunner_plan_create
-lexrunner_plan_validate
-lexrunner_workspace_init
-lexrunner_workspace_doctor
-lexrunner_run_start
-lexrunner_run_status
-lexrunner_core_health
+remember           → mcp_lex_remember
+recall             → mcp_lex_recall
+list_frames        → mcp_lex_list_frames
+timeline           → mcp_lex_timeline
+policy_check       → mcp_lex_policy_check
+code_atlas         → mcp_lex_code_atlas
 ```
 
-**LexSona:**
+**LexRunner (displayed as `mcp_lexrunner_{name}`):**
 ```
-lexsona_persona_activate
-lexsona_persona_list
-lexsona_persona_show
-lexsona_rules_learn
-lexsona_rules_list
-lexsona_constraints_derive
+discover           → mcp_lexrunner_discover
+doctor             → mcp_lexrunner_doctor
+local_init         → mcp_lexrunner_local_init
+start_run          → mcp_lexrunner_start_run
+list_artifacts     → mcp_lexrunner_list_artifacts
+get_status         → mcp_lexrunner_get_status
+gates_run          → mcp_lexrunner_gates_run
+plan_create        → mcp_lexrunner_plan_create
 ```
 
-**Lex:**
+**LexSona (displayed as `mcp_lexsona_{name}`):**
 ```
-lex_remember
-lex_recall
-lex_list_frames
-lex_timeline
-lex_policy_check
-lex_code_atlas
+persona_activate   → mcp_lexsona_persona_activate
+persona_list       → mcp_lexsona_persona_list
+rules_learn        → mcp_lexsona_rules_learn
+constraints_derive → mcp_lexsona_constraints_derive
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@smartergpt/lex",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartergpt/lex",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@smartergpt/lex": "^2.0.3",
         "@types/express": "^5.0.5",
         "@types/jsonwebtoken": "^9.0.10",
         "axios": "^1.13.2",
@@ -658,9 +659,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
+      "integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
       "cpu": [
         "ppc64"
       ],
@@ -675,9 +676,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
+      "integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
       "cpu": [
         "arm"
       ],
@@ -692,9 +693,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
+      "integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
       "cpu": [
         "arm64"
       ],
@@ -709,9 +710,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
+      "integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
       "cpu": [
         "x64"
       ],
@@ -726,9 +727,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
+      "integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
       "cpu": [
         "arm64"
       ],
@@ -743,9 +744,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
+      "integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
       "cpu": [
         "x64"
       ],
@@ -760,9 +761,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
       "cpu": [
         "arm64"
       ],
@@ -777,9 +778,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
+      "integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
       "cpu": [
         "x64"
       ],
@@ -794,9 +795,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
+      "integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
       "cpu": [
         "arm"
       ],
@@ -811,9 +812,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
+      "integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
       "cpu": [
         "arm64"
       ],
@@ -828,9 +829,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
+      "integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
       "cpu": [
         "ia32"
       ],
@@ -845,9 +846,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
+      "integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
       "cpu": [
         "loong64"
       ],
@@ -862,9 +863,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
+      "integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
       "cpu": [
         "mips64el"
       ],
@@ -879,9 +880,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
+      "integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
       "cpu": [
         "ppc64"
       ],
@@ -896,9 +897,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
+      "integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
       "cpu": [
         "riscv64"
       ],
@@ -913,9 +914,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
+      "integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
       "cpu": [
         "s390x"
       ],
@@ -930,9 +931,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
+      "integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
       "cpu": [
         "x64"
       ],
@@ -947,9 +948,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
       "cpu": [
         "arm64"
       ],
@@ -964,9 +965,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
       "cpu": [
         "x64"
       ],
@@ -981,9 +982,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
       "cpu": [
         "arm64"
       ],
@@ -998,9 +999,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
       "cpu": [
         "x64"
       ],
@@ -1015,9 +1016,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
+      "integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
       "cpu": [
         "arm64"
       ],
@@ -1032,9 +1033,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
+      "integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
       "cpu": [
         "x64"
       ],
@@ -1049,9 +1050,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
+      "integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
       "cpu": [
         "arm64"
       ],
@@ -1066,9 +1067,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
+      "integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
       "cpu": [
         "ia32"
       ],
@@ -1083,9 +1084,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
+      "integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
       "cpu": [
         "x64"
       ],
@@ -1183,9 +1184,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1195,7 +1196,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -2573,6 +2574,51 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@smartergpt/lex": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@smartergpt/lex/-/lex-2.0.3.tgz",
+      "integrity": "sha512-Rkh42R41Hl9wrmDCtgkaWhGeUo7YnrSkqF6eT6+Y7hsk3xtXxlyaGTuSFijXokLdb03QSk2sRwhMI6Y6T52VcA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "^5.0.5",
+        "@types/jsonwebtoken": "^9.0.10",
+        "axios": "^1.13.2",
+        "better-sqlite3-multiple-ciphers": "^12.4.6",
+        "commander": "^14.0.2",
+        "express": "^5.1.0",
+        "express-rate-limit": "^8.2.1",
+        "glob": "^13.0.0",
+        "helmet": "^8.1.0",
+        "inquirer": "^13.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "minimatch": "^10.1.1",
+        "pino": "^10.1.0",
+        "sharp": "^0.34.5",
+        "shiki": "^3.20.0",
+        "typescript": "^5.9.3",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.1",
+        "zod": "^4.1.12"
+      },
+      "bin": {
+        "lex": "dist/shared/cli/lex.js"
+      },
+      "engines": {
+        "node": ">=20 <23"
+      },
+      "optionalDependencies": {
+        "pino-pretty": "^13.1.2"
+      },
+      "peerDependencies": {
+        "pino-pretty": "*"
+      },
+      "peerDependenciesMeta": {
+        "pino-pretty": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
@@ -2738,7 +2784,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
       "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2826,17 +2871,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
-      "integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz",
+      "integrity": "sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.49.0",
-        "@typescript-eslint/type-utils": "8.49.0",
-        "@typescript-eslint/utils": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0",
+        "@typescript-eslint/scope-manager": "8.50.0",
+        "@typescript-eslint/type-utils": "8.50.0",
+        "@typescript-eslint/utils": "8.50.0",
+        "@typescript-eslint/visitor-keys": "8.50.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.1.0"
@@ -2849,23 +2894,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.49.0",
+        "@typescript-eslint/parser": "^8.50.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
-      "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz",
+      "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.49.0",
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/typescript-estree": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0",
+        "@typescript-eslint/scope-manager": "8.50.0",
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/typescript-estree": "8.50.0",
+        "@typescript-eslint/visitor-keys": "8.50.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2880,171 +2924,15 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
-      "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.49.0",
-        "@typescript-eslint/types": "^8.49.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
-      "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
-      "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
-      "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
-      "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.49.0",
-        "@typescript-eslint/tsconfig-utils": "8.49.0",
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
-      "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.49.0",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
-      "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz",
+      "integrity": "sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.49.0",
-        "@typescript-eslint/types": "^8.49.0",
+        "@typescript-eslint/tsconfig-utils": "^8.50.0",
+        "@typescript-eslint/types": "^8.50.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3059,14 +2947,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
-      "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz",
+      "integrity": "sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0"
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/visitor-keys": "8.50.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3077,9 +2965,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
-      "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz",
+      "integrity": "sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3094,15 +2982,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
-      "integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz",
+      "integrity": "sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/typescript-estree": "8.49.0",
-        "@typescript-eslint/utils": "8.49.0",
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/typescript-estree": "8.50.0",
+        "@typescript-eslint/utils": "8.50.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -3119,9 +3007,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
-      "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz",
+      "integrity": "sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3133,16 +3021,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
-      "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz",
+      "integrity": "sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.49.0",
-        "@typescript-eslint/tsconfig-utils": "8.49.0",
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0",
+        "@typescript-eslint/project-service": "8.50.0",
+        "@typescript-eslint/tsconfig-utils": "8.50.0",
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/visitor-keys": "8.50.0",
         "debug": "^4.3.4",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
@@ -3187,16 +3075,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.49.0.tgz",
-      "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz",
+      "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.49.0",
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/typescript-estree": "8.49.0"
+        "@typescript-eslint/scope-manager": "8.50.0",
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/typescript-estree": "8.50.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3211,13 +3099,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
-      "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz",
+      "integrity": "sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/types": "8.50.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -3266,7 +3154,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4066,7 +3953,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4428,9 +4314,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
+      "integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4441,32 +4327,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.0",
-        "@esbuild/android-arm": "0.27.0",
-        "@esbuild/android-arm64": "0.27.0",
-        "@esbuild/android-x64": "0.27.0",
-        "@esbuild/darwin-arm64": "0.27.0",
-        "@esbuild/darwin-x64": "0.27.0",
-        "@esbuild/freebsd-arm64": "0.27.0",
-        "@esbuild/freebsd-x64": "0.27.0",
-        "@esbuild/linux-arm": "0.27.0",
-        "@esbuild/linux-arm64": "0.27.0",
-        "@esbuild/linux-ia32": "0.27.0",
-        "@esbuild/linux-loong64": "0.27.0",
-        "@esbuild/linux-mips64el": "0.27.0",
-        "@esbuild/linux-ppc64": "0.27.0",
-        "@esbuild/linux-riscv64": "0.27.0",
-        "@esbuild/linux-s390x": "0.27.0",
-        "@esbuild/linux-x64": "0.27.0",
-        "@esbuild/netbsd-arm64": "0.27.0",
-        "@esbuild/netbsd-x64": "0.27.0",
-        "@esbuild/openbsd-arm64": "0.27.0",
-        "@esbuild/openbsd-x64": "0.27.0",
-        "@esbuild/openharmony-arm64": "0.27.0",
-        "@esbuild/sunos-x64": "0.27.0",
-        "@esbuild/win32-arm64": "0.27.0",
-        "@esbuild/win32-ia32": "0.27.0",
-        "@esbuild/win32-x64": "0.27.0"
+        "@esbuild/aix-ppc64": "0.27.1",
+        "@esbuild/android-arm": "0.27.1",
+        "@esbuild/android-arm64": "0.27.1",
+        "@esbuild/android-x64": "0.27.1",
+        "@esbuild/darwin-arm64": "0.27.1",
+        "@esbuild/darwin-x64": "0.27.1",
+        "@esbuild/freebsd-arm64": "0.27.1",
+        "@esbuild/freebsd-x64": "0.27.1",
+        "@esbuild/linux-arm": "0.27.1",
+        "@esbuild/linux-arm64": "0.27.1",
+        "@esbuild/linux-ia32": "0.27.1",
+        "@esbuild/linux-loong64": "0.27.1",
+        "@esbuild/linux-mips64el": "0.27.1",
+        "@esbuild/linux-ppc64": "0.27.1",
+        "@esbuild/linux-riscv64": "0.27.1",
+        "@esbuild/linux-s390x": "0.27.1",
+        "@esbuild/linux-x64": "0.27.1",
+        "@esbuild/netbsd-arm64": "0.27.1",
+        "@esbuild/netbsd-x64": "0.27.1",
+        "@esbuild/openbsd-arm64": "0.27.1",
+        "@esbuild/openbsd-x64": "0.27.1",
+        "@esbuild/openharmony-arm64": "0.27.1",
+        "@esbuild/sunos-x64": "0.27.1",
+        "@esbuild/win32-arm64": "0.27.1",
+        "@esbuild/win32-ia32": "0.27.1",
+        "@esbuild/win32-x64": "0.27.1"
       }
     },
     "node_modules/escalade": {
@@ -4504,7 +4390,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4887,7 +4772,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4952,9 +4836,9 @@
       "license": "MIT"
     },
     "node_modules/fast-copy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.0.tgz",
-      "integrity": "sha512-/oA0gx1xyXE9R2YlV4FXwZJXngFdm9Du0zN8FhY38jnLkhp1u35h6bCyKgRhlsA6C9I+1vfXE4KISdt7xc6M9w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.1.tgz",
+      "integrity": "sha512-+uUOQlhsaswsizHFmEFAQhB3lSiQ+lisxl50N6ZP0wywlZeWsIESxSi9ftPEps8UGfiBzyYP7x27zA674WUvXw==",
       "license": "MIT",
       "optional": true
     },
@@ -5076,9 +4960,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -5089,7 +4973,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -5630,9 +5518,9 @@
       }
     },
     "node_modules/human-id": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.2.tgz",
-      "integrity": "sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz",
+      "integrity": "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5640,9 +5528,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6251,10 +6139,10 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "license": "ISC",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -7535,31 +7423,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -7569,6 +7461,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -8249,7 +8145,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8383,7 +8278,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8802,9 +8696,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.0.tgz",
-      "integrity": "sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
+      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartergpt/lex",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "MIT-licensed memory, policy, and atlas framework with MCP server. For local dev and private automation.",
   "type": "module",
   "main": "dist/index.js",
@@ -185,6 +185,7 @@
     }
   },
   "dependencies": {
+    "@smartergpt/lex": "^2.0.3",
     "@types/express": "^5.0.5",
     "@types/jsonwebtoken": "^9.0.10",
     "axios": "^1.13.2",

--- a/src/memory/mcp_server/server.ts
+++ b/src/memory/mcp_server/server.ts
@@ -325,41 +325,41 @@ export class MCPServer {
     const { name, arguments: args } = params;
 
     switch (name) {
-      // Canonical names (lex_{action} - VS Code adds mcp_lex_ prefix)
-      case "lex_remember":
-      case "lex.remember": // Deprecated alias
+      // Canonical names - VS Code adds mcp_lex_ prefix automatically
+      case "remember":
+      case "lex_remember": // Deprecated alias (v2.0.x)
         return await this.handleRemember(args);
 
-      case "lex_recall":
-      case "lex.recall": // Deprecated alias
+      case "recall":
+      case "lex_recall": // Deprecated alias (v2.0.x)
         return await this.handleRecall(args);
 
-      case "lex_list_frames":
-      case "lex.list_frames": // Deprecated alias
+      case "list_frames":
+      case "lex_list_frames": // Deprecated alias (v2.0.x)
         return await this.handleListFrames(args);
 
-      case "lex_policy_check":
-      case "lex.policy_check": // Deprecated alias
+      case "policy_check":
+      case "lex_policy_check": // Deprecated alias (v2.0.x)
         return await this.handlePolicyCheck(args);
 
-      case "lex_timeline":
-      case "lex.timeline": // Deprecated alias
+      case "timeline":
+      case "lex_timeline": // Deprecated alias (v2.0.x)
         return await this.handleTimeline(args);
 
-      case "lex_code_atlas":
-      case "lex.code_atlas": // Deprecated alias
+      case "code_atlas":
+      case "lex_code_atlas": // Deprecated alias (v2.0.x)
         return await this.handleCodeAtlas(args);
 
       default:
         throw new MCPError(MCPErrorCode.INTERNAL_UNKNOWN_TOOL, `Unknown tool: ${name}`, {
           requestedTool: name,
           availableTools: [
-            "lex_remember",
-            "lex_recall",
-            "lex_list_frames",
-            "lex_policy_check",
-            "lex_timeline",
-            "lex_code_atlas",
+            "remember",
+            "recall",
+            "list_frames",
+            "policy_check",
+            "timeline",
+            "code_atlas",
           ],
         });
     }

--- a/src/memory/mcp_server/tools.ts
+++ b/src/memory/mcp_server/tools.ts
@@ -20,7 +20,7 @@ export interface MCPTool {
  */
 export const MCP_TOOLS: MCPTool[] = [
   {
-    name: "lex_remember",
+    name: "remember",
     description: "Store a Frame (episodic memory snapshot)",
     inputSchema: {
       type: "object",
@@ -91,7 +91,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex_recall",
+    name: "recall",
     description:
       "Search Frames by reference point, branch, or Jira ticket. Returns Frame + Atlas Frame neighborhood.",
     inputSchema: {
@@ -118,7 +118,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex_list_frames",
+    name: "list_frames",
     description:
       "List recent Frames, optionally filtered by branch or module. Returns Frame + Atlas Frame for each result.",
     inputSchema: {
@@ -145,7 +145,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex_policy_check",
+    name: "policy_check",
     description: "Validate code against policy rules from lexmap.policy.json",
     inputSchema: {
       type: "object",
@@ -166,7 +166,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex_timeline",
+    name: "timeline",
     description: "Show visual timeline of Frame evolution for a ticket or branch",
     inputSchema: {
       type: "object",
@@ -194,7 +194,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "lex_code_atlas",
+    name: "code_atlas",
     description: "Analyze code structure and dependencies across modules",
     inputSchema: {
       type: "object",

--- a/test/memory/mcp_server/alias-integration.test.ts
+++ b/test/memory/mcp_server/alias-integration.test.ts
@@ -70,7 +70,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Testing exact match",
               summary_caption: "Exact module ID match test",
@@ -101,7 +101,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Multiple exact modules",
               summary_caption: "Testing multiple exact matches",
@@ -128,7 +128,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Testing typo correction",
               summary_caption: "Typo in module ID",
@@ -158,7 +158,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Testing fuzzy matching",
               summary_caption: "Common typo test",
@@ -189,7 +189,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Testing substring",
               summary_caption: "Substring module reference",
@@ -215,7 +215,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Testing shorthand",
               summary_caption: "Shorthand module ID",
@@ -246,7 +246,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Testing ambiguous input",
               summary_caption: "Ambiguous module reference",
@@ -274,7 +274,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Testing module list",
               summary_caption: "Invalid module test",
@@ -312,7 +312,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Testing mixed modules",
               summary_caption: "Mix of valid and invalid",
@@ -347,7 +347,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Warmup",
               summary_caption: "JIT warmup",
@@ -362,7 +362,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Performance test",
               summary_caption: "Testing validation performance",
@@ -392,7 +392,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Warmup",
               summary_caption: "JIT warmup",
@@ -407,7 +407,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Small scope",
               summary_caption: "2 modules",
@@ -423,7 +423,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "Large scope test",
               summary_caption: "6 modules",
@@ -476,7 +476,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const rememberResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "E2E test with validation",
               summary_caption: "End-to-end alias flow",
@@ -495,7 +495,7 @@ describe("MCP Server Alias Resolution Integration Tests", () => {
         const recallResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               reference_point: "E2E test",
             },

--- a/test/memory/mcp_server/ax-error-integration.test.ts
+++ b/test/memory/mcp_server/ax-error-integration.test.ts
@@ -95,7 +95,7 @@ describe("AXError Integration - MCP Server", () => {
         const request = {
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               // No search parameters provided
             },

--- a/test/memory/mcp_server/integration.test.ts
+++ b/test/memory/mcp_server/integration.test.ts
@@ -61,7 +61,7 @@ describe("MCP Server Integration Tests", () => {
         const rememberResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: rememberArgs,
           },
         });
@@ -76,7 +76,7 @@ describe("MCP Server Integration Tests", () => {
         const recallResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               reference_point: "integration cycle",
             },
@@ -120,7 +120,7 @@ describe("MCP Server Integration Tests", () => {
           await srv.handleRequest({
             method: "tools/call",
             params: {
-              name: "lex.remember",
+              name: "remember",
               arguments: frame,
             },
           });
@@ -130,7 +130,7 @@ describe("MCP Server Integration Tests", () => {
         const listResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.list_frames",
+            name: "list_frames",
             arguments: { limit: 10 },
           },
         });
@@ -145,7 +145,7 @@ describe("MCP Server Integration Tests", () => {
         const recallResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               reference_point: "first frame",
             },
@@ -170,7 +170,7 @@ describe("MCP Server Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "invalid module test",
               summary_caption: "Testing validation",
@@ -204,7 +204,7 @@ describe("MCP Server Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "typo test",
               summary_caption: "Testing fuzzy matching",
@@ -227,7 +227,7 @@ describe("MCP Server Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "all valid modules",
               summary_caption: "Testing with all valid modules",
@@ -253,7 +253,7 @@ describe("MCP Server Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "authentication refactoring work",
               summary_caption: "Refactored auth system",
@@ -267,7 +267,7 @@ describe("MCP Server Integration Tests", () => {
         const searchResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               reference_point: "authentication refactoring",
             },
@@ -290,7 +290,7 @@ describe("MCP Server Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "payment system",
               summary_caption: "Stripe integration for payment processing",
@@ -305,7 +305,7 @@ describe("MCP Server Integration Tests", () => {
         const keywordSearch = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               reference_point: "stripe",
             },
@@ -322,7 +322,7 @@ describe("MCP Server Integration Tests", () => {
         const summarySearch = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               reference_point: "integration processing",
             },
@@ -345,7 +345,7 @@ describe("MCP Server Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "database optimization",
               summary_caption: "Optimized database queries",
@@ -360,7 +360,7 @@ describe("MCP Server Integration Tests", () => {
         const wildcardSearch = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               reference_point: "datab*",
             },
@@ -386,7 +386,7 @@ describe("MCP Server Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "indexer work",
               summary_caption: "Indexer module",
@@ -399,7 +399,7 @@ describe("MCP Server Integration Tests", () => {
         await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "typescript work",
               summary_caption: "TS module",
@@ -413,7 +413,7 @@ describe("MCP Server Integration Tests", () => {
         const filterResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.list_frames",
+            name: "list_frames",
             arguments: {
               module: "policy/scanners",
               limit: 10,
@@ -443,7 +443,7 @@ describe("MCP Server Integration Tests", () => {
           await srv.handleRequest({
             method: "tools/call",
             params: {
-              name: "lex.remember",
+              name: "remember",
               arguments: {
                 reference_point: `frame ${i}`,
                 summary_caption: `Frame ${i}`,
@@ -458,7 +458,7 @@ describe("MCP Server Integration Tests", () => {
         const limitedResponse = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.list_frames",
+            name: "list_frames",
             arguments: {
               limit: 3,
             },
@@ -483,7 +483,7 @@ describe("MCP Server Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "incomplete",
               // Missing: summary_caption, status_snapshot, module_scope
@@ -507,7 +507,7 @@ describe("MCP Server Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {
               reference_point: "zzz-nonexistent-query-zzz",
             },
@@ -530,7 +530,7 @@ describe("MCP Server Integration Tests", () => {
         const response = await srv.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: {},
           },
         });
@@ -593,12 +593,12 @@ describe("MCP Server Integration Tests", () => {
         assert.strictEqual(response.tools.length, 6, "Should have 6 tools");
 
         const toolNames = response.tools.map((t) => t.name);
-        assert.ok(toolNames.includes("lex_remember"));
-        assert.ok(toolNames.includes("lex_recall"));
-        assert.ok(toolNames.includes("lex_list_frames"));
-        assert.ok(toolNames.includes("lex_policy_check"));
-        assert.ok(toolNames.includes("lex_timeline"));
-        assert.ok(toolNames.includes("lex_code_atlas"));
+        assert.ok(toolNames.includes("remember"));
+        assert.ok(toolNames.includes("recall"));
+        assert.ok(toolNames.includes("list_frames"));
+        assert.ok(toolNames.includes("policy_check"));
+        assert.ok(toolNames.includes("timeline"));
+        assert.ok(toolNames.includes("code_atlas"));
       } finally {
         await teardown();
       }
@@ -611,7 +611,7 @@ describe("MCP Server Integration Tests", () => {
           method: "tools/list",
         });
 
-        const rememberTool = response.tools?.find((t) => t.name === "lex_remember");
+        const rememberTool = response.tools?.find((t) => t.name === "remember");
         assert.ok(rememberTool, "Should include lex_remember");
         assert.ok(rememberTool.inputSchema, "Should include input schema");
         assert.ok(rememberTool.inputSchema.properties, "Schema should have properties");

--- a/test/memory/mcp_server/memory-store-isolation.test.ts
+++ b/test/memory/mcp_server/memory-store-isolation.test.ts
@@ -38,7 +38,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         const rememberResponse = await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "memory store test",
               summary_caption: "Testing with MemoryFrameStore",
@@ -62,7 +62,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         const recallResponse = await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: { reference_point: "memory store" },
           },
         });
@@ -87,7 +87,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "test A unique frame",
               summary_caption: "Frame for test A",
@@ -119,7 +119,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "test B unique frame",
               summary_caption: "Frame for test B",
@@ -150,7 +150,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         const response = await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "remember test",
               summary_caption: "Testing remember with MemoryFrameStore",
@@ -190,7 +190,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "searchable recall test",
               summary_caption: "Frame to recall",
@@ -205,7 +205,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         const response = await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: { reference_point: "searchable recall" },
           },
         });
@@ -231,7 +231,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
           await server.handleRequest({
             method: "tools/call",
             params: {
-              name: "lex.remember",
+              name: "remember",
               arguments: {
                 reference_point: `list frame ${i}`,
                 summary_caption: `Frame number ${i}`,
@@ -247,7 +247,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         const response = await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.list_frames",
+            name: "list_frames",
             arguments: { limit: 10 },
           },
         });
@@ -273,7 +273,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "auth module frame",
               summary_caption: "Auth work",
@@ -287,7 +287,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "ui module frame",
               summary_caption: "UI work",
@@ -302,7 +302,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         const response = await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.list_frames",
+            name: "list_frames",
             arguments: { module: "policy/scanners", limit: 10 },
           },
         });
@@ -348,7 +348,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         const response = await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.recall",
+            name: "recall",
             arguments: { reference_point: "pre-existing" },
           },
         });
@@ -373,7 +373,7 @@ describe("MCP Server with MemoryFrameStore - Test Isolation", () => {
         const response = await server.handleRequest({
           method: "tools/call",
           params: {
-            name: "lex.remember",
+            name: "remember",
             arguments: {
               reference_point: "image test",
               summary_caption: "Testing image with MemoryFrameStore",

--- a/test/memory/mcp_server/policy-check.test.ts
+++ b/test/memory/mcp_server/policy-check.test.ts
@@ -68,7 +68,7 @@ describe("MCP Server - lex.policy_check", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.policy_check",
+          name: "policy_check",
           arguments: {
             path: testDir,
             policyPath: join(testDir, "lexmap.policy.json"),
@@ -98,7 +98,7 @@ describe("MCP Server - lex.policy_check", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.policy_check",
+          name: "policy_check",
           arguments: {
             path: testDir,
             policyPath: join(testDir, "lexmap.policy.json"),
@@ -125,7 +125,7 @@ describe("MCP Server - lex.policy_check", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.policy_check",
+          name: "policy_check",
           arguments: {
             path: testDir,
             policyPath: join(testDir, "nonexistent.json"),
@@ -163,7 +163,7 @@ describe("MCP Server - lex.policy_check", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.policy_check",
+          name: "policy_check",
           arguments: {
             path: testDir,
             policyPath: join(testDir, "lexmap.policy.json"),
@@ -198,7 +198,7 @@ describe("MCP Server - lex.policy_check", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.policy_check",
+          name: "policy_check",
           arguments: {},
         },
       });
@@ -221,12 +221,12 @@ describe("MCP Server - lex.policy_check", () => {
       assert.ok(response.tools, "Response should have tools array");
       const toolNames = response.tools.map((t: any) => t.name);
       assert.ok(
-        toolNames.includes("lex_policy_check"),
+        toolNames.includes("policy_check"),
         "Should include lex_policy_check tool"
       );
 
       // Find the policy_check tool and verify its schema
-      const policyCheckTool = response.tools.find((t: any) => t.name === "lex_policy_check");
+      const policyCheckTool = response.tools.find((t: any) => t.name === "policy_check");
       assert.ok(policyCheckTool, "Should find policy_check tool");
       assert.ok(policyCheckTool.description, "Tool should have description");
       assert.ok(policyCheckTool.inputSchema, "Tool should have input schema");

--- a/test/memory/mcp_server/server.test.ts
+++ b/test/memory/mcp_server/server.test.ts
@@ -48,18 +48,18 @@ describe("MCP Server - Protocol", () => {
 
       const toolNames = response.tools.map((t) => t.name);
       assert.ok(
-        toolNames.includes("lex_remember"),
+        toolNames.includes("remember"),
         "Should include lex_remember"
       );
-      assert.ok(toolNames.includes("lex_recall"), "Should include lex_recall");
-      assert.ok(toolNames.includes("lex_list_frames"), "Should include lex_list_frames");
-      assert.ok(toolNames.includes("lex_policy_check"), "Should include lex_policy_check");
+      assert.ok(toolNames.includes("recall"), "Should include lex_recall");
+      assert.ok(toolNames.includes("list_frames"), "Should include lex_list_frames");
+      assert.ok(toolNames.includes("policy_check"), "Should include lex_policy_check");
       assert.ok(
-        toolNames.includes("lex_timeline"),
+        toolNames.includes("timeline"),
         "Should include lex_timeline"
       );
       assert.ok(
-        toolNames.includes("lex_code_atlas"),
+        toolNames.includes("code_atlas"),
         "Should include lex_code_atlas"
       );
     } finally {
@@ -83,7 +83,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: args,
         },
       });
@@ -106,7 +106,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "incomplete data",
             // Missing: summary_caption, status_snapshot, module_scope
@@ -131,7 +131,7 @@ describe("MCP Server - Protocol", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "authentication refactoring",
             summary_caption: "Extracted password validation",
@@ -148,7 +148,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.recall",
+          name: "recall",
           arguments: {
             reference_point: "authentication",
           },
@@ -173,7 +173,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.recall",
+          name: "recall",
           arguments: {
             reference_point: "nonexistent work",
           },
@@ -196,7 +196,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.recall",
+          name: "recall",
           arguments: {}, // No search parameters
         },
       });
@@ -218,7 +218,7 @@ describe("MCP Server - Protocol", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "frame one",
             summary_caption: "First test frame",
@@ -231,7 +231,7 @@ describe("MCP Server - Protocol", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "frame two",
             summary_caption: "Second test frame",
@@ -245,7 +245,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.list_frames",
+          name: "list_frames",
           arguments: { limit: 10 },
         },
       });
@@ -267,7 +267,7 @@ describe("MCP Server - Protocol", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "auth work",
             summary_caption: "Auth module work",
@@ -280,7 +280,7 @@ describe("MCP Server - Protocol", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "ui work",
             summary_caption: "UI module work",
@@ -294,7 +294,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.list_frames",
+          name: "list_frames",
           arguments: { module: "policy/scanners", limit: 10 },
         },
       });
@@ -371,7 +371,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: args,
         },
       });
@@ -412,7 +412,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: args,
         },
       });
@@ -450,7 +450,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: args,
         },
       });
@@ -490,7 +490,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: args,
         },
       });
@@ -512,7 +512,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "invalid module test",
             summary_caption: "Testing validation",
@@ -546,7 +546,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "typo test",
             summary_caption: "Testing fuzzy matching",
@@ -573,7 +573,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "multiple errors test",
             summary_caption: "Testing multiple validation errors",
@@ -607,7 +607,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "mixed validity test",
             summary_caption: "Testing mixed valid/invalid modules",
@@ -639,7 +639,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "all valid modules",
             summary_caption: "Testing with all policy modules",
@@ -682,7 +682,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: args,
         },
       });
@@ -713,7 +713,7 @@ describe("MCP Server - Protocol", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: args,
         },
       });

--- a/test/memory/mcp_server/timeline.test.ts
+++ b/test/memory/mcp_server/timeline.test.ts
@@ -45,10 +45,10 @@ describe("MCP Server - Timeline Tool", () => {
 
       assert.ok(response.tools, "Response should have tools array");
       const toolNames = response.tools.map((t: { name: string }) => t.name);
-      assert.ok(toolNames.includes("lex_timeline"), "Should include lex_timeline");
+      assert.ok(toolNames.includes("timeline"), "Should include lex_timeline");
 
       // Find the timeline tool and check its schema
-      const timelineTool = response.tools.find((t: { name: string }) => t.name === "lex_timeline");
+      const timelineTool = response.tools.find((t: { name: string }) => t.name === "timeline");
       assert.ok(timelineTool, "Timeline tool should exist");
       assert.ok(timelineTool.inputSchema, "Timeline tool should have inputSchema");
       assert.ok(
@@ -67,7 +67,7 @@ describe("MCP Server - Timeline Tool", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "initial work",
             summary_caption: "Started feature",
@@ -84,7 +84,7 @@ describe("MCP Server - Timeline Tool", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "added tests",
             summary_caption: "Added unit tests",
@@ -102,7 +102,7 @@ describe("MCP Server - Timeline Tool", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.timeline",
+          name: "timeline",
           arguments: {
             ticketOrBranch: "TICKET-123",
           },
@@ -127,7 +127,7 @@ describe("MCP Server - Timeline Tool", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "branch work 1",
             summary_caption: "First commit",
@@ -143,7 +143,7 @@ describe("MCP Server - Timeline Tool", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "branch work 2",
             summary_caption: "Second commit",
@@ -160,7 +160,7 @@ describe("MCP Server - Timeline Tool", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.timeline",
+          name: "timeline",
           arguments: {
             ticketOrBranch: "feature/timeline",
           },
@@ -183,7 +183,7 @@ describe("MCP Server - Timeline Tool", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.timeline",
+          name: "timeline",
           arguments: {
             ticketOrBranch: "NONEXISTENT-999",
           },
@@ -206,7 +206,7 @@ describe("MCP Server - Timeline Tool", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "old work",
             summary_caption: "Old frame",
@@ -228,7 +228,7 @@ describe("MCP Server - Timeline Tool", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "new work",
             summary_caption: "New frame",
@@ -245,7 +245,7 @@ describe("MCP Server - Timeline Tool", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.timeline",
+          name: "timeline",
           arguments: {
             ticketOrBranch: "TICKET-456",
             since: sinceDate,
@@ -268,7 +268,7 @@ describe("MCP Server - Timeline Tool", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "json test",
             summary_caption: "JSON format test",
@@ -284,7 +284,7 @@ describe("MCP Server - Timeline Tool", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.timeline",
+          name: "timeline",
           arguments: {
             ticketOrBranch: "TICKET-JSON",
             format: "json",
@@ -314,7 +314,7 @@ describe("MCP Server - Timeline Tool", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.timeline",
+          name: "timeline",
           arguments: {},
         },
       });
@@ -335,7 +335,7 @@ describe("MCP Server - Timeline Tool", () => {
       await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.remember",
+          name: "remember",
           arguments: {
             reference_point: "filtered out",
             summary_caption: "Old frame",
@@ -354,7 +354,7 @@ describe("MCP Server - Timeline Tool", () => {
       const response = await srv.handleRequest({
         method: "tools/call",
         params: {
-          name: "lex.timeline",
+          name: "timeline",
           arguments: {
             ticketOrBranch: "TICKET-FILTER",
             since: futureDate,


### PR DESCRIPTION
## Summary

**BREAKING CHANGE:** MCP tool names no longer include namespace prefix.

VS Code automatically adds `mcp_{servername}_` prefix to all MCP tool names. Our previous naming included redundant prefixes, causing tools to appear as:
- `mcp_lex_lex_remember` (wrong)

Now tools appear correctly as:
- `mcp_lex_remember` (correct, matches GitHub MCP pattern)

## Tool Name Changes

| Old Name (v2.0.x) | New Name (v2.1.x) | VS Code Display |
|-------------------|-------------------|-----------------|
| `lex_remember` | `remember` | `mcp_lex_remember` |
| `lex_recall` | `recall` | `mcp_lex_recall` |
| `lex_list_frames` | `list_frames` | `mcp_lex_list_frames` |
| `lex_timeline` | `timeline` | `mcp_lex_timeline` |
| `lex_policy_check` | `policy_check` | `mcp_lex_policy_check` |
| `lex_code_atlas` | `code_atlas` | `mcp_lex_code_atlas` |

## Backwards Compatibility

Old `lex_*` names are preserved as deprecated aliases and will continue to work. They will be removed in v3.0.0.

## Changes

- Updated `src/memory/mcp_server/tools.ts` - removed `lex_` prefix from tool names
- Updated `src/memory/mcp_server/server.ts` - updated case statements with deprecated aliases
- Updated `docs/NAMING_CONVENTIONS.md` - corrected pattern documentation
- Updated all MCP test files to use new tool names
- Bumped version to 2.1.0

## Reference

Following the GitHub MCP pattern where tools are defined as `create_pull_request` (not `github_create_pull_request`) and VS Code displays them as `mcp_github_create_pull_request`.

Fixes #562