### PR TITLE
fix(deps): bump better-sqlite3-multiple-ciphers floor to ^12.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/express": "^5.0.5",
         "@types/jsonwebtoken": "^9.0.10",
         "axios": "^1.13.2",
-        "better-sqlite3-multiple-ciphers": "^12.4.6",
+        "better-sqlite3-multiple-ciphers": "^12.6.2",
         "commander": "^14.0.2",
         "express": "^5.1.0",
         "express-rate-limit": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "@types/express": "^5.0.5",
     "@types/jsonwebtoken": "^9.0.10",
     "axios": "^1.13.2",
-    "better-sqlite3-multiple-ciphers": "^12.4.6",
+    "better-sqlite3-multiple-ciphers": "^12.6.2",
     "commander": "^14.0.2",
     "express": "^5.1.0",
     "express-rate-limit": "^8.2.1",


### PR DESCRIPTION
## Summary\n\nBumps `better-sqlite3-multiple-ciphers` version floor from `^12.4.6` to `^12.6.2` to align with lexsona and lexrunner.\n\n## Context\n\nPart of the cross-repo SQLite version alignment effort (see Guffawaffle/lexrunner#730). All three repos (lex, lexsona, lexrunner) should use the same `better-sqlite3-multiple-ciphers` package at `^12.6.2`.\n\n## Changes\n\n- `package.json`: bump `better-sqlite3-multiple-ciphers` from `^12.4.6` → `^12.6.2`\n- `package-lock.json`: updated lockfile\n\n## Testing\n\n- `npm run local-ci` passes (123 tests, build clean, lint clean)\n- Native bindings rebuilt and verified"