### PR TITLE
Add bulk frame deletion methods to FrameStore interface

### DIFF
--- a/src/memory/store/frame-store.ts
+++ b/src/memory/store/frame-store.ts
@@ -183,6 +183,28 @@ export interface FrameStore {
   deleteFrame(id: string): Promise<boolean>;
 
   /**
+   * Delete all Frames with timestamps before the given date.
+   * Useful for TTL-based retention policies.
+   * @param date - Delete Frames with timestamp < date (UTC).
+   * @returns The number of Frames deleted.
+   */
+  deleteFramesBefore(date: Date): Promise<number>;
+
+  /**
+   * Delete all Frames matching a branch name.
+   * @param branch - The branch to match.
+   * @returns The number of Frames deleted.
+   */
+  deleteFramesByBranch(branch: string): Promise<number>;
+
+  /**
+   * Delete all Frames that include the given module in their module_scope.
+   * @param moduleId - The module ID to match (any-match within the array).
+   * @returns The number of Frames deleted.
+   */
+  deleteFramesByModule(moduleId: string): Promise<number>;
+
+  /**
    * Get the total number of Frames in the store.
    * @returns The total Frame count.
    */

--- a/src/memory/store/memory/frame-store.ts
+++ b/src/memory/store/memory/frame-store.ts
@@ -253,6 +253,55 @@ export class MemoryFrameStore implements FrameStore {
   }
 
   /**
+   * Delete all Frames with timestamps before the given date.
+   * @param date - Delete Frames with timestamp < date (UTC).
+   * @returns The number of Frames deleted.
+   */
+  async deleteFramesBefore(date: Date): Promise<number> {
+    const cutoff = date.getTime();
+    let deleted = 0;
+    for (const [id, frame] of this.frames) {
+      if (new Date(frame.timestamp).getTime() < cutoff) {
+        this.frames.delete(id);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
+
+  /**
+   * Delete all Frames matching a branch name.
+   * @param branch - The branch to match.
+   * @returns The number of Frames deleted.
+   */
+  async deleteFramesByBranch(branch: string): Promise<number> {
+    let deleted = 0;
+    for (const [id, frame] of this.frames) {
+      if (frame.branch === branch) {
+        this.frames.delete(id);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
+
+  /**
+   * Delete all Frames that include the given module in their module_scope.
+   * @param moduleId - The module ID to match.
+   * @returns The number of Frames deleted.
+   */
+  async deleteFramesByModule(moduleId: string): Promise<number> {
+    let deleted = 0;
+    for (const [id, frame] of this.frames) {
+      if (frame.module_scope.includes(moduleId)) {
+        this.frames.delete(id);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
+
+  /**
    * Get the total number of Frames in the store.
    * @returns The total Frame count.
    */

--- a/test/memory/store/memory/frame-store.spec.ts
+++ b/test/memory/store/memory/frame-store.spec.ts
@@ -558,6 +558,81 @@ describe("MemoryFrameStore", () => {
       assert.strictEqual(result.page.hasMore, false);
     });
   });
+  describe("deleteFramesBefore", () => {
+    test("should delete frames older than given date", async () => {
+      store = new MemoryFrameStore();
+      await store.saveFrame(testFrame1); // Nov 1
+      await store.saveFrame(testFrame2); // Nov 2
+      await store.saveFrame(testFrame3); // Nov 3
+
+      // Delete frames before Nov 2 (should delete frame1)
+      const deleted = await store.deleteFramesBefore(new Date("2025-11-02T00:00:00Z"));
+      assert.strictEqual(deleted, 1, "Should delete 1 frame");
+
+      const remaining = await store.getFrameCount();
+      assert.strictEqual(remaining, 2, "Should have 2 frames remaining");
+
+      const gone = await store.getFrameById("frame-001");
+      assert.strictEqual(gone, null, "Deleted frame should not be found");
+    });
+
+    test("should return 0 when no frames match", async () => {
+      store = new MemoryFrameStore();
+      await store.saveFrame(testFrame1);
+      const deleted = await store.deleteFramesBefore(new Date("2020-01-01T00:00:00Z"));
+      assert.strictEqual(deleted, 0, "Should delete 0 frames");
+    });
+  });
+
+  describe("deleteFramesByBranch", () => {
+    test("should delete all frames for a branch", async () => {
+      store = new MemoryFrameStore();
+      await store.saveFrame(testFrame1); // feature/auth-fix
+      await store.saveFrame(testFrame2); // feature/payment-integration
+      await store.saveFrame(testFrame3); // feature/auth-fix
+
+      const deleted = await store.deleteFramesByBranch("feature/auth-fix");
+      assert.strictEqual(deleted, 2, "Should delete 2 frames from auth-fix branch");
+
+      const remaining = await store.getFrameCount();
+      assert.strictEqual(remaining, 1, "Should have 1 frame remaining");
+
+      const kept = await store.getFrameById("frame-002");
+      assert.ok(kept, "Payment frame should still exist");
+    });
+
+    test("should return 0 for non-existent branch", async () => {
+      store = new MemoryFrameStore();
+      await store.saveFrame(testFrame1);
+      const deleted = await store.deleteFramesByBranch("nonexistent/branch");
+      assert.strictEqual(deleted, 0);
+    });
+  });
+
+  describe("deleteFramesByModule", () => {
+    test("should delete all frames containing a module", async () => {
+      store = new MemoryFrameStore();
+      await store.saveFrame(testFrame1); // ["ui/user-admin-panel", "services/auth-core"]
+      await store.saveFrame(testFrame2); // ["services/payment-gateway", "ui/checkout"]
+      await store.saveFrame(testFrame3); // ["services/auth-core", "lib/crypto"]
+
+      const deleted = await store.deleteFramesByModule("services/auth-core");
+      assert.strictEqual(deleted, 2, "Should delete 2 frames containing services/auth-core");
+
+      const remaining = await store.getFrameCount();
+      assert.strictEqual(remaining, 1, "Should have 1 frame remaining");
+
+      const kept = await store.getFrameById("frame-002");
+      assert.ok(kept, "Payment frame should still exist");
+    });
+
+    test("should return 0 for non-existent module", async () => {
+      store = new MemoryFrameStore();
+      await store.saveFrame(testFrame1);
+      const deleted = await store.deleteFramesByModule("nonexistent/module");
+      assert.strictEqual(deleted, 0);
+    });
+  });
 });
 
 console.log("\n✅ MemoryFrameStore Tests - In-memory FrameStore implementation for testing\n");


### PR DESCRIPTION
## Summary

Adds three bulk deletion methods to the FrameStore interface for lifecycle management and TTL-based retention cleanup.

## New Methods

| Method | Use Case | SQLite Implementation |
|--------|----------|-----------------------|
| `deleteFramesBefore(date)` | TTL retention / age-based cleanup | `DELETE FROM frames WHERE timestamp < ?` |
| `deleteFramesByBranch(branch)` | Branch lifecycle cleanup | `DELETE FROM frames WHERE branch = ?` |
| `deleteFramesByModule(moduleId)` | Module decommission cleanup | `DELETE ... WHERE EXISTS (SELECT 1 FROM json_each(module_scope) WHERE value = ?)` |

All three return `Promise<number>` — the count of deleted frames.

## Changes

### Interface (`src/memory/store/frame-store.ts`)
- Add `deleteFramesBefore(date: Date): Promise<number>`
- Add `deleteFramesByBranch(branch: string): Promise<number>`
- Add `deleteFramesByModule(moduleId: string): Promise<number>`

### SqliteFrameStore (`src/memory/store/sqlite/frame-store.ts`)
- `deleteFramesBefore`: ISO timestamp comparison
- `deleteFramesByBranch`: Direct column match
- `deleteFramesByModule`: Uses `json_each()` to match within the JSON array `module_scope` column
- All respect closed-store guard pattern

### MemoryFrameStore (`src/memory/store/memory/frame-store.ts`)
- Map iteration with timestamp/branch/module_scope matching
- Same return semantics as SQLite implementation

### Tests (15 new tests)
- 9 tests in SQLite spec (3 per method × 3 methods: happy path, no-match, closed-store)
- 6 tests in Memory spec (2 per method × 3 methods: happy path, no-match)

## Verification

- Build: ✅ clean
- Tests: ✅ 2168 total, 0 failures
- Lint: ✅ 0 errors (6 pre-existing warnings)

## Majel Impact

Enables Majel to clean up user session frames without raw DB access:
```typescript
// TTL cleanup: delete frames older than 30 days
await store.deleteFramesBefore(new Date(Date.now() - 30 * 86400000));

// Clean up after branch merge
await store.deleteFramesByBranch("feature/old-branch");
```

Closes #693