### PR TITLE
Add purgeSuperseded() for bulk dead-frame cleanup

### DIFF
--- a/src/memory/store/frame-store.ts
+++ b/src/memory/store/frame-store.ts
@@ -276,6 +276,14 @@ export interface FrameStore {
   updateFrame(id: string, updates: Partial<Omit<Frame, "id" | "timestamp">>): Promise<boolean>;
 
   /**
+   * Delete all Frames that have been marked as superseded (superseded_by IS NOT NULL).
+   * Useful for bulk cleanup of dead frames after deduplication/consolidation.
+   *
+   * @returns The number of Frames deleted.
+   */
+  purgeSuperseded(): Promise<number>;
+
+  /**
    * Close the store and release any resources.
    */
   close(): Promise<void>;

--- a/src/memory/store/memory/frame-store.ts
+++ b/src/memory/store/memory/frame-store.ts
@@ -282,6 +282,23 @@ export class MemoryFrameStore implements FrameStore {
   }
 
   /**
+   * Delete all Frames that have been marked as superseded.
+   * Removes frames where superseded_by is set.
+   *
+   * @returns The number of Frames deleted.
+   */
+  async purgeSuperseded(): Promise<number> {
+    let deleted = 0;
+    for (const [id, frame] of this.frames) {
+      if (frame.superseded_by) {
+        this.frames.delete(id);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
+
+  /**
    * Delete all Frames with timestamps before the given date.
    * @param date - Delete Frames with timestamp < date (UTC).
    * @returns The number of Frames deleted.

--- a/src/memory/store/sqlite/frame-store.ts
+++ b/src/memory/store/sqlite/frame-store.ts
@@ -747,6 +747,23 @@ export class SqliteFrameStore implements FrameStore {
   }
 
   /**
+   * Delete all Frames that have been marked as superseded.
+   * Removes frames where superseded_by IS NOT NULL.
+   * FTS5 entries are removed automatically by SQLite triggers.
+   *
+   * @returns The number of Frames deleted.
+   */
+  async purgeSuperseded(): Promise<number> {
+    if (this.isClosed) {
+      throw new Error("SqliteFrameStore is closed");
+    }
+
+    const stmt = this._db.prepare("DELETE FROM frames WHERE superseded_by IS NOT NULL");
+    const result = stmt.run();
+    return result.changes;
+  }
+
+  /**
    * Close the store and release any resources.
    * Idempotent - safe to call multiple times.
    */

--- a/test/memory/store/purge-superseded.test.ts
+++ b/test/memory/store/purge-superseded.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for FrameStore purgeSuperseded() method.
+ * Issue #704 — Bulk dead-frame cleanup for superseded frames.
+ *
+ * Run with: npm test
+ */
+
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { SqliteFrameStore } from "@app/memory/store/sqlite/index.js";
+import { MemoryFrameStore } from "@app/memory/store/memory/index.js";
+import type { Frame } from "@app/memory/frames/types.js";
+import type { FrameStore } from "@app/memory/store/frame-store.js";
+
+/**
+ * Create a valid test Frame.
+ */
+function createTestFrame(id: string, overrides: Partial<Frame> = {}): Frame {
+  return {
+    id,
+    timestamp: new Date().toISOString(),
+    branch: "test-branch",
+    module_scope: ["test/module-a"],
+    summary_caption: `Test frame ${id}`,
+    reference_point: `reference for ${id}`,
+    status_snapshot: {
+      next_action: "Continue testing",
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Test suite factory for purgeSuperseded on a specific FrameStore implementation.
+ */
+function createPurgeTests(name: string, createStore: () => FrameStore) {
+  describe(`${name} purgeSuperseded()`, () => {
+    let store: FrameStore;
+
+    beforeEach(() => {
+      store = createStore();
+    });
+
+    afterEach(async () => {
+      await store.close();
+    });
+
+    test("returns 0 for empty store", async () => {
+      const deleted = await store.purgeSuperseded();
+      assert.strictEqual(deleted, 0);
+    });
+
+    test("returns 0 when no frames are superseded", async () => {
+      await store.saveFrame(createTestFrame("f-001"));
+      await store.saveFrame(createTestFrame("f-002"));
+      await store.saveFrame(createTestFrame("f-003"));
+
+      const deleted = await store.purgeSuperseded();
+      assert.strictEqual(deleted, 0);
+
+      const count = await store.getFrameCount();
+      assert.strictEqual(count, 3);
+    });
+
+    test("deletes a single superseded frame", async () => {
+      await store.saveFrame(createTestFrame("f-001"));
+      await store.saveFrame(createTestFrame("f-002", { superseded_by: "f-001" }));
+
+      const deleted = await store.purgeSuperseded();
+      assert.strictEqual(deleted, 1);
+
+      const count = await store.getFrameCount();
+      assert.strictEqual(count, 1);
+
+      // The superseded frame should be gone
+      const purged = await store.getFrameById("f-002");
+      assert.strictEqual(purged, null);
+
+      // The superseding frame should remain
+      const remaining = await store.getFrameById("f-001");
+      assert.ok(remaining);
+    });
+
+    test("deletes multiple superseded frames", async () => {
+      await store.saveFrame(createTestFrame("f-latest"));
+      await store.saveFrame(createTestFrame("f-old-1", { superseded_by: "f-latest" }));
+      await store.saveFrame(createTestFrame("f-old-2", { superseded_by: "f-latest" }));
+      await store.saveFrame(createTestFrame("f-old-3", { superseded_by: "f-old-2" }));
+      await store.saveFrame(createTestFrame("f-unrelated"));
+
+      const deleted = await store.purgeSuperseded();
+      assert.strictEqual(deleted, 3);
+
+      const count = await store.getFrameCount();
+      assert.strictEqual(count, 2);
+
+      // Non-superseded frames should remain
+      assert.ok(await store.getFrameById("f-latest"));
+      assert.ok(await store.getFrameById("f-unrelated"));
+
+      // Superseded frames should be gone
+      assert.strictEqual(await store.getFrameById("f-old-1"), null);
+      assert.strictEqual(await store.getFrameById("f-old-2"), null);
+      assert.strictEqual(await store.getFrameById("f-old-3"), null);
+    });
+
+    test("works with updateFrame-based supersession", async () => {
+      await store.saveFrame(createTestFrame("f-001"));
+      await store.saveFrame(createTestFrame("f-002"));
+
+      // Mark f-001 as superseded via updateFrame
+      await store.updateFrame("f-001", { superseded_by: "f-002" });
+
+      const deleted = await store.purgeSuperseded();
+      assert.strictEqual(deleted, 1);
+
+      assert.strictEqual(await store.getFrameById("f-001"), null);
+      assert.ok(await store.getFrameById("f-002"));
+    });
+
+    test("preserves frames with merged_from but no superseded_by", async () => {
+      await store.saveFrame(createTestFrame("f-merged", { merged_from: ["f-src-a", "f-src-b"] }));
+
+      const deleted = await store.purgeSuperseded();
+      assert.strictEqual(deleted, 0);
+
+      assert.ok(await store.getFrameById("f-merged"));
+    });
+
+    test("is idempotent (second call returns 0)", async () => {
+      await store.saveFrame(createTestFrame("f-001", { superseded_by: "f-002" }));
+      await store.saveFrame(createTestFrame("f-002"));
+
+      const first = await store.purgeSuperseded();
+      assert.strictEqual(first, 1);
+
+      const second = await store.purgeSuperseded();
+      assert.strictEqual(second, 0);
+    });
+  });
+}
+
+// Run tests for both implementations
+createPurgeTests("SqliteFrameStore", () => new SqliteFrameStore(":memory:"));
+createPurgeTests("MemoryFrameStore", () => new MemoryFrameStore());


### PR DESCRIPTION
## Summary

Adds `purgeSuperseded()` to the FrameStore interface for efficient bulk cleanup of dead frames after deduplication/consolidation.

## Changes

### New: `purgeSuperseded()` method
- Added to FrameStore interface: `purgeSuperseded(): Promise<number>`
- **SqliteFrameStore**: Single `DELETE FROM frames WHERE superseded_by IS NOT NULL`
- **MemoryFrameStore**: Iterate and delete frames with `superseded_by` set

### Why
When Lex's deduplication marks frames with `superseded_by`, the originals remain in storage. Without a bulk operation, cleanup requires O(N) paginated list calls + individual delete calls. This method reduces it to a single call.

### Tests
14 new tests across 2 suites covering:
- Empty store (returns 0)
- No superseded frames (returns 0, preserves all)
- Single superseded frame deletion
- Multiple superseded frames deletion
- Integration with `updateFrame()`-based supersession
- Preservation of frames with `merged_from` but no `superseded_by`
- Idempotency (second call returns 0)

## Verification
- Build: ✅
- Tests: ✅ (14/14 new + all existing pass)
- Lint: ✅

Closes #704