### PR TITLE
release: prepare Lex 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.10.0
+
+### Minor Changes
+
+- Add a shared PostgreSQL FrameStore so WSL2 and Windows clients can use one
+  coordinated store while preserving SQLite as the default local backend.
+- Make `lex init` backend-aware, including PostgreSQL-only bootstrap support and
+  explicit handling for existing shared stores.
+
+### Patch Changes
+
+- Add hard read-only SQLite access for inspection workflows without creating or
+  mutating store files.
+- Align the compiler and build graph with TypeScript 6 while retaining the
+  existing runtime, CLI, MCP, and package contracts.
+
 ## 2.9.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ closeDb(db);
 
 ## Project status
 
-**Current Version:** `2.9.1` ([Changelog](./CHANGELOG.md))
+**Current Version:** `2.10.0` ([Changelog](./CHANGELOG.md))
 
 Current Lex releases include structured output, recoverable errors, and Frame Schema v3 for agent and orchestrator integration.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -378,7 +378,7 @@ For registry-specific issues, see [MCP Registry Documentation](https://github.co
 
 ## Notes
 
-- Package uses semantic versioning (currently `2.9.1`)
+- Package uses semantic versioning (currently `2.10.0`)
 - MIT license
 - Repository: `https://github.com/Guffawaffle/lex.git`
 - Package uses ESM (`"type": "module"`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartergpt/lex",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartergpt/lex",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartergpt/lex",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "MIT-licensed memory, policy, and atlas framework with MCP server. For local dev and private automation.",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/verify-mcp-registry-publication.mjs
+++ b/scripts/verify-mcp-registry-publication.mjs
@@ -3,7 +3,7 @@
  * Verifies that a just-published Lex entry is the live MCP Registry latest
  * version. Intended for the protected post-publication workflow step.
  *
- * Usage: node scripts/verify-mcp-registry-publication.mjs --version 2.9.1
+ * Usage: node scripts/verify-mcp-registry-publication.mjs --version 2.10.0
  */
 
 const versionIndex = process.argv.indexOf("--version");

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Guffawaffle/lex",
     "source": "github"
   },
-  "version": "2.9.1",
+  "version": "2.10.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@smartergpt/lex-mcp",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- bump Lex package, lockfile, MCP registry metadata, and release documentation to 2.10.0
- record the PostgreSQL FrameStore, backend-aware initialization, hard read-only SQLite access, and TypeScript 6 alignment in the changelog
- keep the Lex and Lex-MCP release contract version-aligned

## Validation

- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run validate-docs`
- `npm run check:mcp-registry-contract`
- `npm run test:integration`
- `npm run build`
- `npm run guard:pack`
- `npm run test:smoke`
- `npm audit` (0 vulnerabilities)

The complete functional suite passed except for the existing host-sensitive 10,000-frame Atlas timing guard: it took 76.4s in the full run and 72.5s in isolation against a 70s ceiling. All other tests passed, and this PR changes no runtime files.

## Release order

Publish `@smartergpt/lex@2.10.0` first. The coordinated `@smartergpt/lex-mcp@2.10.0` release must follow because the wrapper pins this exact version.
