### PR TITLE
feat: implement deterministic runtime scope resolution

### DIFF
--- a/.changeset/trusted-runtime-scope.md
+++ b/.changeset/trusted-runtime-scope.md
@@ -4,4 +4,6 @@
 
 Add public, versioned runtime-scope contracts for canonical authority, surface-local bindings,
 immutable invocation scope, structured diagnostics, stable resolver errors, and cross-platform
-conformance fixtures.
+conformance fixtures. Include deterministic execution-surface and registry-location resolution,
+a separate versioned SQLite local registry with explicit lifecycle operations, a fail-closed
+runtime-scope resolver, and concrete conformance coverage for every exported fixture.

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ closeDb(db);
 | `@smartergpt/lex/cli-output` | CLI JSON utilities | [CLI Output](./docs/CLI_OUTPUT.md) |
 | `@smartergpt/lex/store` | Direct database operations | [Store Contracts](./docs/STORE_CONTRACTS.md) |
 | `@smartergpt/lex/types` | All shared types | [API Usage](./docs/API_USAGE.md) |
-| `@smartergpt/lex/runtime-scope` | Identity, authority, binding, diagnostics, and conformance contracts | [Runtime Scope](./docs/RUNTIME_SCOPE_CONTRACT.md) |
+| `@smartergpt/lex/runtime-scope` | Identity, authority, local registry, resolver, diagnostics, and conformance | [Runtime Scope](./docs/RUNTIME_SCOPE_CONTRACT.md) |
 | `@smartergpt/lex/errors` | AXError schema and utilities (v2.0+) | [AX Contract](./docs/specs/AX-CONTRACT.md) |
 | `@smartergpt/lex/policy` | Policy loading & validation | [API Usage](./docs/API_USAGE.md) |
 | `@smartergpt/lex/atlas` | Atlas Frame generation | [Architecture](./docs/ARCHITECTURE.md) |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -262,6 +262,7 @@ These modules are **allowed** to use `db.prepare()`:
 | `src/memory/mcp_server/auth/state-storage.ts` | OAuth state storage |
 | `src/memory/mcp_server/routes/*.ts` | MCP route handlers (minimal SQL only) |
 | `src/shared/cli/db.ts` | CLI database utilities |
+| `src/shared/runtime-scope/registry-queries.ts` | Surface-local binding registry schema and lifecycle queries |
 
 ### How to Fix: Move SQL to Curated Module
 
@@ -608,5 +609,4 @@ If you're still having issues:
 
 - [TypeScript Project References](https://www.typescriptlang.org/docs/handbook/project-references.html)
 - [Package.json Subpath Exports](https://nodejs.org/api/packages.html#subpath-exports)
-
 

--- a/docs/CONTRACT_SURFACE.md
+++ b/docs/CONTRACT_SURFACE.md
@@ -37,7 +37,9 @@ Lex exposes a contract surface that any runner or tool can target. This document
 - Paths, Git state, manifests, flags, and environment values may select evidence but cannot grant access.
 - Diagnostics are versioned, redacted observability and never change resolution.
 
-**Conformance:** The package exports deterministic Windows/WSL, clone, worktree, fork, binding, selector, cached-authority, and diagnostic fixtures. Phase 1 adds no resolver or store behavior.
+**Implementation:** Phase 2 adds opt-in, pure execution-surface and registry-location resolution, a separate versioned SQLite local registry, a deterministic fail-closed runtime-scope resolver, and an in-memory authority implementation for tests and embedding. Registry initialization and binding lifecycle changes are explicit administrative operations; normal resolution is read-only. Existing CLI, MCP, Frame, and FrameStore behavior remains unchanged.
+
+**Conformance:** The package exports deterministic Windows/WSL, clone, worktree, fork, binding, selector, cached-authority, and diagnostic fixtures. Lex runs all exported fixtures against the concrete Phase 2 resolver and registry without changing their expected semantics.
 
 See [Trusted Runtime Scope Contract](./RUNTIME_SCOPE_CONTRACT.md) and [ADR-0011](./adr/0011-trusted-runtime-scope-and-authority.md).
 

--- a/docs/RUNTIME_SCOPE_CONTRACT.md
+++ b/docs/RUNTIME_SCOPE_CONTRACT.md
@@ -118,7 +118,7 @@ Registry selection follows the native process, including when WSL launches a Win
 | WSL or Linux fallback | `~/.local/state/lex/registry.db` |
 | macOS | `~/Library/Application Support/Lex/registry.db` |
 
-These variables and home paths are captured by the entrypoint and supplied as values; core resolution never reads them directly. Each WSL distribution therefore has its own registry through its own native user-state path.
+These variables and home paths are captured by the entrypoint and supplied as values; core resolution never reads them directly. Registry locations must be absolute and native to the execution surface: WSL registries cannot use Windows-mounted paths, and Windows registries cannot use WSL UNC paths. Each WSL distribution therefore has its own registry through its own native user-state path. Launch provenance such as Windows-via-WSL interop remains observable evidence but is not part of a Windows installation's persistent registry identity.
 
 ### Local SQLite registry
 
@@ -137,7 +137,8 @@ A registry is bound to its captured execution-surface evidence. Copying it to an
 3. enforces finite cached-authority expiry;
 4. validates any optional repository declaration against canonical authority;
 5. verifies matching local repository evidence and rejects ambiguity; and
-6. returns only the compact result or stable error vocabulary.
+6. attenuates `AuthorizedScope.capabilities` to the explicitly requested subset, including an empty set when no capabilities were requested; and
+7. returns only the compact result or stable error vocabulary.
 
 Authority and registry exceptions fail closed. Normal results contain no diagnostic envelope, local topology inventory, or authority trace. Diagnostics remain a separate, explicitly requested, capability-gated concern.
 

--- a/docs/RUNTIME_SCOPE_CONTRACT.md
+++ b/docs/RUNTIME_SCOPE_CONTRACT.md
@@ -1,12 +1,17 @@
 # Trusted Runtime Scope Contract
 
-Lex exposes its Phase 1 identity and authority vocabulary from:
+Lex exposes its versioned identity, authority, local-registry, and resolver surface from:
 
 ```ts
 import {
   RUNTIME_SCOPE_CONTRACT_VERSION,
+  RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
   RUNTIME_SCOPE_CONFORMANCE_FIXTURES,
   WORKSPACE_AUTHORITY_ERROR_CODES,
+  SqliteLocalBindingRegistry,
+  detectExecutionSurface,
+  resolveLocalRegistryLocation,
+  resolveRuntimeScope,
   type AuthorityDirectory,
   type LocalBindingRegistry,
   type ResolvedRuntimeConfig,
@@ -17,7 +22,7 @@ import {
 } from "@smartergpt/lex/runtime-scope";
 ```
 
-Phase 1 is a public contract, not a resolver or database implementation. Existing CLI, MCP, Frame, and store behavior is unchanged.
+Phase 1 froze the public contract. Phase 2 adds opt-in deterministic resolver and local-registry services. Existing CLI, MCP, Frame, and FrameStore behavior is unchanged; no existing entrypoint invokes these services yet.
 
 ## Boundary
 
@@ -96,12 +101,52 @@ Normal agent-facing output should not contain raw tenant/workspace topology, pri
 
 Implementations should adapt the fixtures to their test harness without changing their expected semantics. The fixtures perform no file or database access.
 
+Lex also runs every exported fixture through its concrete Phase 2 resolver and SQLite registry in the implementation conformance suite.
+
+## Phase 2 implementation
+
+### Trusted capture and execution surfaces
+
+`detectExecutionSurface`, `resolveLocalRegistryLocation`, and `resolveRuntimeScope` operate only on explicit inputs. They do not read `process.env`, `process.cwd()`, `process.platform`, OS release files, or mutable global caches. A trusted entrypoint must capture allowed ambient values once in a `BootstrapInputSnapshotV1` and pass the immutable snapshot inward.
+
+Registry selection follows the native process, including when WSL launches a Windows process:
+
+| Native surface | Default local registry |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\\Lex\\registry.db` |
+| WSL or Linux with XDG state | `$XDG_STATE_HOME/lex/registry.db` |
+| WSL or Linux fallback | `~/.local/state/lex/registry.db` |
+| macOS | `~/Library/Application Support/Lex/registry.db` |
+
+These variables and home paths are captured by the entrypoint and supplied as values; core resolution never reads them directly. Each WSL distribution therefore has its own registry through its own native user-state path.
+
+### Local SQLite registry
+
+`SqliteLocalBindingRegistry` uses a separate, application-identified, versioned SQLite file. It never opens or migrates a Frame database. Initialization is an explicit administrative operation and refuses to adopt an unrelated or newer-schema database. Ordinary `open()` is read-only by default and never creates or migrates a registry.
+
+Registration, inspection, verification, rebinding, and revocation are explicit lifecycle methods with auditable receipts. Normal resolution only looks up and verifies bindings. Rebinding preserves the binding and local repository-instance identities, requires stable provider, Git common-directory, or filesystem evidence in addition to any checked-in declaration, and cannot use a declaration by itself as proof.
+
+A registry is bound to its captured execution-surface evidence. Copying it to another native surface fails closed even when the file contains plausible canonical IDs.
+
+### Deterministic resolver
+
+`resolveRuntimeScope` resolves one immutable `InvocationContextV1` and `AuthorizedScopeV1` from a request plus injected `AuthorityDirectory` and `LocalBindingRegistry` implementations. The resolver:
+
+1. validates captured runtime and registry identity;
+2. resolves and authorizes the principal before inspecting local topology;
+3. enforces finite cached-authority expiry;
+4. validates any optional repository declaration against canonical authority;
+5. verifies matching local repository evidence and rejects ambiguity; and
+6. returns only the compact result or stable error vocabulary.
+
+Authority and registry exceptions fail closed. Normal results contain no diagnostic envelope, local topology inventory, or authority trace. Diagnostics remain a separate, explicitly requested, capability-gated concern.
+
+`InMemoryAuthorityDirectory` is a deterministic test and embedding implementation of the authority contract. It is not shared PostgreSQL authority and does not establish a production trust boundary.
+
 ## Deferred implementation
 
-The following are intentionally absent from Phase 1:
+The following remain intentionally absent after Phase 2:
 
-- local SQLite registry schema and services;
-- deterministic resolver implementation;
 - CLI/MCP bootstrap integration;
 - Frame ownership columns or migration;
 - PostgreSQL RLS;
@@ -109,4 +154,4 @@ The following are intentionally absent from Phase 1:
 - offline authority pairing;
 - a cross-repository helper package.
 
-See [ADR-0011](./adr/0011-trusted-runtime-scope-and-authority.md) and epic [#749](https://github.com/Guffawaffle/lex/issues/749).
+See [ADR-0011](./adr/0011-trusted-runtime-scope-and-authority.md), epic [#749](https://github.com/Guffawaffle/lex/issues/749), and Phase 2 issue [#755](https://github.com/Guffawaffle/lex/issues/755).

--- a/docs/adr/0011-trusted-runtime-scope-and-authority.md
+++ b/docs/adr/0011-trusted-runtime-scope-and-authority.md
@@ -5,6 +5,7 @@
 - Authors: Guff, Sol, Lex
 - Tracking epic: #749
 - Phase 1 issue: #753
+- Phase 2 issue: #755
 
 ## Context
 
@@ -101,7 +102,7 @@ Full diagnostic fields are capability-gated and redacted. Normal agent-facing re
 
 An episodic Frame has one owning tenant/workspace scope. Same-tenant cross-workspace use is an explicit immutable projection requiring source-share and target-accept authority. Cross-tenant or public reuse requires publication of a new immutable content-addressed artifact and explicit workspace acceptance.
 
-These storage and sharing behaviors are architectural constraints but are not implemented by Phase 1.
+These storage and sharing behaviors are architectural constraints but are not implemented by Phase 1 or Phase 2.
 
 ### 9. Legacy ownership is assigned only through deterministic evidence
 
@@ -114,6 +115,8 @@ Ambiguous records remain in admin-only migration staging and cannot enter normal
 Phase 1 publishes the TypeScript contract through `@smartergpt/lex/runtime-scope`. It includes opaque ID types, authority and binding interfaces, immutable runtime envelopes, diagnostic envelopes, stable errors, and data-only conformance fixtures.
 
 The fixtures describe Windows/WSL identity separation, multiple WSL distributions, registry selection, clones, worktrees, moved roots, forks, manifest edits and absence, environment selectors, registry copies, expired grants, conflicting evidence, and diagnostic non-interference. They do not open databases or alter runtime behavior.
+
+Phase 2 implements pure execution-surface and registry-location resolution, a separate versioned SQLite local registry, explicit binding lifecycle operations, and a deterministic fail-closed resolver over injected authority and registry interfaces. All exported fixtures execute against the implementation in tests. The implementation remains opt-in and does not change CLI, MCP, Frame, or FrameStore behavior.
 
 ## Consequences
 
@@ -138,7 +141,6 @@ The fixtures describe Windows/WSL identity separation, multiple WSL distribution
 - UUID generation version.
 - Exact public binding command spelling.
 - Offline authority snapshots and cross-surface pairing.
-- Local registry physical schema and resolver implementation (Phase 2).
 - CLI/MCP integration and diagnostics implementation (Phase 3).
 - Scoped FrameStore behavior and physical ownership migration (Phase 4 and later).
 - PostgreSQL RLS, same-tenant projections, and catalog publication.
@@ -150,3 +152,4 @@ The fixtures describe Windows/WSL identity separation, multiple WSL distribution
 - #736 owns authoritative Frame/FrameStore reconciliation.
 - #750 owns explicit SQLite structural repair.
 - #734 owns the narrower Markdown-derived KnowledgeFrame vertical slice.
+- #755 owns deterministic runtime-scope resolution and the local registry implementation.

--- a/docs/adr/0011-trusted-runtime-scope-and-authority.md
+++ b/docs/adr/0011-trusted-runtime-scope-and-authority.md
@@ -71,7 +71,7 @@ Binding creation, rebinding, inspection, and revocation are administrative opera
 
 `InvocationContext` records the runtime, active project root, requested workspace selector, repository claim/evidence, local binding, runtime surface, and source revision.
 
-`AuthorizedScope` records the single active tenant/workspace grant for an invocation. It is minted by trusted authority and stamps scope into later store operations.
+`AuthorizedScope` records the single active tenant/workspace grant for an invocation. It is minted by trusted authority and stamps scope into later store operations. Its capability set is attenuated to the capabilities explicitly requested for that invocation; requesting none never expands to the grant's full capability set.
 
 Only a trusted entrypoint may capture ambient CLI, environment, path, and platform inputs. Core modules receive immutable values and do not reread `process.env`, `cwd`, or mutable global caches.
 

--- a/scripts/consumer-smoke-test.sh
+++ b/scripts/consumer-smoke-test.sh
@@ -145,18 +145,38 @@ EOF
 cat > test-runtime-scope.mts << 'EOF'
 import {
   RUNTIME_SCOPE_CONTRACT_VERSION,
+  RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
   RUNTIME_SCOPE_CONFORMANCE_FIXTURES,
+  SqliteLocalBindingRegistry,
   WORKSPACE_AUTHORITY_ERROR_CODES,
+  detectExecutionSurface,
+  resolveLocalRegistryLocation,
+  resolveRuntimeScope,
 } from '@smartergpt/lex/runtime-scope';
 
-console.log('✅ Runtime scope subpath (@smartergpt/lex/runtime-scope): Contracts imported successfully');
+const surface = detectExecutionSurface({
+  platform: 'linux',
+  installationRef: 'consumer-smoke',
+  wslDistribution: 'Consumer-Smoke-WSL',
+});
+const location = resolveLocalRegistryLocation({
+  executionSurface: surface,
+  homeDirectory: '/home/consumer',
+});
+
+console.log('✅ Runtime scope subpath (@smartergpt/lex/runtime-scope): Contracts and implementation imported successfully');
 
 if (
   RUNTIME_SCOPE_CONTRACT_VERSION !== 1 ||
+  RUNTIME_SCOPE_IMPLEMENTATION_VERSION !== 1 ||
   RUNTIME_SCOPE_CONFORMANCE_FIXTURES.length < 12 ||
-  WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND !== 'LEX_WORKSPACE_UNBOUND'
+  WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND !== 'LEX_WORKSPACE_UNBOUND' ||
+  surface.kind !== 'wsl' ||
+  location.registryPath !== '/home/consumer/.local/state/lex/registry.db' ||
+  typeof SqliteLocalBindingRegistry !== 'function' ||
+  typeof resolveRuntimeScope !== 'function'
 ) {
-  console.error('❌ Runtime scope contract exports are incomplete');
+  console.error('❌ Runtime scope exports or deterministic surface resolution are incomplete');
   process.exit(1);
 }
 EOF

--- a/src/shared/runtime-scope/in-memory-authority.ts
+++ b/src/shared/runtime-scope/in-memory-authority.ts
@@ -1,0 +1,211 @@
+import type {
+  AuthorityDirectory,
+  AuthorizedWorkspaceGrantV1,
+  PrincipalIdentityV1,
+  PrincipalResolutionRequestV1,
+  RepositoryRecordV1,
+  RepositorySelectorV1,
+  TenantRecordV1,
+  TenantSelectorV1,
+  WorkspaceAuthorizationDecisionV1,
+  WorkspaceAuthorizationRequestV1,
+  WorkspaceRecordV1,
+  WorkspaceSelectorV1,
+} from "./authority.js";
+import type { AuthenticationRef, PrincipalId } from "./ids.js";
+
+export interface InMemoryAuthenticationBindingV1 {
+  readonly authenticationRef: AuthenticationRef;
+  readonly principalId: PrincipalId;
+}
+
+export interface InMemoryAuthorityGrantV1 {
+  readonly grant: AuthorizedWorkspaceGrantV1;
+  readonly revokedAt?: string;
+}
+
+export interface InMemoryAuthoritySeedV1 {
+  readonly principals: readonly PrincipalIdentityV1[];
+  readonly tenants: readonly TenantRecordV1[];
+  readonly workspaces: readonly WorkspaceRecordV1[];
+  readonly repositories: readonly RepositoryRecordV1[];
+  readonly authentication: readonly InMemoryAuthenticationBindingV1[];
+  readonly grants: readonly InMemoryAuthorityGrantV1[];
+}
+
+function uniqueMap<Value>(
+  values: readonly Value[],
+  keyFor: (value: Value) => string,
+  name: string
+): ReadonlyMap<string, Value> {
+  const result = new Map<string, Value>();
+  for (const value of values) {
+    const key = keyFor(value);
+    if (result.has(key)) throw new TypeError(`Duplicate ${name}: ${key}.`);
+    result.set(key, Object.freeze({ ...value }));
+  }
+  return result;
+}
+
+function isExpired(expiresAt: string | undefined, now: string): boolean {
+  if (!expiresAt) return false;
+  const expiry = Date.parse(expiresAt);
+  const current = Date.parse(now);
+  if (!Number.isFinite(expiry) || !Number.isFinite(current)) {
+    throw new TypeError("Authority timestamps must be ISO-compatible values.");
+  }
+  return expiry <= current;
+}
+
+/**
+ * Deterministic injected authority for resolver and conformance tests.
+ * It deliberately has no local topology or persistence behavior.
+ */
+export class InMemoryAuthorityDirectory implements AuthorityDirectory {
+  private readonly principalsById: ReadonlyMap<string, PrincipalIdentityV1>;
+  private readonly tenantsById: ReadonlyMap<string, TenantRecordV1>;
+  private readonly tenantsBySlug: ReadonlyMap<string, TenantRecordV1>;
+  private readonly workspacesById: ReadonlyMap<string, WorkspaceRecordV1>;
+  private readonly workspacesBySlug: ReadonlyMap<string, WorkspaceRecordV1>;
+  private readonly repositoriesById: ReadonlyMap<string, RepositoryRecordV1>;
+  private readonly authentication: ReadonlyMap<string, InMemoryAuthenticationBindingV1>;
+  private readonly grants: readonly InMemoryAuthorityGrantV1[];
+
+  constructor(
+    seed: InMemoryAuthoritySeedV1,
+    private readonly now: () => string = () => new Date().toISOString()
+  ) {
+    this.principalsById = uniqueMap(
+      seed.principals,
+      ({ principalId }) => principalId,
+      "principal ID"
+    );
+    this.tenantsById = uniqueMap(seed.tenants, ({ tenantId }) => tenantId, "tenant ID");
+    this.tenantsBySlug = uniqueMap(seed.tenants, ({ tenantSlug }) => tenantSlug, "tenant slug");
+    this.workspacesById = uniqueMap(
+      seed.workspaces,
+      ({ workspaceId }) => workspaceId,
+      "workspace ID"
+    );
+    this.workspacesBySlug = uniqueMap(
+      seed.workspaces,
+      ({ tenantId, workspaceSlug }) => `${tenantId}/${workspaceSlug}`,
+      "tenant-scoped workspace slug"
+    );
+    this.repositoriesById = uniqueMap(
+      seed.repositories,
+      ({ repositoryId }) => repositoryId,
+      "repository ID"
+    );
+    this.authentication = uniqueMap(
+      seed.authentication,
+      ({ authenticationRef }) => authenticationRef,
+      "authentication reference"
+    );
+    this.grants = Object.freeze(
+      seed.grants
+        .map((entry) =>
+          Object.freeze({
+            ...entry,
+            grant: Object.freeze({
+              ...entry.grant,
+              capabilities: Object.freeze([...entry.grant.capabilities]),
+            }),
+          })
+        )
+        .sort((left, right) => left.grant.grantId.localeCompare(right.grant.grantId))
+    );
+  }
+
+  async resolvePrincipal(
+    request: PrincipalResolutionRequestV1
+  ): Promise<PrincipalIdentityV1 | null> {
+    const binding = this.authentication.get(request.authenticationRef);
+    return binding ? (this.principalsById.get(binding.principalId) ?? null) : null;
+  }
+
+  async getTenant(selector: TenantSelectorV1): Promise<TenantRecordV1 | null> {
+    return "tenantId" in selector
+      ? (this.tenantsById.get(selector.tenantId) ?? null)
+      : (this.tenantsBySlug.get(selector.tenantSlug) ?? null);
+  }
+
+  async getWorkspace(selector: WorkspaceSelectorV1): Promise<WorkspaceRecordV1 | null> {
+    if ("workspaceId" in selector) return this.workspacesById.get(selector.workspaceId) ?? null;
+    const tenant = await this.getTenant(selector.tenant);
+    return tenant
+      ? (this.workspacesBySlug.get(`${tenant.tenantId}/${selector.workspaceSlug}`) ?? null)
+      : null;
+  }
+
+  async getRepository(selector: RepositorySelectorV1): Promise<RepositoryRecordV1 | null> {
+    return this.repositoriesById.get(selector.repositoryId) ?? null;
+  }
+
+  async authorizeWorkspace(
+    request: WorkspaceAuthorizationRequestV1
+  ): Promise<WorkspaceAuthorizationDecisionV1> {
+    const principal = this.principalsById.get(request.principalId);
+    if (!principal || principal.state !== "active") {
+      return Object.freeze({ authorized: false, reason: "principal-unknown" });
+    }
+
+    let tenant: TenantRecordV1 | null = null;
+    if (!("workspaceId" in request.workspace)) {
+      tenant = await this.getTenant(request.workspace.tenant);
+      if (!tenant || tenant.state !== "active") {
+        return Object.freeze({ authorized: false, reason: "tenant-unknown" });
+      }
+    }
+
+    const workspace = await this.getWorkspace(request.workspace);
+    if (!workspace || workspace.state !== "active") {
+      return Object.freeze({ authorized: false, reason: "workspace-unknown" });
+    }
+    tenant ??= this.tenantsById.get(workspace.tenantId) ?? null;
+    if (!tenant || tenant.state !== "active" || tenant.tenantId !== workspace.tenantId) {
+      return Object.freeze({ authorized: false, reason: "tenant-unknown" });
+    }
+
+    const matching = this.grants.filter(
+      ({ grant }) =>
+        grant.principalId === principal.principalId &&
+        grant.tenantId === tenant.tenantId &&
+        grant.workspaceId === workspace.workspaceId
+    );
+    if (matching.length === 0) {
+      return Object.freeze({ authorized: false, reason: "membership-missing" });
+    }
+
+    const active = matching.filter(({ revokedAt }) => revokedAt === undefined);
+    if (active.length === 0) {
+      return Object.freeze({
+        authorized: false,
+        reason: "grant-revoked",
+        authorityVersion: matching[0]?.grant.authorityVersion,
+      });
+    }
+
+    const current = active.filter(({ grant }) => !isExpired(grant.expiresAt, this.now()));
+    if (current.length === 0) {
+      return Object.freeze({
+        authorized: false,
+        reason: "grant-expired",
+        authorityVersion: active[0]?.grant.authorityVersion,
+      });
+    }
+
+    const capable = current.find(({ grant }) =>
+      request.requestedCapabilities.every((capability) => grant.capabilities.includes(capability))
+    );
+    if (!capable) {
+      return Object.freeze({
+        authorized: false,
+        reason: "capability-missing",
+        authorityVersion: current[0]?.grant.authorityVersion,
+      });
+    }
+
+    return Object.freeze({ authorized: true, grant: capable.grant });
+  }
+}

--- a/src/shared/runtime-scope/index.ts
+++ b/src/shared/runtime-scope/index.ts
@@ -125,6 +125,56 @@ export {
 } from "./conformance.js";
 
 export {
+  RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+  nativePlatformFromNode,
+  detectExecutionSurface,
+  resolveLocalRegistryLocation,
+  type BootstrapInputSnapshotV1,
+  type ExecutionSurfaceDetectionInputV1,
+  type RegistryLocationSource,
+  type RegistryLocationInputV1,
+  type ResolvedRegistryLocationV1,
+  type BootstrapInputSnapshot,
+  type ResolvedRegistryLocation,
+} from "./surface.js";
+
+export {
+  LOCAL_REGISTRY_SCHEMA_VERSION,
+  LOCAL_REGISTRY_APPLICATION_ID,
+  LocalRegistryError,
+  SqliteLocalBindingRegistry,
+  computeRepositoryEvidenceDigest,
+  type LocalRegistryAccessMode,
+  type LocalRegistryErrorCode,
+  type LocalRegistryIdFactoryV1,
+  type InitializeLocalRegistryOptionsV1,
+  type OpenLocalRegistryOptionsV1,
+  type InspectBindingsRequestV1,
+  type RebindBindingRequestV1,
+  type BindingLifecycleAction,
+  type BindingLifecycleReceiptV1,
+  type BindingLifecycleReceipt,
+} from "./registry.js";
+
+export {
+  InMemoryAuthorityDirectory,
+  type InMemoryAuthenticationBindingV1,
+  type InMemoryAuthorityGrantV1,
+  type InMemoryAuthoritySeedV1,
+} from "./in-memory-authority.js";
+
+export {
+  resolveRuntimeScope,
+  runtimeScopeFailureFromRegistryError,
+  type RuntimeScopeResolutionRequestV1,
+  type RuntimeScopeResolverDependenciesV1,
+  type RuntimeScopeResolutionErrorV1,
+  type RuntimeScopeResolutionResultV1,
+  type RuntimeScopeResolutionRequest,
+  type RuntimeScopeResolutionResult,
+} from "./resolver.js";
+
+export {
   WORKSPACE_AUTHORITY_ERROR_CODES,
   type WorkspaceAuthorityErrorCode,
 } from "../errors/error-codes.js";

--- a/src/shared/runtime-scope/registry-queries.ts
+++ b/src/shared/runtime-scope/registry-queries.ts
@@ -1,0 +1,452 @@
+/** Curated, parameterized SQL for the surface-local runtime-scope registry. */
+
+import type Database from "better-sqlite3-multiple-ciphers";
+
+export interface RegistryIdentityRow {
+  registry_instance_id: string;
+  execution_surface_id: string;
+  surface_evidence_digest: string;
+  native_platform: string;
+  surface_kind: string;
+  wsl_distribution: string | null;
+  created_at: string;
+}
+
+export interface BindingRow {
+  binding_id: string;
+  registry_instance_id: string;
+  execution_surface_id: string;
+  workspace_instance_id: string;
+  repository_instance_id: string;
+  tenant_id: string;
+  workspace_id: string;
+  repository_id: string;
+  canonical_root: string;
+  manifest_digest: string | null;
+  git_common_directory_digest: string | null;
+  filesystem_evidence_digest: string | null;
+  provider: string | null;
+  provider_repository_id: string | null;
+  provider_remote_digest: string | null;
+  authority_source: string;
+  authority_version: string;
+  authority_digest: string;
+  authority_verified_at: string;
+  authority_expires_at: string;
+  authority_revoked_at: string | null;
+  state: "active" | "revoked";
+  created_at: string;
+  last_verified_at: string | null;
+  revoked_at: string | null;
+  registered_by_principal_id: string;
+}
+
+export interface BindingEventRow {
+  receipt_id: string;
+  binding_id: string;
+  action: "register" | "rebind" | "revoke";
+  registry_instance_id: string;
+  execution_surface_id: string;
+  repository_instance_id: string;
+  workspace_instance_id: string;
+  evidence_digest: string;
+  authority_digest: string;
+  actor_principal_id: string;
+  created_at: string;
+  reason: string | null;
+}
+
+export interface BindingUpdateRow {
+  binding_id: string;
+  canonical_root: string;
+  manifest_digest: string | null;
+  git_common_directory_digest: string | null;
+  filesystem_evidence_digest: string | null;
+  provider: string | null;
+  provider_repository_id: string | null;
+  provider_remote_digest: string | null;
+  authority_source: string;
+  authority_version: string;
+  authority_digest: string;
+  authority_verified_at: string;
+  authority_expires_at: string;
+  authority_revoked_at: string | null;
+  last_verified_at: string;
+}
+
+export function listLocalRegistryTableNames(db: Database.Database): readonly string[] {
+  return (
+    db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+      )
+      .all() as Array<{ name: string }>
+  ).map(({ name }) => name);
+}
+
+export function readLocalRegistryMigrationVersion(db: Database.Database): number | null {
+  if (!new Set(listLocalRegistryTableNames(db)).has("local_registry_migrations")) return null;
+  const row = db.prepare("SELECT MAX(version) AS version FROM local_registry_migrations").get() as {
+    version: number | null;
+  };
+  return row.version;
+}
+
+export function createLocalRegistrySchemaV1(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE local_registry_migrations (
+      version INTEGER PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    );
+
+    CREATE TABLE local_registry_identity (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      registry_instance_id TEXT NOT NULL UNIQUE,
+      execution_surface_id TEXT NOT NULL UNIQUE,
+      surface_evidence_digest TEXT NOT NULL,
+      native_platform TEXT NOT NULL,
+      surface_kind TEXT NOT NULL,
+      wsl_distribution TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE repository_bindings (
+      binding_id TEXT PRIMARY KEY,
+      registry_instance_id TEXT NOT NULL,
+      execution_surface_id TEXT NOT NULL,
+      workspace_instance_id TEXT NOT NULL,
+      repository_instance_id TEXT NOT NULL,
+      tenant_id TEXT NOT NULL,
+      workspace_id TEXT NOT NULL,
+      repository_id TEXT NOT NULL,
+      canonical_root TEXT NOT NULL,
+      manifest_digest TEXT,
+      git_common_directory_digest TEXT,
+      filesystem_evidence_digest TEXT,
+      provider TEXT,
+      provider_repository_id TEXT,
+      provider_remote_digest TEXT,
+      authority_source TEXT NOT NULL,
+      authority_version TEXT NOT NULL,
+      authority_digest TEXT NOT NULL,
+      authority_verified_at TEXT NOT NULL,
+      authority_expires_at TEXT NOT NULL,
+      authority_revoked_at TEXT,
+      state TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+      created_at TEXT NOT NULL,
+      last_verified_at TEXT,
+      revoked_at TEXT,
+      registered_by_principal_id TEXT NOT NULL,
+      FOREIGN KEY (registry_instance_id) REFERENCES local_registry_identity(registry_instance_id),
+      FOREIGN KEY (execution_surface_id) REFERENCES local_registry_identity(execution_surface_id)
+    );
+
+    CREATE UNIQUE INDEX repository_bindings_active_instance_workspace_key
+      ON repository_bindings(repository_instance_id, workspace_id)
+      WHERE state = 'active';
+    CREATE INDEX repository_bindings_active_root_idx
+      ON repository_bindings(state, canonical_root);
+    CREATE INDEX repository_bindings_scope_idx
+      ON repository_bindings(tenant_id, workspace_id, repository_id, state);
+    CREATE INDEX repository_bindings_provider_idx
+      ON repository_bindings(provider, provider_repository_id, state);
+    CREATE INDEX repository_bindings_git_common_idx
+      ON repository_bindings(git_common_directory_digest, state);
+
+    CREATE VIEW local_registry_binding_rows AS
+      SELECT
+        binding_id,
+        registry_instance_id,
+        execution_surface_id,
+        workspace_instance_id,
+        repository_instance_id,
+        tenant_id,
+        workspace_id,
+        repository_id,
+        canonical_root,
+        manifest_digest,
+        git_common_directory_digest,
+        filesystem_evidence_digest,
+        provider,
+        provider_repository_id,
+        provider_remote_digest,
+        authority_source,
+        authority_version,
+        authority_digest,
+        authority_verified_at,
+        authority_expires_at,
+        authority_revoked_at,
+        state,
+        created_at,
+        last_verified_at,
+        revoked_at,
+        registered_by_principal_id
+      FROM repository_bindings;
+
+    CREATE TABLE binding_events (
+      receipt_id TEXT PRIMARY KEY,
+      binding_id TEXT NOT NULL,
+      action TEXT NOT NULL CHECK (action IN ('register', 'rebind', 'revoke')),
+      registry_instance_id TEXT NOT NULL,
+      execution_surface_id TEXT NOT NULL,
+      repository_instance_id TEXT NOT NULL,
+      workspace_instance_id TEXT NOT NULL,
+      evidence_digest TEXT NOT NULL,
+      authority_digest TEXT NOT NULL,
+      actor_principal_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      reason TEXT,
+      FOREIGN KEY (binding_id) REFERENCES repository_bindings(binding_id)
+    );
+
+    CREATE INDEX binding_events_binding_created_idx
+      ON binding_events(binding_id, created_at, receipt_id);
+  `);
+}
+
+export function insertLocalRegistryIdentity(
+  db: Database.Database,
+  identity: RegistryIdentityRow
+): void {
+  db.prepare(
+    `INSERT INTO local_registry_identity (
+      singleton,
+      registry_instance_id,
+      execution_surface_id,
+      surface_evidence_digest,
+      native_platform,
+      surface_kind,
+      wsl_distribution,
+      created_at
+    ) VALUES (1, @registry_instance_id, @execution_surface_id, @surface_evidence_digest,
+      @native_platform, @surface_kind, @wsl_distribution, @created_at)`
+  ).run(identity);
+}
+
+export function insertLocalRegistryMigration(
+  db: Database.Database,
+  version: number,
+  appliedAt: string
+): void {
+  db.prepare("INSERT INTO local_registry_migrations (version, applied_at) VALUES (?, ?)").run(
+    version,
+    appliedAt
+  );
+}
+
+export function setLocalRegistrySchemaIdentity(
+  db: Database.Database,
+  applicationId: number,
+  schemaVersion: number
+): void {
+  db.pragma(`application_id = ${applicationId}`);
+  db.pragma(`user_version = ${schemaVersion}`);
+}
+
+export function readLocalRegistryIdentity(db: Database.Database): RegistryIdentityRow | undefined {
+  return db
+    .prepare(
+      `SELECT
+        registry_instance_id,
+        execution_surface_id,
+        surface_evidence_digest,
+        native_platform,
+        surface_kind,
+        wsl_distribution,
+        created_at
+      FROM local_registry_identity
+      WHERE singleton = 1`
+    )
+    .get() as RegistryIdentityRow | undefined;
+}
+
+export function readLocalRegistryApplicationId(db: Database.Database): number {
+  return db.pragma("application_id", { simple: true }) as number;
+}
+
+export function readLocalRegistryBinding(
+  db: Database.Database,
+  bindingId: string
+): BindingRow | undefined {
+  return db
+    .prepare("SELECT * FROM local_registry_binding_rows WHERE binding_id = ?")
+    .get(bindingId) as BindingRow | undefined;
+}
+
+export function insertLocalRegistryEvent(db: Database.Database, event: BindingEventRow): void {
+  db.prepare(
+    `INSERT INTO binding_events (
+      receipt_id,
+      binding_id,
+      action,
+      registry_instance_id,
+      execution_surface_id,
+      repository_instance_id,
+      workspace_instance_id,
+      evidence_digest,
+      authority_digest,
+      actor_principal_id,
+      created_at,
+      reason
+    ) VALUES (
+      @receipt_id,
+      @binding_id,
+      @action,
+      @registry_instance_id,
+      @execution_surface_id,
+      @repository_instance_id,
+      @workspace_instance_id,
+      @evidence_digest,
+      @authority_digest,
+      @actor_principal_id,
+      @created_at,
+      @reason
+    )`
+  ).run(event);
+}
+
+export function listLocalRegistryBindings(
+  db: Database.Database,
+  bindingId: string | null,
+  state: "active" | "revoked" | null
+): readonly BindingRow[] {
+  return db
+    .prepare(
+      `SELECT *
+       FROM local_registry_binding_rows
+       WHERE (? IS NULL OR binding_id = ?)
+         AND (? IS NULL OR state = ?)
+       ORDER BY binding_id`
+    )
+    .all(bindingId, bindingId, state, state) as BindingRow[];
+}
+
+export function listLocalRegistryEvents(
+  db: Database.Database,
+  bindingId: string | null
+): readonly BindingEventRow[] {
+  return db
+    .prepare(
+      `SELECT
+        receipt_id,
+        binding_id,
+        action,
+        registry_instance_id,
+        execution_surface_id,
+        repository_instance_id,
+        workspace_instance_id,
+        evidence_digest,
+        authority_digest,
+        actor_principal_id,
+        created_at,
+        reason
+      FROM binding_events
+      WHERE (? IS NULL OR binding_id = ?)
+      ORDER BY created_at, receipt_id`
+    )
+    .all(bindingId, bindingId) as BindingEventRow[];
+}
+
+export function listActiveLocalRegistryBindings(db: Database.Database): readonly BindingRow[] {
+  return db
+    .prepare(
+      `SELECT *
+       FROM local_registry_binding_rows
+       WHERE state = 'active'
+       ORDER BY binding_id`
+    )
+    .all() as BindingRow[];
+}
+
+export function insertLocalRegistryBinding(db: Database.Database, binding: BindingRow): void {
+  db.prepare(
+    `INSERT INTO repository_bindings (
+      binding_id,
+      registry_instance_id,
+      execution_surface_id,
+      workspace_instance_id,
+      repository_instance_id,
+      tenant_id,
+      workspace_id,
+      repository_id,
+      canonical_root,
+      manifest_digest,
+      git_common_directory_digest,
+      filesystem_evidence_digest,
+      provider,
+      provider_repository_id,
+      provider_remote_digest,
+      authority_source,
+      authority_version,
+      authority_digest,
+      authority_verified_at,
+      authority_expires_at,
+      authority_revoked_at,
+      state,
+      created_at,
+      last_verified_at,
+      revoked_at,
+      registered_by_principal_id
+    ) VALUES (
+      @binding_id,
+      @registry_instance_id,
+      @execution_surface_id,
+      @workspace_instance_id,
+      @repository_instance_id,
+      @tenant_id,
+      @workspace_id,
+      @repository_id,
+      @canonical_root,
+      @manifest_digest,
+      @git_common_directory_digest,
+      @filesystem_evidence_digest,
+      @provider,
+      @provider_repository_id,
+      @provider_remote_digest,
+      @authority_source,
+      @authority_version,
+      @authority_digest,
+      @authority_verified_at,
+      @authority_expires_at,
+      @authority_revoked_at,
+      @state,
+      @created_at,
+      @last_verified_at,
+      @revoked_at,
+      @registered_by_principal_id
+    )`
+  ).run(binding);
+}
+
+export function updateLocalRegistryBinding(db: Database.Database, binding: BindingUpdateRow): void {
+  db.prepare(
+    `UPDATE repository_bindings SET
+      canonical_root = @canonical_root,
+      manifest_digest = @manifest_digest,
+      git_common_directory_digest = @git_common_directory_digest,
+      filesystem_evidence_digest = @filesystem_evidence_digest,
+      provider = @provider,
+      provider_repository_id = @provider_repository_id,
+      provider_remote_digest = @provider_remote_digest,
+      authority_source = @authority_source,
+      authority_version = @authority_version,
+      authority_digest = @authority_digest,
+      authority_verified_at = @authority_verified_at,
+      authority_expires_at = @authority_expires_at,
+      authority_revoked_at = @authority_revoked_at,
+      last_verified_at = @last_verified_at
+    WHERE binding_id = @binding_id AND state = 'active'`
+  ).run(binding);
+}
+
+export function revokeLocalRegistryBinding(
+  db: Database.Database,
+  bindingId: string,
+  revokedAt: string
+): void {
+  db.prepare(
+    `UPDATE repository_bindings
+     SET state = 'revoked', revoked_at = ?
+     WHERE binding_id = ? AND state = 'active'`
+  ).run(revokedAt, bindingId);
+}

--- a/src/shared/runtime-scope/registry-queries.ts
+++ b/src/shared/runtime-scope/registry-queries.ts
@@ -418,9 +418,13 @@ export function insertLocalRegistryBinding(db: Database.Database, binding: Bindi
   ).run(binding);
 }
 
-export function updateLocalRegistryBinding(db: Database.Database, binding: BindingUpdateRow): void {
-  db.prepare(
-    `UPDATE repository_bindings SET
+export function updateLocalRegistryBinding(
+  db: Database.Database,
+  binding: BindingUpdateRow
+): number {
+  return db
+    .prepare(
+      `UPDATE repository_bindings SET
       canonical_root = @canonical_root,
       manifest_digest = @manifest_digest,
       git_common_directory_digest = @git_common_directory_digest,
@@ -436,17 +440,20 @@ export function updateLocalRegistryBinding(db: Database.Database, binding: Bindi
       authority_revoked_at = @authority_revoked_at,
       last_verified_at = @last_verified_at
     WHERE binding_id = @binding_id AND state = 'active'`
-  ).run(binding);
+    )
+    .run(binding).changes;
 }
 
 export function revokeLocalRegistryBinding(
   db: Database.Database,
   bindingId: string,
   revokedAt: string
-): void {
-  db.prepare(
-    `UPDATE repository_bindings
+): number {
+  return db
+    .prepare(
+      `UPDATE repository_bindings
      SET state = 'revoked', revoked_at = ?
      WHERE binding_id = ? AND state = 'active'`
-  ).run(revokedAt, bindingId);
+    )
+    .run(revokedAt, bindingId).changes;
 }

--- a/src/shared/runtime-scope/registry.ts
+++ b/src/shared/runtime-scope/registry.ts
@@ -1,0 +1,909 @@
+import { createHash, randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, posix, win32 } from "node:path";
+
+import type Database from "better-sqlite3-multiple-ciphers";
+
+import type { WorkspaceSelectorV1 } from "./authority.js";
+import {
+  LOCAL_BINDING_CONTRACT_VERSION,
+  type BindingReceiptV1,
+  type BindingVerificationStatus,
+  type BindingVerificationV1,
+  type CachedAuthorityEvidenceV1,
+  type ExecutionSurfaceEvidenceV1,
+  type FindRepositoryInstancesRequestV1,
+  type LocalBindingRegistry,
+  type RegisterBindingRequestV1,
+  type RepositoryDeclarationV1,
+  type RepositoryInstanceBindingV1,
+  type RepositoryInstanceEvidenceV1,
+  type RevokeBindingRequestV1,
+  type VerifyBindingRequestV1,
+} from "./bindings.js";
+import type {
+  BindingId,
+  BindingReceiptId,
+  ContentDigest,
+  ExecutionSurfaceId,
+  PrincipalId,
+  RegistryInstanceId,
+} from "./ids.js";
+import {
+  createLocalRegistrySchemaV1,
+  insertLocalRegistryBinding,
+  insertLocalRegistryEvent,
+  insertLocalRegistryIdentity,
+  insertLocalRegistryMigration,
+  listActiveLocalRegistryBindings,
+  listLocalRegistryBindings,
+  listLocalRegistryEvents,
+  listLocalRegistryTableNames,
+  readLocalRegistryApplicationId,
+  readLocalRegistryBinding,
+  readLocalRegistryIdentity,
+  readLocalRegistryMigrationVersion,
+  revokeLocalRegistryBinding,
+  setLocalRegistrySchemaIdentity,
+  updateLocalRegistryBinding,
+  type BindingEventRow,
+  type BindingRow,
+  type RegistryIdentityRow,
+} from "./registry-queries.js";
+
+export const LOCAL_REGISTRY_SCHEMA_VERSION = 1 as const;
+export const LOCAL_REGISTRY_APPLICATION_ID = 0x4c585231 as const;
+
+export type LocalRegistryAccessMode = "read-only" | "administrative";
+export type LocalRegistryErrorCode =
+  | "REGISTRY_NOT_FOUND"
+  | "REGISTRY_SCHEMA_INCOMPATIBLE"
+  | "REGISTRY_SURFACE_MISMATCH"
+  | "REGISTRY_READ_ONLY"
+  | "REGISTRY_INVALID_INPUT"
+  | "REGISTRY_CONFLICT";
+
+export class LocalRegistryError extends Error {
+  constructor(
+    public readonly code: LocalRegistryErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "LocalRegistryError";
+  }
+}
+
+export interface LocalRegistryIdFactoryV1 {
+  readonly bindingId: () => BindingId;
+  readonly receiptId: () => BindingReceiptId;
+}
+
+export interface InitializeLocalRegistryOptionsV1 {
+  readonly databasePath: string;
+  readonly registryInstanceId: RegistryInstanceId;
+  readonly executionSurfaceId: ExecutionSurfaceId;
+  readonly executionSurface: ExecutionSurfaceEvidenceV1;
+  readonly createdAt?: string;
+  readonly now?: () => string;
+  readonly idFactory?: LocalRegistryIdFactoryV1;
+}
+
+export interface OpenLocalRegistryOptionsV1 {
+  readonly databasePath: string;
+  readonly executionSurface: ExecutionSurfaceEvidenceV1;
+  readonly access?: LocalRegistryAccessMode;
+  readonly expectedRegistryInstanceId?: RegistryInstanceId;
+  readonly expectedExecutionSurfaceId?: ExecutionSurfaceId;
+  readonly now?: () => string;
+  readonly idFactory?: LocalRegistryIdFactoryV1;
+}
+
+export interface InspectBindingsRequestV1 {
+  readonly bindingId?: BindingId;
+  readonly state?: "active" | "revoked";
+}
+
+export interface RebindBindingRequestV1 {
+  readonly bindingId: BindingId;
+  readonly declaration?: RepositoryDeclarationV1;
+  readonly evidence: RepositoryInstanceEvidenceV1;
+  readonly authorityEvidence: CachedAuthorityEvidenceV1;
+  readonly reboundByPrincipalId: PrincipalId;
+  readonly reboundAt: string;
+  readonly reason: string;
+}
+
+export type BindingLifecycleAction = "register" | "rebind" | "revoke";
+
+export interface BindingLifecycleReceiptV1 extends BindingReceiptV1 {
+  readonly action: BindingLifecycleAction;
+  readonly reason?: string;
+}
+
+type DatabaseConstructor = new (filename: string, options?: Database.Options) => Database.Database;
+
+const require = createRequire(import.meta.url);
+let cachedDatabaseConstructor: DatabaseConstructor | undefined;
+
+function openSqlite(filename: string, options?: Database.Options): Database.Database {
+  cachedDatabaseConstructor ??= require("better-sqlite3-multiple-ciphers") as DatabaseConstructor;
+  return new cachedDatabaseConstructor(filename, options);
+}
+
+function defaultIdFactory(): LocalRegistryIdFactoryV1 {
+  return {
+    bindingId: () => randomUUID() as BindingId,
+    receiptId: () => randomUUID() as BindingReceiptId,
+  };
+}
+
+function requireNonEmpty(value: string, name: string): string {
+  if (value.trim().length === 0) {
+    throw new LocalRegistryError("REGISTRY_INVALID_INPUT", `${name} cannot be empty.`);
+  }
+  return value;
+}
+
+function timestamp(value: string, name: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new LocalRegistryError(
+      "REGISTRY_INVALID_INPUT",
+      `${name} must be an ISO-compatible timestamp.`
+    );
+  }
+  return parsed;
+}
+
+function digestFields(fields: readonly (string | undefined)[]): ContentDigest {
+  const hash = createHash("sha256");
+  for (const field of fields) {
+    const value = field ?? "";
+    hash.update(String(Buffer.byteLength(value, "utf8")));
+    hash.update(":");
+    hash.update(value);
+    hash.update(";");
+  }
+  return `sha256:${hash.digest("hex")}` as ContentDigest;
+}
+
+function normalizeRoot(root: string, surface: ExecutionSurfaceEvidenceV1): string {
+  const capturedRoot = requireNonEmpty(root, "repository canonical root");
+  return surface.nativePlatform === "win32"
+    ? win32.normalize(capturedRoot).toLowerCase()
+    : posix.normalize(capturedRoot);
+}
+
+function normalizeEvidence(
+  evidence: RepositoryInstanceEvidenceV1,
+  surface: ExecutionSurfaceEvidenceV1
+): RepositoryInstanceEvidenceV1 {
+  return Object.freeze({
+    ...evidence,
+    canonicalRoot: normalizeRoot(evidence.canonicalRoot, surface),
+    ...(evidence.provider
+      ? {
+          provider: Object.freeze({
+            ...evidence.provider,
+            provider: requireNonEmpty(evidence.provider.provider, "provider"),
+            providerRepositoryId: requireNonEmpty(
+              evidence.provider.providerRepositoryId,
+              "providerRepositoryId"
+            ),
+          }),
+        }
+      : {}),
+  });
+}
+
+export function computeRepositoryEvidenceDigest(
+  evidence: RepositoryInstanceEvidenceV1,
+  surface: ExecutionSurfaceEvidenceV1
+): ContentDigest {
+  const normalized = normalizeEvidence(evidence, surface);
+  return digestFields([
+    String(normalized.schemaVersion),
+    normalized.canonicalRoot,
+    normalized.manifestDigest,
+    normalized.gitCommonDirectoryDigest,
+    normalized.filesystemEvidenceDigest,
+    normalized.provider?.provider,
+    normalized.provider?.providerRepositoryId,
+    normalized.provider?.remoteDigest,
+  ]);
+}
+
+function authorityStatus(
+  authority: CachedAuthorityEvidenceV1,
+  at: string
+): "usable" | "expired" | "revoked" {
+  const atTime = timestamp(at, "authority verification time");
+  const expiresAt = timestamp(authority.expiresAt, "authority expiresAt");
+  timestamp(authority.verifiedAt, "authority verifiedAt");
+  if (authority.revokedAt) {
+    timestamp(authority.revokedAt, "authority revokedAt");
+    return "revoked";
+  }
+  return expiresAt <= atTime ? "expired" : "usable";
+}
+
+function assertAuthorityUsable(authority: CachedAuthorityEvidenceV1, at: string): void {
+  const status = authorityStatus(authority, at);
+  if (status !== "usable") {
+    throw new LocalRegistryError(
+      "REGISTRY_INVALID_INPUT",
+      `Cached authority is ${status} and cannot authorize a local binding lifecycle change.`
+    );
+  }
+}
+
+function applySchemaV1(
+  db: Database.Database,
+  options: InitializeLocalRegistryOptionsV1,
+  appliedAt: string
+): void {
+  createLocalRegistrySchemaV1(db);
+  insertLocalRegistryIdentity(db, {
+    registry_instance_id: options.registryInstanceId,
+    execution_surface_id: options.executionSurfaceId,
+    surface_evidence_digest: options.executionSurface.evidenceDigest,
+    native_platform: options.executionSurface.nativePlatform,
+    surface_kind: options.executionSurface.kind,
+    wsl_distribution: options.executionSurface.wslDistribution ?? null,
+    created_at: options.createdAt ?? appliedAt,
+  });
+  insertLocalRegistryMigration(db, LOCAL_REGISTRY_SCHEMA_VERSION, appliedAt);
+  setLocalRegistrySchemaIdentity(db, LOCAL_REGISTRY_APPLICATION_ID, LOCAL_REGISTRY_SCHEMA_VERSION);
+}
+
+function initializeSchema(
+  db: Database.Database,
+  options: InitializeLocalRegistryOptionsV1,
+  appliedAt: string
+): void {
+  const tables = listLocalRegistryTableNames(db);
+  const version = readLocalRegistryMigrationVersion(db);
+
+  if (version === null) {
+    if (tables.length > 0) {
+      throw new LocalRegistryError(
+        "REGISTRY_SCHEMA_INCOMPATIBLE",
+        "Refusing to initialize a local binding registry inside an existing non-registry SQLite database."
+      );
+    }
+    const migrate = db.transaction(() => applySchemaV1(db, options, appliedAt));
+    migrate();
+    return;
+  }
+
+  if (version !== LOCAL_REGISTRY_SCHEMA_VERSION) {
+    throw new LocalRegistryError(
+      "REGISTRY_SCHEMA_INCOMPATIBLE",
+      `Local registry schema ${version} is not supported by schema ${LOCAL_REGISTRY_SCHEMA_VERSION}.`
+    );
+  }
+}
+
+function readIdentity(db: Database.Database): RegistryIdentityRow {
+  const identity = readLocalRegistryIdentity(db);
+  if (!identity) {
+    throw new LocalRegistryError(
+      "REGISTRY_SCHEMA_INCOMPATIBLE",
+      "The local registry identity record is missing."
+    );
+  }
+  return identity;
+}
+
+function validateSchemaAndIdentity(
+  db: Database.Database,
+  executionSurface: ExecutionSurfaceEvidenceV1,
+  expectedRegistryInstanceId?: RegistryInstanceId,
+  expectedExecutionSurfaceId?: ExecutionSurfaceId
+): RegistryIdentityRow {
+  const applicationId = readLocalRegistryApplicationId(db);
+  const version = readLocalRegistryMigrationVersion(db);
+  if (
+    applicationId !== LOCAL_REGISTRY_APPLICATION_ID ||
+    version !== LOCAL_REGISTRY_SCHEMA_VERSION
+  ) {
+    throw new LocalRegistryError(
+      "REGISTRY_SCHEMA_INCOMPATIBLE",
+      "The selected database is not a supported Lex local binding registry."
+    );
+  }
+
+  const identity = readIdentity(db);
+  if (
+    identity.surface_evidence_digest !== executionSurface.evidenceDigest ||
+    identity.native_platform !== executionSurface.nativePlatform ||
+    identity.surface_kind !== executionSurface.kind ||
+    identity.wsl_distribution !== (executionSurface.wslDistribution ?? null) ||
+    (expectedRegistryInstanceId !== undefined &&
+      identity.registry_instance_id !== expectedRegistryInstanceId) ||
+    (expectedExecutionSurfaceId !== undefined &&
+      identity.execution_surface_id !== expectedExecutionSurfaceId)
+  ) {
+    throw new LocalRegistryError(
+      "REGISTRY_SURFACE_MISMATCH",
+      "The local registry belongs to a different native execution surface or installation."
+    );
+  }
+  return identity;
+}
+
+function rowEvidence(row: BindingRow): RepositoryInstanceEvidenceV1 {
+  return Object.freeze({
+    schemaVersion: LOCAL_BINDING_CONTRACT_VERSION,
+    canonicalRoot: row.canonical_root,
+    ...(row.manifest_digest ? { manifestDigest: row.manifest_digest as ContentDigest } : {}),
+    ...(row.git_common_directory_digest
+      ? { gitCommonDirectoryDigest: row.git_common_directory_digest as ContentDigest }
+      : {}),
+    ...(row.filesystem_evidence_digest
+      ? { filesystemEvidenceDigest: row.filesystem_evidence_digest as ContentDigest }
+      : {}),
+    ...(row.provider && row.provider_repository_id
+      ? {
+          provider: Object.freeze({
+            provider: row.provider,
+            providerRepositoryId: row.provider_repository_id,
+            ...(row.provider_remote_digest
+              ? { remoteDigest: row.provider_remote_digest as ContentDigest }
+              : {}),
+          }),
+        }
+      : {}),
+  });
+}
+
+function rowBinding(row: BindingRow): RepositoryInstanceBindingV1 {
+  return Object.freeze({
+    schemaVersion: LOCAL_BINDING_CONTRACT_VERSION,
+    bindingId: row.binding_id as BindingId,
+    registryInstanceId: row.registry_instance_id as RegistryInstanceId,
+    executionSurfaceId: row.execution_surface_id as ExecutionSurfaceId,
+    workspaceInstanceId:
+      row.workspace_instance_id as RepositoryInstanceBindingV1["workspaceInstanceId"],
+    repositoryInstanceId:
+      row.repository_instance_id as RepositoryInstanceBindingV1["repositoryInstanceId"],
+    tenantId: row.tenant_id as RepositoryInstanceBindingV1["tenantId"],
+    workspaceId: row.workspace_id as RepositoryInstanceBindingV1["workspaceId"],
+    repositoryId: row.repository_id as RepositoryInstanceBindingV1["repositoryId"],
+    evidence: rowEvidence(row),
+    cachedAuthority: Object.freeze({
+      schemaVersion: LOCAL_BINDING_CONTRACT_VERSION,
+      authoritySource: row.authority_source,
+      authorityVersion: row.authority_version as CachedAuthorityEvidenceV1["authorityVersion"],
+      authorityDigest: row.authority_digest as ContentDigest,
+      verifiedAt: row.authority_verified_at,
+      expiresAt: row.authority_expires_at,
+      ...(row.authority_revoked_at ? { revokedAt: row.authority_revoked_at } : {}),
+    }),
+    state: row.state,
+    createdAt: row.created_at,
+    ...(row.last_verified_at ? { lastVerifiedAt: row.last_verified_at } : {}),
+    ...(row.revoked_at ? { revokedAt: row.revoked_at } : {}),
+  });
+}
+
+function eventReceipt(row: BindingEventRow): BindingLifecycleReceiptV1 {
+  return Object.freeze({
+    schemaVersion: LOCAL_BINDING_CONTRACT_VERSION,
+    receiptId: row.receipt_id as BindingReceiptId,
+    bindingId: row.binding_id as BindingId,
+    registryInstanceId: row.registry_instance_id as RegistryInstanceId,
+    executionSurfaceId: row.execution_surface_id as ExecutionSurfaceId,
+    repositoryInstanceId:
+      row.repository_instance_id as BindingLifecycleReceiptV1["repositoryInstanceId"],
+    workspaceInstanceId:
+      row.workspace_instance_id as BindingLifecycleReceiptV1["workspaceInstanceId"],
+    evidenceDigest: row.evidence_digest as ContentDigest,
+    authorityDigest: row.authority_digest as ContentDigest,
+    registeredByPrincipalId: row.actor_principal_id as PrincipalId,
+    createdAt: row.created_at,
+    action: row.action,
+    ...(row.reason ? { reason: row.reason } : {}),
+  });
+}
+
+function bindingReceipt(row: BindingEventRow): BindingReceiptV1 {
+  const lifecycle = eventReceipt(row);
+  return Object.freeze({
+    schemaVersion: lifecycle.schemaVersion,
+    receiptId: lifecycle.receiptId,
+    bindingId: lifecycle.bindingId,
+    registryInstanceId: lifecycle.registryInstanceId,
+    executionSurfaceId: lifecycle.executionSurfaceId,
+    repositoryInstanceId: lifecycle.repositoryInstanceId,
+    workspaceInstanceId: lifecycle.workspaceInstanceId,
+    evidenceDigest: lifecycle.evidenceDigest,
+    authorityDigest: lifecycle.authorityDigest,
+    registeredByPrincipalId: lifecycle.registeredByPrincipalId,
+    createdAt: lifecycle.createdAt,
+  });
+}
+
+function sameOptional(left: string | undefined, right: string | undefined): boolean {
+  return left === right;
+}
+
+function sameProvider(
+  left: RepositoryInstanceEvidenceV1["provider"],
+  right: RepositoryInstanceEvidenceV1["provider"]
+): boolean {
+  if (!left && !right) return true;
+  if (!left || !right) return false;
+  return (
+    left.provider === right.provider &&
+    left.providerRepositoryId === right.providerRepositoryId &&
+    sameOptional(left.remoteDigest, right.remoteDigest)
+  );
+}
+
+function selectorMatchesBinding(
+  selector: WorkspaceSelectorV1 | undefined,
+  binding: RepositoryInstanceBindingV1
+): boolean {
+  return (
+    selector === undefined ||
+    !("workspaceId" in selector) ||
+    selector.workspaceId === binding.workspaceId
+  );
+}
+
+function candidateMatchesRequest(
+  request: FindRepositoryInstancesRequestV1,
+  binding: RepositoryInstanceBindingV1,
+  surface: ExecutionSurfaceEvidenceV1
+): boolean {
+  if (!selectorMatchesBinding(request.requestedWorkspace, binding)) return false;
+  const incoming = normalizeEvidence(request.evidence, surface);
+  const projectRoot = normalizeRoot(request.projectRoot, surface);
+  const rootMatches =
+    binding.evidence.canonicalRoot === projectRoot ||
+    binding.evidence.canonicalRoot === incoming.canonicalRoot;
+  const declarationMatches = request.repositoryDeclaration?.repositoryId === binding.repositoryId;
+  const manifestMatches =
+    incoming.manifestDigest !== undefined &&
+    incoming.manifestDigest === binding.evidence.manifestDigest;
+  const gitMatches =
+    incoming.gitCommonDirectoryDigest !== undefined &&
+    incoming.gitCommonDirectoryDigest === binding.evidence.gitCommonDirectoryDigest;
+  const filesystemMatches =
+    incoming.filesystemEvidenceDigest !== undefined &&
+    incoming.filesystemEvidenceDigest === binding.evidence.filesystemEvidenceDigest;
+  const providerMatches =
+    incoming.provider !== undefined && sameProvider(incoming.provider, binding.evidence.provider);
+
+  return (
+    rootMatches ||
+    declarationMatches ||
+    manifestMatches ||
+    gitMatches ||
+    filesystemMatches ||
+    providerMatches
+  );
+}
+
+function verificationReasons(
+  binding: RepositoryInstanceBindingV1,
+  declaration: RepositoryDeclarationV1 | undefined,
+  incoming: RepositoryInstanceEvidenceV1,
+  allowRootChange: boolean
+): readonly string[] {
+  const reasons: string[] = [];
+  if (binding.state !== "active") reasons.push("binding-revoked");
+  if (!allowRootChange && binding.evidence.canonicalRoot !== incoming.canonicalRoot) {
+    reasons.push("canonical-root-mismatch");
+  }
+  if (declaration && declaration.repositoryId !== binding.repositoryId) {
+    reasons.push("repository-declaration-mismatch");
+  }
+  if (!sameOptional(binding.evidence.manifestDigest, incoming.manifestDigest)) {
+    reasons.push("manifest-evidence-mismatch");
+  }
+  if (!sameOptional(binding.evidence.gitCommonDirectoryDigest, incoming.gitCommonDirectoryDigest)) {
+    reasons.push("git-common-directory-mismatch");
+  }
+  if (!sameOptional(binding.evidence.filesystemEvidenceDigest, incoming.filesystemEvidenceDigest)) {
+    reasons.push("filesystem-evidence-mismatch");
+  }
+  if (!sameProvider(binding.evidence.provider, incoming.provider)) {
+    reasons.push("provider-evidence-mismatch");
+  }
+  return Object.freeze(reasons);
+}
+
+function hasStableRebindEvidence(
+  binding: RepositoryInstanceBindingV1,
+  _declaration: RepositoryDeclarationV1 | undefined,
+  evidence: RepositoryInstanceEvidenceV1
+): boolean {
+  return (
+    (binding.evidence.gitCommonDirectoryDigest !== undefined &&
+      binding.evidence.gitCommonDirectoryDigest === evidence.gitCommonDirectoryDigest) ||
+    (binding.evidence.filesystemEvidenceDigest !== undefined &&
+      binding.evidence.filesystemEvidenceDigest === evidence.filesystemEvidenceDigest) ||
+    (binding.evidence.provider !== undefined &&
+      sameProvider(binding.evidence.provider, evidence.provider))
+  );
+}
+
+export class SqliteLocalBindingRegistry implements LocalBindingRegistry {
+  readonly registryInstanceId: RegistryInstanceId;
+  readonly executionSurfaceId: ExecutionSurfaceId;
+  readonly executionSurface: ExecutionSurfaceEvidenceV1;
+  readonly databasePath: string;
+  readonly access: LocalRegistryAccessMode;
+
+  private constructor(
+    private readonly db: Database.Database,
+    identity: RegistryIdentityRow,
+    options: {
+      databasePath: string;
+      executionSurface: ExecutionSurfaceEvidenceV1;
+      access: LocalRegistryAccessMode;
+      now?: () => string;
+      idFactory?: LocalRegistryIdFactoryV1;
+    }
+  ) {
+    this.registryInstanceId = identity.registry_instance_id as RegistryInstanceId;
+    this.executionSurfaceId = identity.execution_surface_id as ExecutionSurfaceId;
+    this.executionSurface = options.executionSurface;
+    this.databasePath = options.databasePath;
+    this.access = options.access;
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.idFactory = options.idFactory ?? defaultIdFactory();
+  }
+
+  private readonly now: () => string;
+  private readonly idFactory: LocalRegistryIdFactoryV1;
+
+  static initialize(options: InitializeLocalRegistryOptionsV1): SqliteLocalBindingRegistry {
+    requireNonEmpty(options.databasePath, "databasePath");
+    const isMemory = options.databasePath === ":memory:";
+    const existed = !isMemory && existsSync(options.databasePath);
+    if (!isMemory && !existed) {
+      mkdirSync(dirname(options.databasePath), { recursive: true, mode: 0o700 });
+    }
+
+    const db = openSqlite(options.databasePath);
+    try {
+      db.pragma("busy_timeout = 5000");
+      db.pragma("foreign_keys = ON");
+      const appliedAt = options.createdAt ?? options.now?.() ?? new Date().toISOString();
+      timestamp(appliedAt, "registry createdAt");
+      initializeSchema(db, options, appliedAt);
+      const identity = validateSchemaAndIdentity(
+        db,
+        options.executionSurface,
+        options.registryInstanceId,
+        options.executionSurfaceId
+      );
+      db.pragma("journal_mode = WAL");
+      db.pragma("synchronous = FULL");
+      if (!isMemory) chmodSync(options.databasePath, 0o600);
+      return new SqliteLocalBindingRegistry(db, identity, {
+        databasePath: options.databasePath,
+        executionSurface: options.executionSurface,
+        access: "administrative",
+        now: options.now,
+        idFactory: options.idFactory,
+      });
+    } catch (error) {
+      db.close();
+      throw error;
+    }
+  }
+
+  static open(options: OpenLocalRegistryOptionsV1): SqliteLocalBindingRegistry {
+    requireNonEmpty(options.databasePath, "databasePath");
+    if (options.databasePath === ":memory:" || !existsSync(options.databasePath)) {
+      throw new LocalRegistryError(
+        "REGISTRY_NOT_FOUND",
+        `The local binding registry does not exist: ${options.databasePath}.`
+      );
+    }
+    const access = options.access ?? "read-only";
+    const db = openSqlite(options.databasePath, {
+      readonly: access === "read-only",
+      fileMustExist: true,
+    });
+    try {
+      db.pragma("busy_timeout = 5000");
+      db.pragma("foreign_keys = ON");
+      if (access === "read-only") db.pragma("query_only = ON");
+      const identity = validateSchemaAndIdentity(
+        db,
+        options.executionSurface,
+        options.expectedRegistryInstanceId,
+        options.expectedExecutionSurfaceId
+      );
+      return new SqliteLocalBindingRegistry(db, identity, {
+        databasePath: options.databasePath,
+        executionSurface: options.executionSurface,
+        access,
+        now: options.now,
+        idFactory: options.idFactory,
+      });
+    } catch (error) {
+      db.close();
+      throw error;
+    }
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  private assertAdministrative(): void {
+    if (this.access !== "administrative") {
+      throw new LocalRegistryError(
+        "REGISTRY_READ_ONLY",
+        "This local registry was opened read-only; use an explicit administrative operation."
+      );
+    }
+  }
+
+  private bindingRow(bindingId: BindingId): BindingRow | undefined {
+    return readLocalRegistryBinding(this.db, bindingId);
+  }
+
+  private insertEvent(event: BindingEventRow): void {
+    insertLocalRegistryEvent(this.db, event);
+  }
+
+  async inspectBindings(
+    request: InspectBindingsRequestV1 = {}
+  ): Promise<readonly RepositoryInstanceBindingV1[]> {
+    const rows = listLocalRegistryBindings(
+      this.db,
+      request.bindingId ?? null,
+      request.state ?? null
+    );
+    return Object.freeze(rows.map(rowBinding));
+  }
+
+  async inspectReceipts(bindingId?: BindingId): Promise<readonly BindingLifecycleReceiptV1[]> {
+    const rows = listLocalRegistryEvents(this.db, bindingId ?? null);
+    return Object.freeze(rows.map(eventReceipt));
+  }
+
+  async findRepositoryInstances(
+    request: FindRepositoryInstancesRequestV1
+  ): Promise<readonly RepositoryInstanceBindingV1[]> {
+    const rows = listActiveLocalRegistryBindings(this.db);
+    const matches = rows
+      .map(rowBinding)
+      .filter((binding) => candidateMatchesRequest(request, binding, this.executionSurface));
+    return Object.freeze(matches);
+  }
+
+  async registerBinding(request: RegisterBindingRequestV1): Promise<BindingReceiptV1> {
+    this.assertAdministrative();
+    const createdAt = this.now();
+    timestamp(createdAt, "binding createdAt");
+    assertAuthorityUsable(request.authorityEvidence, createdAt);
+    const evidence = normalizeEvidence(request.evidence, this.executionSurface);
+    const evidenceDigest = computeRepositoryEvidenceDigest(evidence, this.executionSurface);
+    const bindingId = this.idFactory.bindingId();
+    const receiptId = this.idFactory.receiptId();
+    const event: BindingEventRow = {
+      receipt_id: receiptId,
+      binding_id: bindingId,
+      action: "register",
+      registry_instance_id: this.registryInstanceId,
+      execution_surface_id: this.executionSurfaceId,
+      repository_instance_id: request.repositoryInstanceId,
+      workspace_instance_id: request.workspaceInstanceId,
+      evidence_digest: evidenceDigest,
+      authority_digest: request.authorityEvidence.authorityDigest,
+      actor_principal_id: request.registeredByPrincipalId,
+      created_at: createdAt,
+      reason: null,
+    };
+
+    const insert = this.db.transaction(() => {
+      insertLocalRegistryBinding(this.db, {
+        binding_id: bindingId,
+        registry_instance_id: this.registryInstanceId,
+        execution_surface_id: this.executionSurfaceId,
+        workspace_instance_id: request.workspaceInstanceId,
+        repository_instance_id: request.repositoryInstanceId,
+        tenant_id: request.tenantId,
+        workspace_id: request.workspaceId,
+        repository_id: request.repositoryId,
+        canonical_root: evidence.canonicalRoot,
+        manifest_digest: evidence.manifestDigest ?? null,
+        git_common_directory_digest: evidence.gitCommonDirectoryDigest ?? null,
+        filesystem_evidence_digest: evidence.filesystemEvidenceDigest ?? null,
+        provider: evidence.provider?.provider ?? null,
+        provider_repository_id: evidence.provider?.providerRepositoryId ?? null,
+        provider_remote_digest: evidence.provider?.remoteDigest ?? null,
+        authority_source: request.authorityEvidence.authoritySource,
+        authority_version: request.authorityEvidence.authorityVersion,
+        authority_digest: request.authorityEvidence.authorityDigest,
+        authority_verified_at: request.authorityEvidence.verifiedAt,
+        authority_expires_at: request.authorityEvidence.expiresAt,
+        authority_revoked_at: request.authorityEvidence.revokedAt ?? null,
+        state: "active",
+        created_at: createdAt,
+        last_verified_at: request.authorityEvidence.verifiedAt,
+        revoked_at: null,
+        registered_by_principal_id: request.registeredByPrincipalId,
+      });
+      this.insertEvent(event);
+    });
+
+    try {
+      insert();
+    } catch (error) {
+      if (error instanceof LocalRegistryError) throw error;
+      throw new LocalRegistryError(
+        "REGISTRY_CONFLICT",
+        `The binding could not be registered: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    return bindingReceipt(event);
+  }
+
+  async verifyBinding(request: VerifyBindingRequestV1): Promise<BindingVerificationV1> {
+    const verifiedAt = request.verifiedAt;
+    timestamp(verifiedAt, "binding verifiedAt");
+    const evidence = normalizeEvidence(request.evidence, this.executionSurface);
+    const evidenceDigest = computeRepositoryEvidenceDigest(evidence, this.executionSurface);
+    const authority = authorityStatus(request.authorityEvidence, verifiedAt);
+    let status: BindingVerificationStatus;
+    let reasons: readonly string[];
+
+    if (authority === "expired") {
+      status = "authority-expired";
+      reasons = Object.freeze(["authority-cache-expired"]);
+    } else if (
+      authority === "revoked" ||
+      (request.binding.cachedAuthority?.revokedAt !== undefined &&
+        request.binding.cachedAuthority.authorityDigest ===
+          request.authorityEvidence.authorityDigest)
+    ) {
+      status = "authority-revoked";
+      reasons = Object.freeze(["authority-grant-revoked"]);
+    } else if (
+      request.binding.registryInstanceId !== this.registryInstanceId ||
+      request.binding.executionSurfaceId !== this.executionSurfaceId
+    ) {
+      status = "mismatch";
+      reasons = Object.freeze(["registry-surface-mismatch"]);
+    } else {
+      reasons = verificationReasons(request.binding, request.declaration, evidence, false);
+      status = reasons.length === 0 ? "verified" : "mismatch";
+    }
+
+    return Object.freeze({
+      schemaVersion: LOCAL_BINDING_CONTRACT_VERSION,
+      status,
+      bindingId: request.binding.bindingId,
+      evidenceDigest,
+      authorityDigest: request.authorityEvidence.authorityDigest,
+      verifiedAt,
+      reasons,
+    });
+  }
+
+  async rebindBinding(request: RebindBindingRequestV1): Promise<BindingLifecycleReceiptV1> {
+    this.assertAdministrative();
+    requireNonEmpty(request.reason, "rebind reason");
+    timestamp(request.reboundAt, "reboundAt");
+    assertAuthorityUsable(request.authorityEvidence, request.reboundAt);
+    const row = this.bindingRow(request.bindingId);
+    if (!row) {
+      throw new LocalRegistryError(
+        "REGISTRY_INVALID_INPUT",
+        "The binding to rebind was not found."
+      );
+    }
+    const binding = rowBinding(row);
+    if (binding.state !== "active") {
+      throw new LocalRegistryError("REGISTRY_CONFLICT", "A revoked binding cannot be rebound.");
+    }
+    const evidence = normalizeEvidence(request.evidence, this.executionSurface);
+    if (!hasStableRebindEvidence(binding, request.declaration, evidence)) {
+      throw new LocalRegistryError(
+        "REGISTRY_INVALID_INPUT",
+        "Rebinding requires stable provider, Git common-directory, or filesystem evidence in addition to any declaration."
+      );
+    }
+    const continuityReasons = verificationReasons(
+      binding,
+      request.declaration,
+      evidence,
+      true
+    ).filter((reason) => reason !== "manifest-evidence-mismatch");
+    if (continuityReasons.length > 0) {
+      throw new LocalRegistryError(
+        "REGISTRY_CONFLICT",
+        `Repository evidence does not preserve binding identity: ${continuityReasons.join(", ")}.`
+      );
+    }
+
+    const evidenceDigest = computeRepositoryEvidenceDigest(evidence, this.executionSurface);
+    const receiptId = this.idFactory.receiptId();
+    const event: BindingEventRow = {
+      receipt_id: receiptId,
+      binding_id: binding.bindingId,
+      action: "rebind",
+      registry_instance_id: this.registryInstanceId,
+      execution_surface_id: this.executionSurfaceId,
+      repository_instance_id: binding.repositoryInstanceId,
+      workspace_instance_id: binding.workspaceInstanceId,
+      evidence_digest: evidenceDigest,
+      authority_digest: request.authorityEvidence.authorityDigest,
+      actor_principal_id: request.reboundByPrincipalId,
+      created_at: request.reboundAt,
+      reason: request.reason,
+    };
+
+    const rebind = this.db.transaction(() => {
+      updateLocalRegistryBinding(this.db, {
+        binding_id: binding.bindingId,
+        canonical_root: evidence.canonicalRoot,
+        manifest_digest: evidence.manifestDigest ?? null,
+        git_common_directory_digest: evidence.gitCommonDirectoryDigest ?? null,
+        filesystem_evidence_digest: evidence.filesystemEvidenceDigest ?? null,
+        provider: evidence.provider?.provider ?? null,
+        provider_repository_id: evidence.provider?.providerRepositoryId ?? null,
+        provider_remote_digest: evidence.provider?.remoteDigest ?? null,
+        authority_source: request.authorityEvidence.authoritySource,
+        authority_version: request.authorityEvidence.authorityVersion,
+        authority_digest: request.authorityEvidence.authorityDigest,
+        authority_verified_at: request.authorityEvidence.verifiedAt,
+        authority_expires_at: request.authorityEvidence.expiresAt,
+        authority_revoked_at: request.authorityEvidence.revokedAt ?? null,
+        last_verified_at: request.reboundAt,
+      });
+      this.insertEvent(event);
+    });
+    rebind();
+    return eventReceipt(event);
+  }
+
+  async revokeBinding(request: RevokeBindingRequestV1): Promise<void> {
+    this.assertAdministrative();
+    requireNonEmpty(request.reason, "revocation reason");
+    timestamp(request.revokedAt, "revokedAt");
+    const row = this.bindingRow(request.bindingId);
+    if (!row) {
+      throw new LocalRegistryError(
+        "REGISTRY_INVALID_INPUT",
+        "The binding to revoke was not found."
+      );
+    }
+    if (row.state === "revoked") return;
+    const binding = rowBinding(row);
+    const evidenceDigest = computeRepositoryEvidenceDigest(binding.evidence, this.executionSurface);
+    const event: BindingEventRow = {
+      receipt_id: this.idFactory.receiptId(),
+      binding_id: binding.bindingId,
+      action: "revoke",
+      registry_instance_id: this.registryInstanceId,
+      execution_surface_id: this.executionSurfaceId,
+      repository_instance_id: binding.repositoryInstanceId,
+      workspace_instance_id: binding.workspaceInstanceId,
+      evidence_digest: evidenceDigest,
+      authority_digest:
+        binding.cachedAuthority?.authorityDigest ?? ("sha256:none" as ContentDigest),
+      actor_principal_id: request.revokedByPrincipalId,
+      created_at: request.revokedAt,
+      reason: request.reason,
+    };
+    const revoke = this.db.transaction(() => {
+      revokeLocalRegistryBinding(this.db, request.bindingId, request.revokedAt);
+      this.insertEvent(event);
+    });
+    revoke();
+  }
+}
+
+export type BindingLifecycleReceipt = BindingLifecycleReceiptV1;

--- a/src/shared/runtime-scope/registry.ts
+++ b/src/shared/runtime-scope/registry.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, posix, win32 } from "node:path";
+import { dirname } from "node:path";
 
 import type Database from "better-sqlite3-multiple-ciphers";
 
@@ -51,6 +51,7 @@ import {
   type BindingRow,
   type RegistryIdentityRow,
 } from "./registry-queries.js";
+import { executionSurfacePathsAreRelated, normalizeExecutionSurfacePath } from "./surface.js";
 
 export const LOCAL_REGISTRY_SCHEMA_VERSION = 1 as const;
 export const LOCAL_REGISTRY_APPLICATION_ID = 0x4c585231 as const;
@@ -156,6 +157,43 @@ function timestamp(value: string, name: string): number {
   return parsed;
 }
 
+function assertSchemaVersion(
+  value: { readonly schemaVersion: number },
+  expected: number,
+  name: string
+): void {
+  if (value.schemaVersion !== expected) {
+    throw new LocalRegistryError(
+      "REGISTRY_INVALID_INPUT",
+      `${name} schema ${String(value.schemaVersion)} is not supported by schema ${expected}.`
+    );
+  }
+}
+
+function assertExecutionSurfaceVersion(surface: ExecutionSurfaceEvidenceV1): void {
+  assertSchemaVersion(surface, LOCAL_BINDING_CONTRACT_VERSION, "execution surface");
+}
+
+function assertEvidenceVersion(evidence: RepositoryInstanceEvidenceV1): void {
+  assertSchemaVersion(evidence, LOCAL_BINDING_CONTRACT_VERSION, "repository evidence");
+}
+
+function assertDeclarationVersion(declaration: RepositoryDeclarationV1 | undefined): void {
+  if (declaration) {
+    assertSchemaVersion(declaration, LOCAL_BINDING_CONTRACT_VERSION, "repository declaration");
+  }
+}
+
+function assertAuthorityVersion(authority: CachedAuthorityEvidenceV1): void {
+  assertSchemaVersion(authority, LOCAL_BINDING_CONTRACT_VERSION, "cached authority");
+}
+
+function assertBindingVersions(binding: RepositoryInstanceBindingV1): void {
+  assertSchemaVersion(binding, LOCAL_BINDING_CONTRACT_VERSION, "repository binding");
+  assertEvidenceVersion(binding.evidence);
+  if (binding.cachedAuthority) assertAuthorityVersion(binding.cachedAuthority);
+}
+
 function digestFields(fields: readonly (string | undefined)[]): ContentDigest {
   const hash = createHash("sha256");
   for (const field of fields) {
@@ -169,16 +207,43 @@ function digestFields(fields: readonly (string | undefined)[]): ContentDigest {
 }
 
 function normalizeRoot(root: string, surface: ExecutionSurfaceEvidenceV1): string {
-  const capturedRoot = requireNonEmpty(root, "repository canonical root");
-  return surface.nativePlatform === "win32"
-    ? win32.normalize(capturedRoot).toLowerCase()
-    : posix.normalize(capturedRoot);
+  try {
+    const normalized = normalizeExecutionSurfacePath(root, surface, "repository canonical root");
+    return surface.nativePlatform === "win32" ? normalized.toLowerCase() : normalized;
+  } catch (error) {
+    throw new LocalRegistryError(
+      "REGISTRY_INVALID_INPUT",
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+function assertRelatedRoots(
+  projectRoot: string,
+  canonicalRoot: string,
+  surface: ExecutionSurfaceEvidenceV1
+): void {
+  try {
+    if (!executionSurfacePathsAreRelated(projectRoot, canonicalRoot, surface)) {
+      throw new LocalRegistryError(
+        "REGISTRY_INVALID_INPUT",
+        "projectRoot must identify the repository root or a path nested with it."
+      );
+    }
+  } catch (error) {
+    if (error instanceof LocalRegistryError) throw error;
+    throw new LocalRegistryError(
+      "REGISTRY_INVALID_INPUT",
+      error instanceof Error ? error.message : String(error)
+    );
+  }
 }
 
 function normalizeEvidence(
   evidence: RepositoryInstanceEvidenceV1,
   surface: ExecutionSurfaceEvidenceV1
 ): RepositoryInstanceEvidenceV1 {
+  assertEvidenceVersion(evidence);
   return Object.freeze({
     ...evidence,
     canonicalRoot: normalizeRoot(evidence.canonicalRoot, surface),
@@ -201,6 +266,7 @@ export function computeRepositoryEvidenceDigest(
   evidence: RepositoryInstanceEvidenceV1,
   surface: ExecutionSurfaceEvidenceV1
 ): ContentDigest {
+  assertExecutionSurfaceVersion(surface);
   const normalized = normalizeEvidence(evidence, surface);
   return digestFields([
     String(normalized.schemaVersion),
@@ -218,6 +284,7 @@ function authorityStatus(
   authority: CachedAuthorityEvidenceV1,
   at: string
 ): "usable" | "expired" | "revoked" {
+  assertAuthorityVersion(authority);
   const atTime = timestamp(at, "authority verification time");
   const expiresAt = timestamp(authority.expiresAt, "authority expiresAt");
   timestamp(authority.verifiedAt, "authority verifiedAt");
@@ -250,7 +317,10 @@ function applySchemaV1(
     surface_evidence_digest: options.executionSurface.evidenceDigest,
     native_platform: options.executionSurface.nativePlatform,
     surface_kind: options.executionSurface.kind,
-    wsl_distribution: options.executionSurface.wslDistribution ?? null,
+    wsl_distribution:
+      options.executionSurface.kind === "wsl"
+        ? (options.executionSurface.wslDistribution ?? null)
+        : null,
     created_at: options.createdAt ?? appliedAt,
   });
   insertLocalRegistryMigration(db, LOCAL_REGISTRY_SCHEMA_VERSION, appliedAt);
@@ -319,7 +389,8 @@ function validateSchemaAndIdentity(
     identity.surface_evidence_digest !== executionSurface.evidenceDigest ||
     identity.native_platform !== executionSurface.nativePlatform ||
     identity.surface_kind !== executionSurface.kind ||
-    identity.wsl_distribution !== (executionSurface.wslDistribution ?? null) ||
+    identity.wsl_distribution !==
+      (executionSurface.kind === "wsl" ? (executionSurface.wslDistribution ?? null) : null) ||
     (expectedRegistryInstanceId !== undefined &&
       identity.registry_instance_id !== expectedRegistryInstanceId) ||
     (expectedExecutionSurfaceId !== undefined &&
@@ -562,6 +633,7 @@ export class SqliteLocalBindingRegistry implements LocalBindingRegistry {
   private readonly idFactory: LocalRegistryIdFactoryV1;
 
   static initialize(options: InitializeLocalRegistryOptionsV1): SqliteLocalBindingRegistry {
+    assertExecutionSurfaceVersion(options.executionSurface);
     requireNonEmpty(options.databasePath, "databasePath");
     const isMemory = options.databasePath === ":memory:";
     const existed = !isMemory && existsSync(options.databasePath);
@@ -599,6 +671,7 @@ export class SqliteLocalBindingRegistry implements LocalBindingRegistry {
   }
 
   static open(options: OpenLocalRegistryOptionsV1): SqliteLocalBindingRegistry {
+    assertExecutionSurfaceVersion(options.executionSurface);
     requireNonEmpty(options.databasePath, "databasePath");
     if (options.databasePath === ":memory:" || !existsSync(options.databasePath)) {
       throw new LocalRegistryError(
@@ -674,6 +747,9 @@ export class SqliteLocalBindingRegistry implements LocalBindingRegistry {
   async findRepositoryInstances(
     request: FindRepositoryInstancesRequestV1
   ): Promise<readonly RepositoryInstanceBindingV1[]> {
+    assertEvidenceVersion(request.evidence);
+    assertDeclarationVersion(request.repositoryDeclaration);
+    assertRelatedRoots(request.projectRoot, request.evidence.canonicalRoot, this.executionSurface);
     const rows = listActiveLocalRegistryBindings(this.db);
     const matches = rows
       .map(rowBinding)
@@ -751,6 +827,10 @@ export class SqliteLocalBindingRegistry implements LocalBindingRegistry {
   }
 
   async verifyBinding(request: VerifyBindingRequestV1): Promise<BindingVerificationV1> {
+    assertBindingVersions(request.binding);
+    assertDeclarationVersion(request.declaration);
+    assertEvidenceVersion(request.evidence);
+    assertAuthorityVersion(request.authorityEvidence);
     const verifiedAt = request.verifiedAt;
     timestamp(verifiedAt, "binding verifiedAt");
     const evidence = normalizeEvidence(request.evidence, this.executionSurface);
@@ -794,59 +874,59 @@ export class SqliteLocalBindingRegistry implements LocalBindingRegistry {
 
   async rebindBinding(request: RebindBindingRequestV1): Promise<BindingLifecycleReceiptV1> {
     this.assertAdministrative();
+    assertDeclarationVersion(request.declaration);
+    assertEvidenceVersion(request.evidence);
+    assertAuthorityVersion(request.authorityEvidence);
     requireNonEmpty(request.reason, "rebind reason");
     timestamp(request.reboundAt, "reboundAt");
     assertAuthorityUsable(request.authorityEvidence, request.reboundAt);
-    const row = this.bindingRow(request.bindingId);
-    if (!row) {
-      throw new LocalRegistryError(
-        "REGISTRY_INVALID_INPUT",
-        "The binding to rebind was not found."
-      );
-    }
-    const binding = rowBinding(row);
-    if (binding.state !== "active") {
-      throw new LocalRegistryError("REGISTRY_CONFLICT", "A revoked binding cannot be rebound.");
-    }
     const evidence = normalizeEvidence(request.evidence, this.executionSurface);
-    if (!hasStableRebindEvidence(binding, request.declaration, evidence)) {
-      throw new LocalRegistryError(
-        "REGISTRY_INVALID_INPUT",
-        "Rebinding requires stable provider, Git common-directory, or filesystem evidence in addition to any declaration."
-      );
-    }
-    const continuityReasons = verificationReasons(
-      binding,
-      request.declaration,
-      evidence,
-      true
-    ).filter((reason) => reason !== "manifest-evidence-mismatch");
-    if (continuityReasons.length > 0) {
-      throw new LocalRegistryError(
-        "REGISTRY_CONFLICT",
-        `Repository evidence does not preserve binding identity: ${continuityReasons.join(", ")}.`
-      );
-    }
-
     const evidenceDigest = computeRepositoryEvidenceDigest(evidence, this.executionSurface);
-    const receiptId = this.idFactory.receiptId();
-    const event: BindingEventRow = {
-      receipt_id: receiptId,
-      binding_id: binding.bindingId,
-      action: "rebind",
-      registry_instance_id: this.registryInstanceId,
-      execution_surface_id: this.executionSurfaceId,
-      repository_instance_id: binding.repositoryInstanceId,
-      workspace_instance_id: binding.workspaceInstanceId,
-      evidence_digest: evidenceDigest,
-      authority_digest: request.authorityEvidence.authorityDigest,
-      actor_principal_id: request.reboundByPrincipalId,
-      created_at: request.reboundAt,
-      reason: request.reason,
-    };
-
-    const rebind = this.db.transaction(() => {
-      updateLocalRegistryBinding(this.db, {
+    const rebind = this.db.transaction((): BindingEventRow => {
+      const row = this.bindingRow(request.bindingId);
+      if (!row) {
+        throw new LocalRegistryError(
+          "REGISTRY_INVALID_INPUT",
+          "The binding to rebind was not found."
+        );
+      }
+      const binding = rowBinding(row);
+      if (binding.state !== "active") {
+        throw new LocalRegistryError("REGISTRY_CONFLICT", "A revoked binding cannot be rebound.");
+      }
+      if (!hasStableRebindEvidence(binding, request.declaration, evidence)) {
+        throw new LocalRegistryError(
+          "REGISTRY_INVALID_INPUT",
+          "Rebinding requires stable provider, Git common-directory, or filesystem evidence in addition to any declaration."
+        );
+      }
+      const continuityReasons = verificationReasons(
+        binding,
+        request.declaration,
+        evidence,
+        true
+      ).filter((reason) => reason !== "manifest-evidence-mismatch");
+      if (continuityReasons.length > 0) {
+        throw new LocalRegistryError(
+          "REGISTRY_CONFLICT",
+          `Repository evidence does not preserve binding identity: ${continuityReasons.join(", ")}.`
+        );
+      }
+      const event: BindingEventRow = {
+        receipt_id: this.idFactory.receiptId(),
+        binding_id: binding.bindingId,
+        action: "rebind",
+        registry_instance_id: this.registryInstanceId,
+        execution_surface_id: this.executionSurfaceId,
+        repository_instance_id: binding.repositoryInstanceId,
+        workspace_instance_id: binding.workspaceInstanceId,
+        evidence_digest: evidenceDigest,
+        authority_digest: request.authorityEvidence.authorityDigest,
+        actor_principal_id: request.reboundByPrincipalId,
+        created_at: request.reboundAt,
+        reason: request.reason,
+      };
+      const changes = updateLocalRegistryBinding(this.db, {
         binding_id: binding.bindingId,
         canonical_root: evidence.canonicalRoot,
         manifest_digest: evidence.manifestDigest ?? null,
@@ -863,46 +943,78 @@ export class SqliteLocalBindingRegistry implements LocalBindingRegistry {
         authority_revoked_at: request.authorityEvidence.revokedAt ?? null,
         last_verified_at: request.reboundAt,
       });
+      if (changes !== 1) {
+        throw new LocalRegistryError(
+          "REGISTRY_CONFLICT",
+          "The binding changed before the rebind could be committed."
+        );
+      }
       this.insertEvent(event);
+      return event;
     });
-    rebind();
-    return eventReceipt(event);
+    try {
+      return eventReceipt(rebind.immediate());
+    } catch (error) {
+      if (error instanceof LocalRegistryError) throw error;
+      throw new LocalRegistryError(
+        "REGISTRY_CONFLICT",
+        `The binding could not be rebound: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
   }
 
   async revokeBinding(request: RevokeBindingRequestV1): Promise<void> {
     this.assertAdministrative();
     requireNonEmpty(request.reason, "revocation reason");
     timestamp(request.revokedAt, "revokedAt");
-    const row = this.bindingRow(request.bindingId);
-    if (!row) {
+    const revoke = this.db.transaction((): BindingEventRow | null => {
+      const row = this.bindingRow(request.bindingId);
+      if (!row) {
+        throw new LocalRegistryError(
+          "REGISTRY_INVALID_INPUT",
+          "The binding to revoke was not found."
+        );
+      }
+      if (row.state === "revoked") return null;
+      const binding = rowBinding(row);
+      const evidenceDigest = computeRepositoryEvidenceDigest(
+        binding.evidence,
+        this.executionSurface
+      );
+      const event: BindingEventRow = {
+        receipt_id: this.idFactory.receiptId(),
+        binding_id: binding.bindingId,
+        action: "revoke",
+        registry_instance_id: this.registryInstanceId,
+        execution_surface_id: this.executionSurfaceId,
+        repository_instance_id: binding.repositoryInstanceId,
+        workspace_instance_id: binding.workspaceInstanceId,
+        evidence_digest: evidenceDigest,
+        authority_digest:
+          binding.cachedAuthority?.authorityDigest ?? ("sha256:none" as ContentDigest),
+        actor_principal_id: request.revokedByPrincipalId,
+        created_at: request.revokedAt,
+        reason: request.reason,
+      };
+      const changes = revokeLocalRegistryBinding(this.db, request.bindingId, request.revokedAt);
+      if (changes !== 1) {
+        throw new LocalRegistryError(
+          "REGISTRY_CONFLICT",
+          "The binding changed before the revocation could be committed."
+        );
+      }
+      this.insertEvent(event);
+      return event;
+    });
+    try {
+      revoke.immediate();
+    } catch (error) {
+      if (error instanceof LocalRegistryError) throw error;
       throw new LocalRegistryError(
-        "REGISTRY_INVALID_INPUT",
-        "The binding to revoke was not found."
+        "REGISTRY_CONFLICT",
+        `The binding could not be revoked: ${error instanceof Error ? error.message : String(error)}`
       );
     }
-    if (row.state === "revoked") return;
-    const binding = rowBinding(row);
-    const evidenceDigest = computeRepositoryEvidenceDigest(binding.evidence, this.executionSurface);
-    const event: BindingEventRow = {
-      receipt_id: this.idFactory.receiptId(),
-      binding_id: binding.bindingId,
-      action: "revoke",
-      registry_instance_id: this.registryInstanceId,
-      execution_surface_id: this.executionSurfaceId,
-      repository_instance_id: binding.repositoryInstanceId,
-      workspace_instance_id: binding.workspaceInstanceId,
-      evidence_digest: evidenceDigest,
-      authority_digest:
-        binding.cachedAuthority?.authorityDigest ?? ("sha256:none" as ContentDigest),
-      actor_principal_id: request.revokedByPrincipalId,
-      created_at: request.revokedAt,
-      reason: request.reason,
-    };
-    const revoke = this.db.transaction(() => {
-      revokeLocalRegistryBinding(this.db, request.bindingId, request.revokedAt);
-      this.insertEvent(event);
-    });
-    revoke();
   }
 }
 

--- a/src/shared/runtime-scope/resolver.ts
+++ b/src/shared/runtime-scope/resolver.ts
@@ -2,11 +2,12 @@ import {
   WORKSPACE_AUTHORITY_ERROR_CODES,
   type WorkspaceAuthorityErrorCode,
 } from "../errors/error-codes.js";
-import type {
-  AuthorityDirectory,
-  AuthorizedWorkspaceGrantV1,
-  WorkspaceAuthorizationDenialReason,
-  WorkspaceSelectorV1,
+import {
+  AUTHORITY_DIRECTORY_CONTRACT_VERSION,
+  type AuthorityDirectory,
+  type AuthorizedWorkspaceGrantV1,
+  type WorkspaceAuthorizationDenialReason,
+  type WorkspaceSelectorV1,
 } from "./authority.js";
 import {
   LOCAL_BINDING_CONTRACT_VERSION,
@@ -27,6 +28,7 @@ import {
 } from "./runtime.js";
 import { LocalRegistryError } from "./registry.js";
 import {
+  executionSurfacePathsAreRelated,
   RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
   nativePlatformFromNode,
   type BootstrapInputSnapshotV1,
@@ -114,6 +116,49 @@ function timestamp(value: string): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function hasSchemaVersion(
+  value: { readonly schemaVersion: number } | undefined,
+  expected: number
+): boolean {
+  return value !== undefined && value.schemaVersion === expected;
+}
+
+function bindingVersionsAreSupported(binding: RepositoryInstanceBindingV1): boolean {
+  return (
+    hasSchemaVersion(binding, LOCAL_BINDING_CONTRACT_VERSION) &&
+    hasSchemaVersion(binding.evidence, LOCAL_BINDING_CONTRACT_VERSION) &&
+    (binding.cachedAuthority === undefined ||
+      hasSchemaVersion(binding.cachedAuthority, LOCAL_BINDING_CONTRACT_VERSION))
+  );
+}
+
+function requestRootsAreRelated(request: RuntimeScopeResolutionRequestV1): boolean {
+  try {
+    return executionSurfacePathsAreRelated(
+      request.projectRoot,
+      request.repositoryEvidence.canonicalRoot,
+      request.bootstrap.executionSurface
+    );
+  } catch {
+    return false;
+  }
+}
+
+function bindingRootBelongsToRequest(
+  binding: RepositoryInstanceBindingV1,
+  request: RuntimeScopeResolutionRequestV1
+): boolean {
+  try {
+    return executionSurfacePathsAreRelated(
+      request.projectRoot,
+      binding.evidence.canonicalRoot,
+      request.bootstrap.executionSurface
+    );
+  } catch {
+    return false;
+  }
+}
+
 function denialCode(reason: WorkspaceAuthorizationDenialReason): WorkspaceAuthorityErrorCode {
   if (reason === "grant-revoked") {
     return WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_GRANT_REVOKED;
@@ -140,6 +185,24 @@ function repositoryEvidence(evidence: RepositoryInstanceEvidenceV1): RepositoryI
   return Object.freeze({
     ...evidence,
     ...(evidence.provider ? { provider: Object.freeze({ ...evidence.provider }) } : {}),
+  });
+}
+
+function repositoryDeclaration(declaration: RepositoryDeclarationV1): RepositoryDeclarationV1 {
+  return Object.freeze({
+    schemaVersion: declaration.schemaVersion,
+    repositoryId: declaration.repositoryId,
+    repositorySlug: declaration.repositorySlug,
+    ...(declaration.preferredWorkspace
+      ? {
+          preferredWorkspace: Object.freeze({
+            ...(declaration.preferredWorkspace.tenantSlug
+              ? { tenantSlug: declaration.preferredWorkspace.tenantSlug }
+              : {}),
+            workspaceSlug: declaration.preferredWorkspace.workspaceSlug,
+          }),
+        }
+      : {}),
   });
 }
 
@@ -195,14 +258,17 @@ function cacheEvidence(
   });
 }
 
-function authorizedScope(grant: AuthorizedWorkspaceGrantV1): AuthorizedScopeV1 {
+function authorizedScope(
+  grant: AuthorizedWorkspaceGrantV1,
+  requestedCapabilities: readonly CapabilityId[]
+): AuthorizedScopeV1 {
   return Object.freeze({
     schemaVersion: RUNTIME_SCOPE_CONTRACT_VERSION,
     grantId: grant.grantId,
     tenantId: grant.tenantId,
     workspaceId: grant.workspaceId,
     principalId: grant.principalId,
-    capabilities: Object.freeze([...grant.capabilities]),
+    capabilities: Object.freeze([...new Set(requestedCapabilities)]),
     authorityVersion: grant.authorityVersion,
     scopeVersion: grant.scopeVersion,
     authorityDigest: grant.authorityDigest,
@@ -220,7 +286,7 @@ function invocationContext(
     projectRoot: request.projectRoot,
     requestedWorkspace: workspaceSelector(request.requestedWorkspace),
     ...(request.repositoryDeclaration
-      ? { repositoryDeclaration: Object.freeze({ ...request.repositoryDeclaration }) }
+      ? { repositoryDeclaration: repositoryDeclaration(request.repositoryDeclaration) }
       : {}),
     repositoryEvidence: repositoryEvidence(request.repositoryEvidence),
     binding: repositoryBinding(binding),
@@ -243,9 +309,15 @@ export async function resolveRuntimeScope(
   if (
     request.schemaVersion !== RUNTIME_SCOPE_IMPLEMENTATION_VERSION ||
     request.bootstrap.schemaVersion !== RUNTIME_SCOPE_IMPLEMENTATION_VERSION ||
+    !hasSchemaVersion(request.bootstrap.executionSurface, LOCAL_BINDING_CONTRACT_VERSION) ||
+    !hasSchemaVersion(request.repositoryEvidence, LOCAL_BINDING_CONTRACT_VERSION) ||
+    (request.repositoryDeclaration !== undefined &&
+      !hasSchemaVersion(request.repositoryDeclaration, LOCAL_BINDING_CONTRACT_VERSION)) ||
+    !hasSchemaVersion(request.runtimeSurface, LOCAL_BINDING_CONTRACT_VERSION) ||
     request.bootstrap.executionSurface.nativePlatform !==
       nativePlatformFromNode(request.bootstrap.platform) ||
     request.projectRoot.trim().length === 0 ||
+    !requestRootsAreRelated(request) ||
     request.authoritySource.trim().length === 0 ||
     request.runtimeSurface.registryInstanceId !== dependencies.localRegistry.registryInstanceId ||
     request.runtimeSurface.executionSurfaceId !== dependencies.localRegistry.executionSurfaceId
@@ -261,7 +333,11 @@ export async function resolveRuntimeScope(
   } catch {
     return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED);
   }
-  if (!principal || principal.state !== "active") {
+  if (
+    !principal ||
+    !hasSchemaVersion(principal, AUTHORITY_DIRECTORY_CONTRACT_VERSION) ||
+    principal.state !== "active"
+  ) {
     return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED);
   }
 
@@ -276,6 +352,14 @@ export async function resolveRuntimeScope(
     return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED);
   }
   if (!decision.authorized) return failure(denialCode(decision.reason));
+  if (
+    !hasSchemaVersion(decision.grant, AUTHORITY_DIRECTORY_CONTRACT_VERSION) ||
+    !request.requestedCapabilities.every((capability) =>
+      decision.grant.capabilities.includes(capability)
+    )
+  ) {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED);
+  }
 
   const authorityEvidence = cacheEvidence(decision.grant, request);
   if (!authorityEvidence) {
@@ -291,7 +375,11 @@ export async function resolveRuntimeScope(
     } catch {
       return failure(WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH);
     }
-    if (!declaredRepository || declaredRepository.state !== "active") {
+    if (
+      !declaredRepository ||
+      !hasSchemaVersion(declaredRepository, AUTHORITY_DIRECTORY_CONTRACT_VERSION) ||
+      declaredRepository.state !== "active"
+    ) {
       return failure(WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH);
     }
   }
@@ -308,8 +396,9 @@ export async function resolveRuntimeScope(
     return runtimeScopeFailureFromRegistryError(error);
   }
   const scopedCandidates = candidates.filter(
-    ({ tenantId, workspaceId }) =>
-      tenantId === decision.grant.tenantId && workspaceId === decision.grant.workspaceId
+    (candidate) =>
+      candidate.tenantId === decision.grant.tenantId &&
+      candidate.workspaceId === decision.grant.workspaceId
   );
   if (scopedCandidates.length === 0) {
     return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND);
@@ -318,6 +407,13 @@ export async function resolveRuntimeScope(
   const verified: RepositoryInstanceBindingV1[] = [];
   const statuses: BindingVerificationStatus[] = [];
   for (const candidate of scopedCandidates) {
+    if (
+      !bindingVersionsAreSupported(candidate) ||
+      !bindingRootBelongsToRequest(candidate, request)
+    ) {
+      statuses.push("mismatch");
+      continue;
+    }
     let repository;
     try {
       repository = await dependencies.authorityDirectory.getRepository({
@@ -327,7 +423,11 @@ export async function resolveRuntimeScope(
       statuses.push("mismatch");
       continue;
     }
-    if (!repository || repository.state !== "active") {
+    if (
+      !repository ||
+      !hasSchemaVersion(repository, AUTHORITY_DIRECTORY_CONTRACT_VERSION) ||
+      repository.state !== "active"
+    ) {
       statuses.push("mismatch");
       continue;
     }
@@ -342,6 +442,10 @@ export async function resolveRuntimeScope(
       });
     } catch (error) {
       return runtimeScopeFailureFromRegistryError(error);
+    }
+    if (!hasSchemaVersion(verification, LOCAL_BINDING_CONTRACT_VERSION)) {
+      statuses.push("mismatch");
+      continue;
     }
     statuses.push(verification.status);
     if (verification.status === "verified") verified.push(candidate);
@@ -368,7 +472,7 @@ export async function resolveRuntimeScope(
   return Object.freeze({
     resolved: true,
     invocationContext: invocationContext(request, binding),
-    authorizedScope: authorizedScope(decision.grant),
+    authorizedScope: authorizedScope(decision.grant, request.requestedCapabilities),
   });
 }
 

--- a/src/shared/runtime-scope/resolver.ts
+++ b/src/shared/runtime-scope/resolver.ts
@@ -1,0 +1,354 @@
+import {
+  WORKSPACE_AUTHORITY_ERROR_CODES,
+  type WorkspaceAuthorityErrorCode,
+} from "../errors/error-codes.js";
+import type {
+  AuthorityDirectory,
+  AuthorizedWorkspaceGrantV1,
+  WorkspaceAuthorizationDenialReason,
+  WorkspaceSelectorV1,
+} from "./authority.js";
+import {
+  LOCAL_BINDING_CONTRACT_VERSION,
+  type BindingVerificationStatus,
+  type CachedAuthorityEvidenceV1,
+  type LocalBindingRegistry,
+  type RepositoryDeclarationV1,
+  type RepositoryInstanceBindingV1,
+  type RepositoryInstanceEvidenceV1,
+  type RuntimeSurfaceIdentityV1,
+} from "./bindings.js";
+import type { AuthenticationRef, CapabilityId } from "./ids.js";
+import {
+  RUNTIME_SCOPE_CONTRACT_VERSION,
+  type AuthorizedScopeV1,
+  type InvocationContextV1,
+  type SourceRevisionEvidenceV1,
+} from "./runtime.js";
+import { LocalRegistryError } from "./registry.js";
+import {
+  RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+  nativePlatformFromNode,
+  type BootstrapInputSnapshotV1,
+} from "./surface.js";
+
+export interface RuntimeScopeResolutionRequestV1 {
+  readonly schemaVersion: typeof RUNTIME_SCOPE_IMPLEMENTATION_VERSION;
+  readonly bootstrap: BootstrapInputSnapshotV1;
+  readonly projectRoot: string;
+  readonly authenticationRef: AuthenticationRef;
+  readonly requestedWorkspace: WorkspaceSelectorV1;
+  readonly requestedCapabilities: readonly CapabilityId[];
+  readonly repositoryDeclaration?: RepositoryDeclarationV1;
+  readonly repositoryEvidence: RepositoryInstanceEvidenceV1;
+  readonly runtimeSurface: RuntimeSurfaceIdentityV1;
+  readonly authoritySource: string;
+  readonly authorityCacheExpiresAt: string;
+  readonly sourceRevision?: SourceRevisionEvidenceV1;
+}
+
+export interface RuntimeScopeResolverDependenciesV1 {
+  readonly authorityDirectory: AuthorityDirectory;
+  readonly localRegistry: LocalBindingRegistry;
+}
+
+export interface RuntimeScopeResolutionErrorV1 {
+  readonly code: WorkspaceAuthorityErrorCode;
+  readonly message: string;
+}
+
+export type RuntimeScopeResolutionResultV1 =
+  | {
+      readonly resolved: true;
+      readonly invocationContext: InvocationContextV1;
+      readonly authorizedScope: AuthorizedScopeV1;
+    }
+  | {
+      readonly resolved: false;
+      readonly error: RuntimeScopeResolutionErrorV1;
+    };
+
+const ERROR_MESSAGES: Readonly<Record<WorkspaceAuthorityErrorCode, string>> = Object.freeze({
+  [WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND]:
+    "No trusted local workspace binding matched this invocation.",
+  [WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH]:
+    "Repository identity evidence did not match the trusted local binding.",
+  [WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED]:
+    "Canonical authority did not authorize the requested workspace selector.",
+  [WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_BINDING_AMBIGUOUS]:
+    "More than one trusted local binding matched without deterministic disambiguation.",
+  [WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_CACHE_EXPIRED]:
+    "Cached authority expired before the binding could be verified.",
+  [WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_GRANT_REVOKED]:
+    "Canonical authority revoked the workspace grant.",
+});
+
+function failure(code: WorkspaceAuthorityErrorCode): RuntimeScopeResolutionResultV1 {
+  return Object.freeze({
+    resolved: false,
+    error: Object.freeze({ code, message: ERROR_MESSAGES[code] }),
+  });
+}
+
+/** Translate local-registry bootstrap failures into the compact stable resolver vocabulary. */
+export function runtimeScopeFailureFromRegistryError(
+  error: unknown
+): RuntimeScopeResolutionResultV1 {
+  if (!(error instanceof LocalRegistryError)) {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH);
+  }
+  if (error.code === "REGISTRY_NOT_FOUND") {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND);
+  }
+  if (error.code === "REGISTRY_SURFACE_MISMATCH") {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED);
+  }
+  if (error.code === "REGISTRY_SCHEMA_INCOMPATIBLE") {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND);
+  }
+  return failure(WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH);
+}
+
+function timestamp(value: string): number | null {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function denialCode(reason: WorkspaceAuthorizationDenialReason): WorkspaceAuthorityErrorCode {
+  if (reason === "grant-revoked") {
+    return WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_GRANT_REVOKED;
+  }
+  if (reason === "grant-expired") {
+    return WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_CACHE_EXPIRED;
+  }
+  return WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED;
+}
+
+function workspaceSelector(selector: WorkspaceSelectorV1): WorkspaceSelectorV1 {
+  return "workspaceId" in selector
+    ? Object.freeze({ workspaceId: selector.workspaceId })
+    : Object.freeze({
+        tenant:
+          "tenantId" in selector.tenant
+            ? Object.freeze({ tenantId: selector.tenant.tenantId })
+            : Object.freeze({ tenantSlug: selector.tenant.tenantSlug }),
+        workspaceSlug: selector.workspaceSlug,
+      });
+}
+
+function repositoryEvidence(evidence: RepositoryInstanceEvidenceV1): RepositoryInstanceEvidenceV1 {
+  return Object.freeze({
+    ...evidence,
+    ...(evidence.provider ? { provider: Object.freeze({ ...evidence.provider }) } : {}),
+  });
+}
+
+function cacheEvidence(
+  grant: AuthorizedWorkspaceGrantV1,
+  request: RuntimeScopeResolutionRequestV1
+): CachedAuthorityEvidenceV1 | null {
+  const current = timestamp(request.bootstrap.capturedAt);
+  const requestedExpiry = timestamp(request.authorityCacheExpiresAt);
+  const grantExpiry = grant.expiresAt ? timestamp(grant.expiresAt) : null;
+  if (
+    current === null ||
+    requestedExpiry === null ||
+    requestedExpiry <= current ||
+    (grant.expiresAt !== undefined && grantExpiry === null) ||
+    (grantExpiry !== null && grantExpiry <= current)
+  ) {
+    return null;
+  }
+  const expiresAt =
+    grantExpiry !== null && grantExpiry < requestedExpiry
+      ? grant.expiresAt!
+      : request.authorityCacheExpiresAt;
+  return Object.freeze({
+    schemaVersion: LOCAL_BINDING_CONTRACT_VERSION,
+    authoritySource: request.authoritySource,
+    authorityVersion: grant.authorityVersion,
+    authorityDigest: grant.authorityDigest,
+    verifiedAt: grant.verifiedAt,
+    expiresAt,
+  });
+}
+
+function authorizedScope(grant: AuthorizedWorkspaceGrantV1): AuthorizedScopeV1 {
+  return Object.freeze({
+    schemaVersion: RUNTIME_SCOPE_CONTRACT_VERSION,
+    grantId: grant.grantId,
+    tenantId: grant.tenantId,
+    workspaceId: grant.workspaceId,
+    principalId: grant.principalId,
+    capabilities: Object.freeze([...grant.capabilities]),
+    authorityVersion: grant.authorityVersion,
+    scopeVersion: grant.scopeVersion,
+    authorityDigest: grant.authorityDigest,
+    verifiedAt: grant.verifiedAt,
+    ...(grant.expiresAt ? { expiresAt: grant.expiresAt } : {}),
+  });
+}
+
+function invocationContext(
+  request: RuntimeScopeResolutionRequestV1,
+  binding: RepositoryInstanceBindingV1
+): InvocationContextV1 {
+  return Object.freeze({
+    schemaVersion: RUNTIME_SCOPE_CONTRACT_VERSION,
+    projectRoot: request.projectRoot,
+    requestedWorkspace: workspaceSelector(request.requestedWorkspace),
+    ...(request.repositoryDeclaration
+      ? { repositoryDeclaration: Object.freeze({ ...request.repositoryDeclaration }) }
+      : {}),
+    repositoryEvidence: repositoryEvidence(request.repositoryEvidence),
+    binding,
+    runtimeSurface: Object.freeze({ ...request.runtimeSurface }),
+    ...(request.sourceRevision
+      ? { sourceRevision: Object.freeze({ ...request.sourceRevision }) }
+      : {}),
+  });
+}
+
+/**
+ * Resolve one immutable runtime scope from captured input and injected state.
+ * This function never reads process.env, cwd, platform globals, or databases
+ * other than through its AuthorityDirectory and LocalBindingRegistry inputs.
+ */
+export async function resolveRuntimeScope(
+  request: RuntimeScopeResolutionRequestV1,
+  dependencies: RuntimeScopeResolverDependenciesV1
+): Promise<RuntimeScopeResolutionResultV1> {
+  if (
+    request.schemaVersion !== RUNTIME_SCOPE_IMPLEMENTATION_VERSION ||
+    request.bootstrap.schemaVersion !== RUNTIME_SCOPE_IMPLEMENTATION_VERSION ||
+    request.bootstrap.executionSurface.nativePlatform !==
+      nativePlatformFromNode(request.bootstrap.platform) ||
+    request.projectRoot.trim().length === 0 ||
+    request.authoritySource.trim().length === 0 ||
+    request.runtimeSurface.registryInstanceId !== dependencies.localRegistry.registryInstanceId ||
+    request.runtimeSurface.executionSurfaceId !== dependencies.localRegistry.executionSurfaceId
+  ) {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH);
+  }
+
+  let principal;
+  try {
+    principal = await dependencies.authorityDirectory.resolvePrincipal({
+      authenticationRef: request.authenticationRef,
+    });
+  } catch {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED);
+  }
+  if (!principal || principal.state !== "active") {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED);
+  }
+
+  let decision;
+  try {
+    decision = await dependencies.authorityDirectory.authorizeWorkspace({
+      principalId: principal.principalId,
+      workspace: request.requestedWorkspace,
+      requestedCapabilities: request.requestedCapabilities,
+    });
+  } catch {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED);
+  }
+  if (!decision.authorized) return failure(denialCode(decision.reason));
+
+  const authorityEvidence = cacheEvidence(decision.grant, request);
+  if (!authorityEvidence) {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_CACHE_EXPIRED);
+  }
+
+  if (request.repositoryDeclaration) {
+    let declaredRepository;
+    try {
+      declaredRepository = await dependencies.authorityDirectory.getRepository({
+        repositoryId: request.repositoryDeclaration.repositoryId,
+      });
+    } catch {
+      return failure(WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH);
+    }
+    if (!declaredRepository || declaredRepository.state !== "active") {
+      return failure(WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH);
+    }
+  }
+
+  let candidates;
+  try {
+    candidates = await dependencies.localRegistry.findRepositoryInstances({
+      projectRoot: request.projectRoot,
+      repositoryDeclaration: request.repositoryDeclaration,
+      requestedWorkspace: request.requestedWorkspace,
+      evidence: request.repositoryEvidence,
+    });
+  } catch (error) {
+    return runtimeScopeFailureFromRegistryError(error);
+  }
+  const scopedCandidates = candidates.filter(
+    ({ tenantId, workspaceId }) =>
+      tenantId === decision.grant.tenantId && workspaceId === decision.grant.workspaceId
+  );
+  if (scopedCandidates.length === 0) {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND);
+  }
+
+  const verified: RepositoryInstanceBindingV1[] = [];
+  const statuses: BindingVerificationStatus[] = [];
+  for (const candidate of scopedCandidates) {
+    let repository;
+    try {
+      repository = await dependencies.authorityDirectory.getRepository({
+        repositoryId: candidate.repositoryId,
+      });
+    } catch {
+      statuses.push("mismatch");
+      continue;
+    }
+    if (!repository || repository.state !== "active") {
+      statuses.push("mismatch");
+      continue;
+    }
+    let verification;
+    try {
+      verification = await dependencies.localRegistry.verifyBinding({
+        binding: candidate,
+        declaration: request.repositoryDeclaration,
+        evidence: request.repositoryEvidence,
+        authorityEvidence,
+        verifiedAt: request.bootstrap.capturedAt,
+      });
+    } catch (error) {
+      return runtimeScopeFailureFromRegistryError(error);
+    }
+    statuses.push(verification.status);
+    if (verification.status === "verified") verified.push(candidate);
+  }
+
+  if (verified.length > 1) {
+    return failure(WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_BINDING_AMBIGUOUS);
+  }
+  if (verified.length === 0) {
+    if (statuses.includes("authority-revoked")) {
+      return failure(WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_GRANT_REVOKED);
+    }
+    if (statuses.includes("authority-expired")) {
+      return failure(WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_CACHE_EXPIRED);
+    }
+    return failure(
+      scopedCandidates.length > 1
+        ? WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_BINDING_AMBIGUOUS
+        : WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH
+    );
+  }
+
+  const binding = verified[0]!;
+  return Object.freeze({
+    resolved: true,
+    invocationContext: invocationContext(request, binding),
+    authorizedScope: authorizedScope(decision.grant),
+  });
+}
+
+export type RuntimeScopeResolutionRequest = RuntimeScopeResolutionRequestV1;
+export type RuntimeScopeResolutionResult = RuntimeScopeResolutionResultV1;

--- a/src/shared/runtime-scope/resolver.ts
+++ b/src/shared/runtime-scope/resolver.ts
@@ -143,6 +143,28 @@ function repositoryEvidence(evidence: RepositoryInstanceEvidenceV1): RepositoryI
   });
 }
 
+function repositoryBinding(binding: RepositoryInstanceBindingV1): RepositoryInstanceBindingV1 {
+  return Object.freeze({
+    schemaVersion: binding.schemaVersion,
+    bindingId: binding.bindingId,
+    registryInstanceId: binding.registryInstanceId,
+    executionSurfaceId: binding.executionSurfaceId,
+    workspaceInstanceId: binding.workspaceInstanceId,
+    repositoryInstanceId: binding.repositoryInstanceId,
+    tenantId: binding.tenantId,
+    workspaceId: binding.workspaceId,
+    repositoryId: binding.repositoryId,
+    evidence: repositoryEvidence(binding.evidence),
+    ...(binding.cachedAuthority
+      ? { cachedAuthority: Object.freeze({ ...binding.cachedAuthority }) }
+      : {}),
+    state: binding.state,
+    createdAt: binding.createdAt,
+    ...(binding.lastVerifiedAt ? { lastVerifiedAt: binding.lastVerifiedAt } : {}),
+    ...(binding.revokedAt ? { revokedAt: binding.revokedAt } : {}),
+  });
+}
+
 function cacheEvidence(
   grant: AuthorizedWorkspaceGrantV1,
   request: RuntimeScopeResolutionRequestV1
@@ -201,7 +223,7 @@ function invocationContext(
       ? { repositoryDeclaration: Object.freeze({ ...request.repositoryDeclaration }) }
       : {}),
     repositoryEvidence: repositoryEvidence(request.repositoryEvidence),
-    binding,
+    binding: repositoryBinding(binding),
     runtimeSurface: Object.freeze({ ...request.runtimeSurface }),
     ...(request.sourceRevision
       ? { sourceRevision: Object.freeze({ ...request.sourceRevision }) }

--- a/src/shared/runtime-scope/surface.ts
+++ b/src/shared/runtime-scope/surface.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { posix, win32 } from "node:path";
+
+import type { ExecutionSurfaceEvidenceV1, LaunchOrigin, NativePlatform } from "./bindings.js";
+import { LOCAL_BINDING_CONTRACT_VERSION } from "./bindings.js";
+import type { ContentDigest } from "./ids.js";
+
+export const RUNTIME_SCOPE_IMPLEMENTATION_VERSION = 1 as const;
+
+/** Inputs captured once by a trusted entrypoint before core resolution begins. */
+export interface BootstrapInputSnapshotV1 {
+  readonly schemaVersion: typeof RUNTIME_SCOPE_IMPLEMENTATION_VERSION;
+  readonly cwd: string;
+  readonly argv: readonly string[];
+  readonly allowedEnvironment: Readonly<Record<string, string | undefined>>;
+  readonly platform: NodeJS.Platform;
+  readonly executionSurface: ExecutionSurfaceEvidenceV1;
+  readonly capturedAt: string;
+}
+
+/** Explicit platform facts used to classify one native Lex process. */
+export interface ExecutionSurfaceDetectionInputV1 {
+  readonly platform: NodeJS.Platform;
+  readonly installationRef: string;
+  readonly wslDistribution?: string;
+  readonly launchOrigin?: LaunchOrigin;
+}
+
+export type RegistryLocationSource =
+  | "windows-local-app-data"
+  | "xdg-state-home"
+  | "linux-home-fallback"
+  | "macos-application-support"
+  | "other-home-fallback";
+
+/** Explicit host paths captured by an entrypoint or injected by an embedder. */
+export interface RegistryLocationInputV1 {
+  readonly executionSurface: ExecutionSurfaceEvidenceV1;
+  readonly homeDirectory: string;
+  readonly localAppDataDirectory?: string;
+  readonly xdgStateDirectory?: string;
+}
+
+export interface ResolvedRegistryLocationV1 {
+  readonly schemaVersion: typeof RUNTIME_SCOPE_IMPLEMENTATION_VERSION;
+  readonly registryPath: string;
+  readonly source: RegistryLocationSource;
+}
+
+function requireNonEmpty(value: string | undefined, name: string): string {
+  if (value === undefined || value.trim().length === 0) {
+    throw new TypeError(`${name} must be captured explicitly and cannot be empty.`);
+  }
+  return value;
+}
+
+function normalizeOptional(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function digestFields(fields: readonly (string | undefined)[]): ContentDigest {
+  const hash = createHash("sha256");
+  for (const field of fields) {
+    const value = field ?? "";
+    hash.update(String(Buffer.byteLength(value, "utf8")));
+    hash.update(":");
+    hash.update(value);
+    hash.update(";");
+  }
+  return `sha256:${hash.digest("hex")}` as ContentDigest;
+}
+
+export function nativePlatformFromNode(platform: NodeJS.Platform): NativePlatform {
+  switch (platform) {
+    case "win32":
+    case "linux":
+    case "darwin":
+      return platform;
+    default:
+      return "other";
+  }
+}
+
+/**
+ * Classify a process from captured facts only. This function never reads
+ * process.platform, process.env, cwd, OS release files, or mutable globals.
+ */
+export function detectExecutionSurface(
+  input: ExecutionSurfaceDetectionInputV1
+): ExecutionSurfaceEvidenceV1 {
+  const installationRef = requireNonEmpty(input.installationRef, "installationRef");
+  const nativePlatform = nativePlatformFromNode(input.platform);
+  const wslDistribution = normalizeOptional(input.wslDistribution);
+  const launchOrigin = input.launchOrigin ?? "native-shell";
+  const kind =
+    nativePlatform === "win32"
+      ? "windows-native"
+      : nativePlatform === "linux" && wslDistribution
+        ? "wsl"
+        : nativePlatform === "linux"
+          ? "linux-native"
+          : nativePlatform === "darwin"
+            ? "macos-native"
+            : "other";
+
+  return Object.freeze({
+    schemaVersion: LOCAL_BINDING_CONTRACT_VERSION,
+    nativePlatform,
+    kind,
+    installationRef,
+    ...(wslDistribution ? { wslDistribution } : {}),
+    launchOrigin,
+    evidenceDigest: digestFields([
+      String(LOCAL_BINDING_CONTRACT_VERSION),
+      nativePlatform,
+      kind,
+      installationRef,
+      wslDistribution,
+      launchOrigin,
+    ]),
+  });
+}
+
+/** Resolve the standard local-registry path without consulting ambient state. */
+export function resolveLocalRegistryLocation(
+  input: RegistryLocationInputV1
+): ResolvedRegistryLocationV1 {
+  const homeDirectory = requireNonEmpty(input.homeDirectory, "homeDirectory");
+  const { executionSurface } = input;
+
+  if (executionSurface.kind === "windows-native") {
+    const localAppData = requireNonEmpty(
+      input.localAppDataDirectory,
+      "localAppDataDirectory for a Windows-native surface"
+    );
+    return Object.freeze({
+      schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+      registryPath: win32.join(localAppData, "Lex", "registry.db"),
+      source: "windows-local-app-data",
+    });
+  }
+
+  if (executionSurface.kind === "macos-native") {
+    return Object.freeze({
+      schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+      registryPath: posix.join(
+        homeDirectory,
+        "Library",
+        "Application Support",
+        "Lex",
+        "registry.db"
+      ),
+      source: "macos-application-support",
+    });
+  }
+
+  const xdgStateDirectory = normalizeOptional(input.xdgStateDirectory);
+  if (xdgStateDirectory) {
+    return Object.freeze({
+      schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+      registryPath: posix.join(xdgStateDirectory, "lex", "registry.db"),
+      source: "xdg-state-home",
+    });
+  }
+
+  return Object.freeze({
+    schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+    registryPath: posix.join(homeDirectory, ".local", "state", "lex", "registry.db"),
+    source:
+      executionSurface.kind === "linux-native" || executionSurface.kind === "wsl"
+        ? "linux-home-fallback"
+        : "other-home-fallback",
+  });
+}
+
+export type BootstrapInputSnapshot = BootstrapInputSnapshotV1;
+export type ResolvedRegistryLocation = ResolvedRegistryLocationV1;

--- a/src/shared/runtime-scope/surface.ts
+++ b/src/shared/runtime-scope/surface.ts
@@ -36,7 +36,7 @@ export type RegistryLocationSource =
 /** Explicit host paths captured by an entrypoint or injected by an embedder. */
 export interface RegistryLocationInputV1 {
   readonly executionSurface: ExecutionSurfaceEvidenceV1;
-  readonly homeDirectory: string;
+  readonly homeDirectory?: string;
   readonly localAppDataDirectory?: string;
   readonly xdgStateDirectory?: string;
 }
@@ -57,6 +57,69 @@ function requireNonEmpty(value: string | undefined, name: string): string {
 function normalizeOptional(value: string | undefined): string | undefined {
   const normalized = value?.trim();
   return normalized ? normalized : undefined;
+}
+
+function assertSurfaceVersion(surface: ExecutionSurfaceEvidenceV1): void {
+  if (surface.schemaVersion !== LOCAL_BINDING_CONTRACT_VERSION) {
+    throw new TypeError(
+      `executionSurface schema ${String(surface.schemaVersion)} is not supported by schema ${LOCAL_BINDING_CONTRACT_VERSION}.`
+    );
+  }
+}
+
+/** Normalize an absolute path using the native path semantics of one execution surface. */
+export function normalizeExecutionSurfacePath(
+  value: string | undefined,
+  surface: ExecutionSurfaceEvidenceV1,
+  name: string
+): string {
+  assertSurfaceVersion(surface);
+  const captured = requireNonEmpty(value, name);
+  const path = surface.nativePlatform === "win32" ? win32 : posix;
+  if (!path.isAbsolute(captured)) {
+    throw new TypeError(`${name} must be an absolute ${surface.nativePlatform} path.`);
+  }
+  return path.normalize(captured);
+}
+
+function isWithin(parent: string, child: string, surface: ExecutionSurfaceEvidenceV1): boolean {
+  const path = surface.nativePlatform === "win32" ? win32 : posix;
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+}
+
+/** Return whether two absolute paths describe nested locations on one native surface. */
+export function executionSurfacePathsAreRelated(
+  left: string,
+  right: string,
+  surface: ExecutionSurfaceEvidenceV1
+): boolean {
+  const capturedLeft = normalizeExecutionSurfacePath(left, surface, "left path");
+  const capturedRight = normalizeExecutionSurfacePath(right, surface, "right path");
+  const normalizedLeft =
+    surface.nativePlatform === "win32" ? capturedLeft.toLowerCase() : capturedLeft;
+  const normalizedRight =
+    surface.nativePlatform === "win32" ? capturedRight.toLowerCase() : capturedRight;
+  return (
+    isWithin(normalizedLeft, normalizedRight, surface) ||
+    isWithin(normalizedRight, normalizedLeft, surface)
+  );
+}
+
+function rejectCrossSurfaceRegistryPath(
+  path: string,
+  surface: ExecutionSurfaceEvidenceV1,
+  name: string
+): void {
+  if (surface.kind === "wsl" && /^\/mnt\/[^/]+(?:\/|$)/iu.test(path)) {
+    throw new TypeError(`${name} must remain inside the WSL filesystem.`);
+  }
+  if (surface.kind === "windows-native" && /^\\\\(?:wsl\$|wsl\.localhost)\\/iu.test(path)) {
+    throw new TypeError(`${name} must remain inside the Windows filesystem.`);
+  }
 }
 
 function digestFields(fields: readonly (string | undefined)[]): ContentDigest {
@@ -116,8 +179,7 @@ export function detectExecutionSurface(
       nativePlatform,
       kind,
       installationRef,
-      wslDistribution,
-      launchOrigin,
+      kind === "wsl" ? wslDistribution : undefined,
     ]),
   });
 }
@@ -126,14 +188,16 @@ export function detectExecutionSurface(
 export function resolveLocalRegistryLocation(
   input: RegistryLocationInputV1
 ): ResolvedRegistryLocationV1 {
-  const homeDirectory = requireNonEmpty(input.homeDirectory, "homeDirectory");
   const { executionSurface } = input;
+  assertSurfaceVersion(executionSurface);
 
   if (executionSurface.kind === "windows-native") {
-    const localAppData = requireNonEmpty(
+    const localAppData = normalizeExecutionSurfacePath(
       input.localAppDataDirectory,
+      executionSurface,
       "localAppDataDirectory for a Windows-native surface"
     );
+    rejectCrossSurfaceRegistryPath(localAppData, executionSurface, "localAppDataDirectory");
     return Object.freeze({
       schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
       registryPath: win32.join(localAppData, "Lex", "registry.db"),
@@ -142,6 +206,11 @@ export function resolveLocalRegistryLocation(
   }
 
   if (executionSurface.kind === "macos-native") {
+    const homeDirectory = normalizeExecutionSurfacePath(
+      input.homeDirectory,
+      executionSurface,
+      "homeDirectory for a macOS-native surface"
+    );
     return Object.freeze({
       schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
       registryPath: posix.join(
@@ -157,12 +226,25 @@ export function resolveLocalRegistryLocation(
 
   const xdgStateDirectory = normalizeOptional(input.xdgStateDirectory);
   if (xdgStateDirectory) {
+    const stateDirectory = normalizeExecutionSurfacePath(
+      xdgStateDirectory,
+      executionSurface,
+      "xdgStateDirectory"
+    );
+    rejectCrossSurfaceRegistryPath(stateDirectory, executionSurface, "xdgStateDirectory");
     return Object.freeze({
       schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
-      registryPath: posix.join(xdgStateDirectory, "lex", "registry.db"),
+      registryPath: posix.join(stateDirectory, "lex", "registry.db"),
       source: "xdg-state-home",
     });
   }
+
+  const homeDirectory = normalizeExecutionSurfacePath(
+    input.homeDirectory,
+    executionSurface,
+    "homeDirectory"
+  );
+  rejectCrossSurfaceRegistryPath(homeDirectory, executionSurface, "homeDirectory");
 
   return Object.freeze({
     schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,

--- a/test/shared/runtime-scope/implementation-conformance.test.ts
+++ b/test/shared/runtime-scope/implementation-conformance.test.ts
@@ -1,0 +1,833 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+
+import {
+  InMemoryAuthorityDirectory,
+  RUNTIME_SCOPE_CONFORMANCE_FIXTURES,
+  SqliteLocalBindingRegistry,
+  WORKSPACE_AUTHORITY_ERROR_CODES,
+  detectExecutionSurface,
+  resolveLocalRegistryLocation,
+  resolveRuntimeScope,
+  runtimeScopeFailureFromRegistryError,
+  type AuthenticationRef,
+  type AuthorityGrantId,
+  type AuthorityVersion,
+  type BindingId,
+  type BindingReceiptId,
+  type CapabilityId,
+  type ContentDigest,
+  type ExecutionSurfaceEvidenceV1,
+  type ExecutionSurfaceId,
+  type InMemoryAuthoritySeedV1,
+  type LocalRegistryIdFactoryV1,
+  type PrincipalId,
+  type RegistryInstanceId,
+  type RepositoryDeclarationV1,
+  type RepositoryId,
+  type RepositoryInstanceEvidenceV1,
+  type RepositoryInstanceId,
+  type RepositorySlug,
+  type RuntimeId,
+  type RuntimeScopeConformanceExpectationV1,
+  type RuntimeScopeConformanceFixtureId,
+  type RuntimeScopeResolutionRequestV1,
+  type RuntimeScopeResolutionResultV1,
+  type ScopeVersion,
+  type TenantId,
+  type TenantSlug,
+  type WorkspaceId,
+  type WorkspaceInstanceId,
+  type WorkspaceSlug,
+} from "../../../src/shared/runtime-scope/index.js";
+
+const NOW = "2026-07-18T05:00:00.000Z";
+const CACHE_EXPIRES = "2026-07-18T05:30:00.000Z";
+const GRANT_EXPIRES = "2026-07-18T06:00:00.000Z";
+const AUTHENTICATION_REF = "auth:guff" as AuthenticationRef;
+const PRINCIPAL_ID = "principal-guff" as PrincipalId;
+const TENANT_ID = "tenant-platform" as TenantId;
+const TENANT_SLUG = "platform-dogfood" as TenantSlug;
+const WORKSPACE_ID = "workspace-lex" as WorkspaceId;
+const WORKSPACE_SLUG = "lex" as WorkspaceSlug;
+const REPOSITORY_ID = "repository-lex" as RepositoryId;
+const REPOSITORY_SLUG = "lex" as RepositorySlug;
+const CAPABILITY = "frame:read" as CapabilityId;
+
+interface RegistryContext {
+  readonly root: string;
+  readonly databasePath: string;
+  readonly surface: ExecutionSurfaceEvidenceV1;
+  readonly registry: SqliteLocalBindingRegistry;
+  readonly registryInstanceId: RegistryInstanceId;
+  readonly executionSurfaceId: ExecutionSurfaceId;
+}
+
+const declaration: RepositoryDeclarationV1 = {
+  schemaVersion: 1,
+  repositoryId: REPOSITORY_ID,
+  repositorySlug: REPOSITORY_SLUG,
+};
+
+function evidence(
+  root: string,
+  options: { providerRepositoryId?: string; gitCommonDigest?: string } = {}
+): RepositoryInstanceEvidenceV1 {
+  return {
+    schemaVersion: 1,
+    canonicalRoot: root,
+    manifestDigest: "sha256:manifest" as ContentDigest,
+    gitCommonDirectoryDigest: (options.gitCommonDigest ?? "sha256:git-common") as ContentDigest,
+    filesystemEvidenceDigest: "sha256:filesystem" as ContentDigest,
+    provider: {
+      provider: "github",
+      providerRepositoryId: options.providerRepositoryId ?? "Guffawaffle/lex",
+      remoteDigest: `sha256:${options.providerRepositoryId ?? "remote"}` as ContentDigest,
+    },
+  };
+}
+
+function authoritySeed(): InMemoryAuthoritySeedV1 {
+  return {
+    principals: [
+      {
+        schemaVersion: 1,
+        principalId: PRINCIPAL_ID,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    tenants: [
+      {
+        schemaVersion: 1,
+        tenantId: TENANT_ID,
+        tenantSlug: TENANT_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    workspaces: [
+      {
+        schemaVersion: 1,
+        workspaceId: WORKSPACE_ID,
+        tenantId: TENANT_ID,
+        workspaceSlug: WORKSPACE_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    repositories: [
+      {
+        schemaVersion: 1,
+        repositoryId: REPOSITORY_ID,
+        repositorySlug: REPOSITORY_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    authentication: [{ authenticationRef: AUTHENTICATION_REF, principalId: PRINCIPAL_ID }],
+    grants: [
+      {
+        grant: {
+          schemaVersion: 1,
+          grantId: "grant-lex" as AuthorityGrantId,
+          tenantId: TENANT_ID,
+          workspaceId: WORKSPACE_ID,
+          principalId: PRINCIPAL_ID,
+          capabilities: [CAPABILITY],
+          authorityVersion: "authority-v1" as AuthorityVersion,
+          scopeVersion: "scope-v1" as ScopeVersion,
+          authorityDigest: "sha256:authority" as ContentDigest,
+          verifiedAt: NOW,
+          expiresAt: GRANT_EXPIRES,
+        },
+      },
+    ],
+  };
+}
+
+function authorityDirectory(): InMemoryAuthorityDirectory {
+  return new InMemoryAuthorityDirectory(authoritySeed(), () => NOW);
+}
+
+function deterministicIds(prefix: string): LocalRegistryIdFactoryV1 {
+  let binding = 0;
+  let receipt = 0;
+  return {
+    bindingId: () => `${prefix}-binding-${++binding}` as BindingId,
+    receiptId: () => `${prefix}-receipt-${++receipt}` as BindingReceiptId,
+  };
+}
+
+function createRegistry(prefix: string, surface: ExecutionSurfaceEvidenceV1): RegistryContext {
+  const root = mkdtempSync(join(tmpdir(), `lex-conformance-${prefix}-`));
+  const databasePath = join(root, "registry.db");
+  const registryInstanceId = `${prefix}-registry` as RegistryInstanceId;
+  const executionSurfaceId = `${prefix}-surface` as ExecutionSurfaceId;
+  return {
+    root,
+    databasePath,
+    surface,
+    registryInstanceId,
+    executionSurfaceId,
+    registry: SqliteLocalBindingRegistry.initialize({
+      databasePath,
+      registryInstanceId,
+      executionSurfaceId,
+      executionSurface: surface,
+      createdAt: NOW,
+      now: () => NOW,
+      idFactory: deterministicIds(prefix),
+    }),
+  };
+}
+
+function closeRegistry(context: RegistryContext): void {
+  try {
+    context.registry.close();
+  } catch {
+    // Some scenarios close the original handle before attempting a second open.
+  }
+  rmSync(context.root, { recursive: true, force: true });
+}
+
+async function registerBinding(
+  context: RegistryContext,
+  root: string,
+  instanceSuffix = "1",
+  repositoryEvidence = evidence(root)
+) {
+  return context.registry.registerBinding({
+    tenantId: TENANT_ID,
+    workspaceId: WORKSPACE_ID,
+    repositoryId: REPOSITORY_ID,
+    repositoryInstanceId:
+      `${context.registryInstanceId}-repository-${instanceSuffix}` as RepositoryInstanceId,
+    workspaceInstanceId:
+      `${context.registryInstanceId}-workspace-${instanceSuffix}` as WorkspaceInstanceId,
+    evidence: repositoryEvidence,
+    authorityEvidence: {
+      schemaVersion: 1,
+      authoritySource: "authority:test",
+      authorityVersion: "authority-v1" as AuthorityVersion,
+      authorityDigest: "sha256:authority" as ContentDigest,
+      verifiedAt: NOW,
+      expiresAt: CACHE_EXPIRES,
+    },
+    registeredByPrincipalId: PRINCIPAL_ID,
+  });
+}
+
+function request(
+  context: RegistryContext,
+  projectRoot: string,
+  repositoryEvidence = evidence(projectRoot),
+  repositoryDeclaration: RepositoryDeclarationV1 | undefined = declaration
+): RuntimeScopeResolutionRequestV1 {
+  const platform = context.surface.nativePlatform === "win32" ? "win32" : "linux";
+  return {
+    schemaVersion: 1,
+    bootstrap: {
+      schemaVersion: 1,
+      cwd: projectRoot,
+      argv: ["lex", "recall"],
+      allowedEnvironment: {},
+      platform,
+      executionSurface: context.surface,
+      capturedAt: NOW,
+    },
+    projectRoot,
+    authenticationRef: AUTHENTICATION_REF,
+    requestedWorkspace: { workspaceId: WORKSPACE_ID },
+    requestedCapabilities: [CAPABILITY],
+    ...(repositoryDeclaration ? { repositoryDeclaration } : {}),
+    repositoryEvidence,
+    runtimeSurface: {
+      schemaVersion: 1,
+      registryInstanceId: context.registryInstanceId,
+      executionSurfaceId: context.executionSurfaceId,
+      runtimeId: `${context.registryInstanceId}-runtime` as RuntimeId,
+    },
+    authoritySource: "authority:test",
+    authorityCacheExpiresAt: CACHE_EXPIRES,
+  };
+}
+
+function resolve(
+  context: RegistryContext,
+  resolutionRequest: RuntimeScopeResolutionRequestV1
+): Promise<RuntimeScopeResolutionResultV1> {
+  return resolveRuntimeScope(resolutionRequest, {
+    authorityDirectory: authorityDirectory(),
+    localRegistry: context.registry,
+  });
+}
+
+function failureExpectation(
+  result: RuntimeScopeResolutionResultV1,
+  localIdentity: RuntimeScopeConformanceExpectationV1["localIdentity"]
+): RuntimeScopeConformanceExpectationV1 {
+  assert.equal(result.resolved, false);
+  assert.ok(!result.resolved);
+  return {
+    result: "fail-closed",
+    errorCode: result.error.code,
+    canonicalIdentity: "not-created",
+    localIdentity,
+    bindingMutation: "none",
+    diagnosticChangesOutcome: false,
+  };
+}
+
+async function receiptsUnchanged<T>(
+  registry: SqliteLocalBindingRegistry,
+  operation: () => Promise<T>
+): Promise<{ result: T; unchanged: boolean }> {
+  const before = (await registry.inspectReceipts()).length;
+  const result = await operation();
+  const after = (await registry.inspectReceipts()).length;
+  return { result, unchanged: before === after };
+}
+
+async function crossSurfaceResolution(): Promise<{
+  windows: RegistryContext;
+  wsl: RegistryContext;
+  windowsResult: RuntimeScopeResolutionResultV1;
+  wslResult: RuntimeScopeResolutionResultV1;
+  resolutionDidNotMutate: boolean;
+}> {
+  const windows = createRegistry(
+    "windows-cross-surface",
+    detectExecutionSurface({ platform: "win32", installationRef: "windows-installation" })
+  );
+  const wsl = createRegistry(
+    "wsl-cross-surface",
+    detectExecutionSurface({
+      platform: "linux",
+      installationRef: "wsl-installation",
+      wslDistribution: "Ubuntu-24.04",
+    })
+  );
+  await registerBinding(windows, "C:\\dev\\lex");
+  await registerBinding(wsl, "/mnt/c/dev/lex");
+  const before =
+    (await windows.registry.inspectReceipts()).length +
+    (await wsl.registry.inspectReceipts()).length;
+  const windowsResult = await resolve(windows, request(windows, "C:\\dev\\lex"));
+  const wslResult = await resolve(wsl, request(wsl, "/mnt/c/dev/lex"));
+  const after =
+    (await windows.registry.inspectReceipts()).length +
+    (await wsl.registry.inspectReceipts()).length;
+  return { windows, wsl, windowsResult, wslResult, resolutionDidNotMutate: before === after };
+}
+
+type ConformanceHandler = () => Promise<RuntimeScopeConformanceExpectationV1>;
+
+const handlers: Record<RuntimeScopeConformanceFixtureId, ConformanceHandler> = {
+  "cached-grant-expired": async () => {
+    const context = createRegistry(
+      "expired",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "expired-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      const receipt = await registerBinding(context, "/srv/lex");
+      const [binding] = await context.registry.inspectBindings({ bindingId: receipt.bindingId });
+      assert.ok(binding);
+      const verification = await context.registry.verifyBinding({
+        binding,
+        declaration,
+        evidence: evidence("/srv/lex"),
+        authorityEvidence: {
+          schemaVersion: 1,
+          authoritySource: "authority:test",
+          authorityVersion: "authority-v1" as AuthorityVersion,
+          authorityDigest: "sha256:authority" as ContentDigest,
+          verifiedAt: NOW,
+          expiresAt: NOW,
+        },
+        verifiedAt: NOW,
+      });
+      assert.equal(verification.status, "authority-expired");
+      assert.equal((await context.registry.inspectBindings()).length, 1);
+      return {
+        result: "fail-closed",
+        errorCode: WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_CACHE_EXPIRED,
+        canonicalIdentity: "not-created",
+        localIdentity: "preserved",
+        bindingMutation: "none",
+        diagnosticChangesOutcome: false,
+      };
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "conflicting-binding-evidence": async () => {
+    const context = createRegistry(
+      "conflicting",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "conflicting-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      await registerBinding(context, "/srv/lex", "1");
+      await registerBinding(context, "/srv/lex", "2");
+      return failureExpectation(await resolve(context, request(context, "/srv/lex")), "preserved");
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "copied-registry-no-authority": async () => {
+    const context = createRegistry(
+      "copied",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "ubuntu-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      context.registry.close();
+      let translated: RuntimeScopeResolutionResultV1 | undefined;
+      try {
+        SqliteLocalBindingRegistry.open({
+          databasePath: context.databasePath,
+          executionSurface: detectExecutionSurface({
+            platform: "linux",
+            installationRef: "debian-installation",
+            wslDistribution: "Debian",
+          }),
+        });
+      } catch (error) {
+        translated = runtimeScopeFailureFromRegistryError(error);
+      }
+      assert.ok(translated);
+      return failureExpectation(translated, "not-created");
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "diagnostic-observability-only": async () => {
+    const context = createRegistry(
+      "diagnostic",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "diagnostic-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      await registerBinding(context, "/srv/lex");
+      const mismatched = request(
+        context,
+        "/srv/lex",
+        evidence("/srv/lex", { providerRepositoryId: "someone/fork" })
+      );
+      const first = await resolve(context, mismatched);
+      const second = await resolve(context, mismatched);
+      assert.deepEqual(second, first);
+      assert.equal("diagnostics" in first, false);
+      return failureExpectation(first, "preserved");
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "edited-manifest-no-authority": async () => {
+    const context = createRegistry(
+      "edited-manifest",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "edited-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      await registerBinding(context, "/srv/lex");
+      const edited: RepositoryDeclarationV1 = {
+        ...declaration,
+        repositoryId: "repository-forged" as RepositoryId,
+      };
+      return failureExpectation(
+        await resolve(context, request(context, "/srv/lex", evidence("/srv/lex"), edited)),
+        "preserved"
+      );
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "environment-selector-no-authority": async () => {
+    const context = createRegistry(
+      "environment-selector",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "environment-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      const base = request(context, "/srv/lex");
+      const result = await resolve(context, {
+        ...base,
+        bootstrap: {
+          ...base.bootstrap,
+          allowedEnvironment: { LEX_WORKSPACE: "not-authorized" },
+        },
+        requestedWorkspace: { workspaceId: "workspace-not-authorized" as WorkspaceId },
+      });
+      return failureExpectation(result, "not-created");
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "fork-declaration-mismatch": async () => {
+    const context = createRegistry(
+      "fork",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "fork-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      await registerBinding(context, "/srv/upstream");
+      const forkEvidence = evidence("/srv/fork", { providerRepositoryId: "someone/lex-fork" });
+      const result = await resolve(
+        context,
+        request(context, "/srv/fork", forkEvidence, declaration)
+      );
+      assert.equal(
+        (await context.registry.inspectBindings()).some(
+          ({ evidence: stored }) => stored.canonicalRoot === "/srv/fork"
+        ),
+        false
+      );
+      return failureExpectation(result, "not-created");
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "missing-repository-declaration": async () => {
+    const context = createRegistry(
+      "missing-declaration",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "missing-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      const unchanged = await receiptsUnchanged(context.registry, () =>
+        resolve(context, request(context, "/srv/unbound", evidence("/srv/unbound"), undefined))
+      );
+      assert.ok(unchanged.unchanged);
+      assert.equal(unchanged.result.resolved, false);
+      assert.ok(!unchanged.result.resolved);
+      return {
+        result: "fail-closed",
+        errorCode: unchanged.result.error.code,
+        canonicalIdentity: "not-created",
+        localIdentity: "not-created",
+        bindingMutation: "explicit-only",
+        diagnosticChangesOutcome: false,
+      };
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "moved-checkout-explicit-rebind": async () => {
+    const context = createRegistry(
+      "moved",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "moved-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      const receipt = await registerBinding(context, "/srv/lex-old");
+      const before = await resolve(context, request(context, "/srv/lex-old"));
+      assert.ok(before.resolved);
+      const receiptsBefore = (await context.registry.inspectReceipts()).length;
+      const rebind = await context.registry.rebindBinding({
+        bindingId: receipt.bindingId,
+        declaration,
+        evidence: evidence("/srv/lex-moved"),
+        authorityEvidence: {
+          schemaVersion: 1,
+          authoritySource: "authority:test",
+          authorityVersion: "authority-v1" as AuthorityVersion,
+          authorityDigest: "sha256:authority" as ContentDigest,
+          verifiedAt: NOW,
+          expiresAt: CACHE_EXPIRES,
+        },
+        reboundByPrincipalId: PRINCIPAL_ID,
+        reboundAt: "2026-07-18T05:05:00.000Z",
+        reason: "Explicit moved-checkout rebind.",
+      });
+      const after = await resolve(context, request(context, "/srv/lex-moved"));
+      assert.ok(after.resolved);
+      assert.equal(rebind.action, "rebind");
+      assert.equal(before.authorizedScope.tenantId, after.authorizedScope.tenantId);
+      assert.equal(before.authorizedScope.workspaceId, after.authorizedScope.workspaceId);
+      assert.equal(
+        before.invocationContext.binding?.repositoryInstanceId,
+        after.invocationContext.binding?.repositoryInstanceId
+      );
+      return {
+        result: "explicit-rebind",
+        canonicalIdentity: "preserved",
+        localIdentity: "preserved",
+        bindingMutation:
+          (await context.registry.inspectReceipts()).length === receiptsBefore + 1
+            ? "explicit-only"
+            : "none",
+        diagnosticChangesOutcome: false,
+      };
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "multiple-wsl-registries": async () => {
+    const ubuntu = createRegistry(
+      "wsl-ubuntu",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "ubuntu-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    const debian = createRegistry(
+      "wsl-debian",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "debian-installation",
+        wslDistribution: "Debian",
+      })
+    );
+    try {
+      await registerBinding(ubuntu, "/home/guff/src/lex");
+      await registerBinding(debian, "/home/guff/src/lex");
+      const ubuntuResolution = await receiptsUnchanged(ubuntu.registry, () =>
+        resolve(ubuntu, request(ubuntu, "/home/guff/src/lex"))
+      );
+      const debianResolution = await receiptsUnchanged(debian.registry, () =>
+        resolve(debian, request(debian, "/home/guff/src/lex"))
+      );
+      assert.ok(ubuntuResolution.result.resolved);
+      assert.ok(debianResolution.result.resolved);
+      assert.equal(
+        ubuntuResolution.result.authorizedScope.workspaceId,
+        debianResolution.result.authorizedScope.workspaceId
+      );
+      assert.notEqual(ubuntu.registry.registryInstanceId, debian.registry.registryInstanceId);
+      return {
+        result: "resolved",
+        canonicalIdentity: "shared",
+        localIdentity: "distinct",
+        bindingMutation:
+          ubuntuResolution.unchanged && debianResolution.unchanged ? "none" : "explicit-only",
+        diagnosticChangesOutcome: false,
+      };
+    } finally {
+      closeRegistry(ubuntu);
+      closeRegistry(debian);
+    }
+  },
+
+  "same-checkout-cross-surface": async () => {
+    const result = await crossSurfaceResolution();
+    try {
+      assert.ok(result.windowsResult.resolved);
+      assert.ok(result.wslResult.resolved);
+      assert.equal(
+        result.windowsResult.authorizedScope.workspaceId,
+        result.wslResult.authorizedScope.workspaceId
+      );
+      assert.notEqual(result.windows.registryInstanceId, result.wsl.registryInstanceId);
+      return {
+        result: "resolved",
+        canonicalIdentity: "shared",
+        localIdentity: "distinct",
+        bindingMutation: result.resolutionDidNotMutate ? "none" : "explicit-only",
+        diagnosticChangesOutcome: false,
+      };
+    } finally {
+      closeRegistry(result.windows);
+      closeRegistry(result.wsl);
+    }
+  },
+
+  "separate-registry-files": async () => {
+    const result = await crossSurfaceResolution();
+    try {
+      const windowsLocation = resolveLocalRegistryLocation({
+        executionSurface: result.windows.surface,
+        homeDirectory: "C:\\Users\\Guff",
+        localAppDataDirectory: "C:\\Users\\Guff\\AppData\\Local",
+      });
+      const wslLocation = resolveLocalRegistryLocation({
+        executionSurface: result.wsl.surface,
+        homeDirectory: "/home/guff",
+        xdgStateDirectory: "/home/guff/.local/state",
+      });
+      assert.notEqual(windowsLocation.registryPath, wslLocation.registryPath);
+      assert.notEqual(result.windows.databasePath, result.wsl.databasePath);
+      assert.ok(result.windowsResult.resolved);
+      assert.ok(result.wslResult.resolved);
+      return {
+        result: "resolved",
+        canonicalIdentity: "shared",
+        localIdentity: "distinct",
+        bindingMutation: result.resolutionDidNotMutate ? "none" : "explicit-only",
+        diagnosticChangesOutcome: false,
+      };
+    } finally {
+      closeRegistry(result.windows);
+      closeRegistry(result.wsl);
+    }
+  },
+
+  "verified-clone-new-instance": async () => {
+    const context = createRegistry(
+      "clone",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "clone-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      await registerBinding(context, "/srv/lex", "1");
+      const secondReceipt = await registerBinding(context, "/srv/lex-clone", "2");
+      const first = await resolve(context, request(context, "/srv/lex"));
+      const second = await resolve(context, request(context, "/srv/lex-clone"));
+      assert.ok(first.resolved);
+      assert.ok(second.resolved);
+      assert.equal(first.authorizedScope.workspaceId, second.authorizedScope.workspaceId);
+      assert.notEqual(
+        first.invocationContext.binding?.repositoryInstanceId,
+        second.invocationContext.binding?.repositoryInstanceId
+      );
+      assert.equal(
+        (await context.registry.inspectReceipts()).some(
+          ({ receiptId }) => receiptId === secondReceipt.receiptId
+        ),
+        true
+      );
+      return {
+        result: "resolved",
+        canonicalIdentity: "shared",
+        localIdentity: "distinct",
+        bindingMutation: "explicit-only",
+        diagnosticChangesOutcome: false,
+      };
+    } finally {
+      closeRegistry(context);
+    }
+  },
+
+  "windows-process-via-wsl-interop": async () => {
+    const surface = detectExecutionSurface({
+      platform: "win32",
+      installationRef: "windows-interop-installation",
+      wslDistribution: "Ubuntu-24.04",
+      launchOrigin: "wsl-interop",
+    });
+    const location = resolveLocalRegistryLocation({
+      executionSurface: surface,
+      homeDirectory: "C:\\Users\\Guff",
+      localAppDataDirectory: "C:\\Users\\Guff\\AppData\\Local",
+      xdgStateDirectory: "/home/guff/.local/state",
+    });
+    assert.equal(surface.kind, "windows-native");
+    assert.equal(location.source, "windows-local-app-data");
+    return {
+      result: "resolved",
+      selectedRegistryRef: "windows",
+      canonicalIdentity: "preserved",
+      localIdentity: "preserved",
+      bindingMutation: "none",
+      diagnosticChangesOutcome: false,
+    };
+  },
+
+  "worktree-new-instance": async () => {
+    const context = createRegistry(
+      "worktree",
+      detectExecutionSurface({
+        platform: "linux",
+        installationRef: "worktree-installation",
+        wslDistribution: "Ubuntu-24.04",
+      })
+    );
+    try {
+      const sharedGit = "sha256:shared-git-common";
+      await registerBinding(
+        context,
+        "/srv/lex",
+        "1",
+        evidence("/srv/lex", { gitCommonDigest: sharedGit })
+      );
+      await registerBinding(
+        context,
+        "/srv/lex-feature",
+        "2",
+        evidence("/srv/lex-feature", { gitCommonDigest: sharedGit })
+      );
+      const first = await resolve(
+        context,
+        request(context, "/srv/lex", evidence("/srv/lex", { gitCommonDigest: sharedGit }))
+      );
+      const second = await resolve(
+        context,
+        request(
+          context,
+          "/srv/lex-feature",
+          evidence("/srv/lex-feature", { gitCommonDigest: sharedGit })
+        )
+      );
+      assert.ok(first.resolved);
+      assert.ok(second.resolved);
+      assert.equal(first.authorizedScope.workspaceId, second.authorizedScope.workspaceId);
+      assert.notEqual(
+        first.invocationContext.binding?.repositoryInstanceId,
+        second.invocationContext.binding?.repositoryInstanceId
+      );
+      return {
+        result: "resolved",
+        canonicalIdentity: "shared",
+        localIdentity: "distinct",
+        bindingMutation: "explicit-only",
+        diagnosticChangesOutcome: false,
+      };
+    } finally {
+      closeRegistry(context);
+    }
+  },
+};
+
+describe("runtime-scope implementation conformance", () => {
+  for (const fixture of RUNTIME_SCOPE_CONFORMANCE_FIXTURES) {
+    test(fixture.id, async () => {
+      const actual = await handlers[fixture.id]();
+      assert.deepEqual(actual, fixture.expected);
+    });
+  }
+});

--- a/test/shared/runtime-scope/registry.test.ts
+++ b/test/shared/runtime-scope/registry.test.ts
@@ -1,0 +1,415 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+
+import Database from "better-sqlite3-multiple-ciphers";
+
+import {
+  LOCAL_REGISTRY_APPLICATION_ID,
+  LOCAL_REGISTRY_SCHEMA_VERSION,
+  LocalRegistryError,
+  SqliteLocalBindingRegistry,
+  detectExecutionSurface,
+  type AuthorityVersion,
+  type BindingId,
+  type BindingReceiptId,
+  type CachedAuthorityEvidenceV1,
+  type ContentDigest,
+  type ExecutionSurfaceId,
+  type LocalRegistryIdFactoryV1,
+  type PrincipalId,
+  type RegistryInstanceId,
+  type RepositoryDeclarationV1,
+  type RepositoryId,
+  type RepositoryInstanceEvidenceV1,
+  type RepositoryInstanceId,
+  type RepositorySlug,
+  type TenantId,
+  type WorkspaceId,
+  type WorkspaceInstanceId,
+} from "../../../src/shared/runtime-scope/index.js";
+
+const NOW = "2026-07-18T05:00:00.000Z";
+const EXPIRES = "2026-07-18T06:00:00.000Z";
+
+function ids(prefix: string) {
+  return {
+    registryInstanceId: `${prefix}-registry` as RegistryInstanceId,
+    executionSurfaceId: `${prefix}-surface` as ExecutionSurfaceId,
+    tenantId: "tenant-platform" as TenantId,
+    workspaceId: "workspace-lex" as WorkspaceId,
+    repositoryId: "repository-lex" as RepositoryId,
+    workspaceInstanceId: `${prefix}-workspace-instance` as WorkspaceInstanceId,
+    repositoryInstanceId: `${prefix}-repository-instance` as RepositoryInstanceId,
+    principalId: "principal-guff" as PrincipalId,
+  };
+}
+
+function deterministicIds(prefix: string): LocalRegistryIdFactoryV1 {
+  let binding = 0;
+  let receipt = 0;
+  return {
+    bindingId: () => `${prefix}-binding-${++binding}` as BindingId,
+    receiptId: () => `${prefix}-receipt-${++receipt}` as BindingReceiptId,
+  };
+}
+
+function authority(overrides: Partial<CachedAuthorityEvidenceV1> = {}): CachedAuthorityEvidenceV1 {
+  return {
+    schemaVersion: 1,
+    authoritySource: "authority:test",
+    authorityVersion: "authority-v1" as AuthorityVersion,
+    authorityDigest: "sha256:authority" as ContentDigest,
+    verifiedAt: NOW,
+    expiresAt: EXPIRES,
+    ...overrides,
+  };
+}
+
+const declaration: RepositoryDeclarationV1 = {
+  schemaVersion: 1,
+  repositoryId: "repository-lex" as RepositoryId,
+  repositorySlug: "lex" as RepositorySlug,
+};
+
+function evidence(root: string): RepositoryInstanceEvidenceV1 {
+  return {
+    schemaVersion: 1,
+    canonicalRoot: root,
+    manifestDigest: "sha256:manifest" as ContentDigest,
+    gitCommonDirectoryDigest: "sha256:git-common" as ContentDigest,
+    filesystemEvidenceDigest: "sha256:filesystem" as ContentDigest,
+    provider: {
+      provider: "github",
+      providerRepositoryId: "Guffawaffle/lex",
+      remoteDigest: "sha256:remote" as ContentDigest,
+    },
+  };
+}
+
+function registerRequest(prefix: string, root: string) {
+  const identity = ids(prefix);
+  return {
+    tenantId: identity.tenantId,
+    workspaceId: identity.workspaceId,
+    repositoryId: identity.repositoryId,
+    repositoryInstanceId: identity.repositoryInstanceId,
+    workspaceInstanceId: identity.workspaceInstanceId,
+    evidence: evidence(root),
+    authorityEvidence: authority(),
+    registeredByPrincipalId: identity.principalId,
+  };
+}
+
+function withTempRegistry(
+  prefix: string,
+  run: (context: {
+    root: string;
+    databasePath: string;
+    registry: SqliteLocalBindingRegistry;
+    surface: ReturnType<typeof detectExecutionSurface>;
+  }) => Promise<void>
+): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), `lex-local-registry-${prefix}-`));
+  const databasePath = join(root, "registry.db");
+  const identity = ids(prefix);
+  const surface = detectExecutionSurface({
+    platform: "linux",
+    installationRef: `${prefix}-installation`,
+    wslDistribution: "Ubuntu-24.04",
+  });
+  const registry = SqliteLocalBindingRegistry.initialize({
+    databasePath,
+    registryInstanceId: identity.registryInstanceId,
+    executionSurfaceId: identity.executionSurfaceId,
+    executionSurface: surface,
+    createdAt: NOW,
+    now: () => NOW,
+    idFactory: deterministicIds(prefix),
+  });
+
+  return run({ root, databasePath, registry, surface }).finally(() => {
+    try {
+      registry.close();
+    } catch {
+      // A test may close the original handle before reopening it.
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+}
+
+describe("SQLite local binding registry", () => {
+  test("initializes a separate versioned SQLite application and reopens read-only", async () => {
+    await withTempRegistry("schema", async ({ databasePath, registry, surface }) => {
+      assert.deepEqual(await registry.inspectBindings(), []);
+      registry.close();
+
+      const raw = new Database(databasePath, { readonly: true, fileMustExist: true });
+      try {
+        assert.equal(raw.pragma("application_id", { simple: true }), LOCAL_REGISTRY_APPLICATION_ID);
+        assert.equal(raw.pragma("user_version", { simple: true }), LOCAL_REGISTRY_SCHEMA_VERSION);
+        const tables = raw
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+          .all() as Array<{ name: string }>;
+        assert.deepEqual(
+          tables.map(({ name }) => name),
+          [
+            "binding_events",
+            "local_registry_identity",
+            "local_registry_migrations",
+            "repository_bindings",
+          ]
+        );
+      } finally {
+        raw.close();
+      }
+
+      const reopened = SqliteLocalBindingRegistry.open({
+        databasePath,
+        executionSurface: surface,
+      });
+      try {
+        assert.equal(reopened.access, "read-only");
+        assert.deepEqual(await reopened.inspectBindings(), []);
+        await assert.rejects(
+          reopened.registerBinding(registerRequest("schema", "/srv/lex")),
+          (error: unknown) =>
+            error instanceof LocalRegistryError && error.code === "REGISTRY_READ_ONLY"
+        );
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  test("registers, finds, verifies, rebinds, revokes, and audits explicitly", async () => {
+    await withTempRegistry("lifecycle", async ({ registry }) => {
+      const identity = ids("lifecycle");
+      const receipt = await registry.registerBinding(registerRequest("lifecycle", "/srv/lex"));
+      assert.equal(receipt.bindingId, "lifecycle-binding-1");
+      assert.equal("action" in receipt, false);
+
+      const found = await registry.findRepositoryInstances({
+        projectRoot: "/srv/lex",
+        repositoryDeclaration: declaration,
+        evidence: evidence("/srv/lex"),
+      });
+      assert.equal(found.length, 1);
+      assert.equal(found[0]?.repositoryId, identity.repositoryId);
+
+      const verified = await registry.verifyBinding({
+        binding: found[0]!,
+        declaration,
+        evidence: evidence("/srv/lex"),
+        authorityEvidence: authority(),
+        verifiedAt: NOW,
+      });
+      assert.equal(verified.status, "verified");
+      assert.deepEqual(verified.reasons, []);
+
+      const mismatch = await registry.verifyBinding({
+        binding: found[0]!,
+        declaration,
+        evidence: evidence("/srv/other"),
+        authorityEvidence: authority(),
+        verifiedAt: NOW,
+      });
+      assert.equal(mismatch.status, "mismatch");
+      assert.deepEqual(mismatch.reasons, ["canonical-root-mismatch"]);
+
+      const rebind = await registry.rebindBinding({
+        bindingId: receipt.bindingId,
+        declaration,
+        evidence: evidence("/srv/lex-moved"),
+        authorityEvidence: authority(),
+        reboundByPrincipalId: identity.principalId,
+        reboundAt: "2026-07-18T05:05:00.000Z",
+        reason: "Checkout moved by an explicit administrative operation.",
+      });
+      assert.equal(rebind.action, "rebind");
+
+      const rebound = await registry.inspectBindings({ bindingId: receipt.bindingId });
+      assert.equal(rebound[0]?.evidence.canonicalRoot, "/srv/lex-moved");
+      assert.equal(rebound[0]?.repositoryInstanceId, identity.repositoryInstanceId);
+      assert.equal(rebound[0]?.workspaceInstanceId, identity.workspaceInstanceId);
+
+      await registry.revokeBinding({
+        bindingId: receipt.bindingId,
+        revokedByPrincipalId: identity.principalId,
+        revokedAt: "2026-07-18T05:10:00.000Z",
+        reason: "Explicit test revocation.",
+      });
+      assert.equal(
+        (await registry.inspectBindings({ bindingId: receipt.bindingId }))[0]?.state,
+        "revoked"
+      );
+      assert.deepEqual(
+        (await registry.inspectReceipts(receipt.bindingId)).map(({ action }) => action),
+        ["register", "rebind", "revoke"]
+      );
+      assert.deepEqual(
+        await registry.findRepositoryInstances({
+          projectRoot: "/srv/lex-moved",
+          repositoryDeclaration: declaration,
+          evidence: evidence("/srv/lex-moved"),
+        }),
+        []
+      );
+    });
+  });
+
+  test("fails closed for expired and revoked cached authority", async () => {
+    await withTempRegistry("authority", async ({ registry }) => {
+      await assert.rejects(
+        registry.registerBinding({
+          ...registerRequest("authority", "/srv/lex"),
+          authorityEvidence: authority({ expiresAt: NOW }),
+        }),
+        /Cached authority is expired/
+      );
+
+      const receipt = await registry.registerBinding(registerRequest("authority", "/srv/lex"));
+      const [binding] = await registry.inspectBindings({ bindingId: receipt.bindingId });
+      assert.ok(binding);
+
+      assert.equal(
+        (
+          await registry.verifyBinding({
+            binding,
+            declaration,
+            evidence: evidence("/srv/lex"),
+            authorityEvidence: authority({ expiresAt: NOW }),
+            verifiedAt: NOW,
+          })
+        ).status,
+        "authority-expired"
+      );
+      assert.equal(
+        (
+          await registry.verifyBinding({
+            binding,
+            declaration,
+            evidence: evidence("/srv/lex"),
+            authorityEvidence: authority({ revokedAt: NOW }),
+            verifiedAt: NOW,
+          })
+        ).status,
+        "authority-revoked"
+      );
+    });
+  });
+
+  test("does not accept an untrusted declaration as the sole rebind evidence", async () => {
+    await withTempRegistry("weak-rebind", async ({ registry }) => {
+      const identity = ids("weak-rebind");
+      const receipt = await registry.registerBinding({
+        ...registerRequest("weak-rebind", "/srv/lex"),
+        evidence: { schemaVersion: 1, canonicalRoot: "/srv/lex" },
+      });
+
+      await assert.rejects(
+        registry.rebindBinding({
+          bindingId: receipt.bindingId,
+          declaration,
+          evidence: { schemaVersion: 1, canonicalRoot: "/srv/lex-moved" },
+          authorityEvidence: authority(),
+          reboundByPrincipalId: identity.principalId,
+          reboundAt: "2026-07-18T05:05:00.000Z",
+          reason: "Attempted declaration-only rebind.",
+        }),
+        /requires stable provider, Git common-directory, or filesystem evidence/
+      );
+      assert.equal(
+        (await registry.inspectBindings({ bindingId: receipt.bindingId }))[0]?.evidence
+          .canonicalRoot,
+        "/srv/lex"
+      );
+    });
+  });
+
+  test("rejects a copied registry on another surface", async () => {
+    await withTempRegistry("copied", async ({ databasePath, registry }) => {
+      registry.close();
+      const otherSurface = detectExecutionSurface({
+        platform: "linux",
+        installationRef: "debian-installation",
+        wslDistribution: "Debian",
+      });
+
+      assert.throws(
+        () =>
+          SqliteLocalBindingRegistry.open({
+            databasePath,
+            executionSurface: otherSurface,
+          }),
+        (error: unknown) =>
+          error instanceof LocalRegistryError && error.code === "REGISTRY_SURFACE_MISMATCH"
+      );
+    });
+  });
+
+  test("refuses to initialize inside an unrelated SQLite database", () => {
+    const root = mkdtempSync(join(tmpdir(), "lex-local-registry-unrelated-"));
+    const databasePath = join(root, "memory.db");
+    const raw = new Database(databasePath);
+    raw.exec("CREATE TABLE frames (id TEXT PRIMARY KEY)");
+    raw.close();
+    const before = new Database(databasePath, { readonly: true });
+    const applicationIdBefore = before.pragma("application_id", { simple: true });
+    before.close();
+
+    try {
+      const identity = ids("unrelated");
+      assert.throws(
+        () =>
+          SqliteLocalBindingRegistry.initialize({
+            databasePath,
+            registryInstanceId: identity.registryInstanceId,
+            executionSurfaceId: identity.executionSurfaceId,
+            executionSurface: detectExecutionSurface({
+              platform: "linux",
+              installationRef: "unrelated-installation",
+            }),
+            createdAt: NOW,
+          }),
+        (error: unknown) =>
+          error instanceof LocalRegistryError && error.code === "REGISTRY_SCHEMA_INCOMPATIBLE"
+      );
+
+      const after = new Database(databasePath, { readonly: true });
+      try {
+        assert.equal(after.pragma("application_id", { simple: true }), applicationIdBefore);
+        const tables = after
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+          .all() as Array<{ name: string }>;
+        assert.deepEqual(
+          tables.map(({ name }) => name),
+          ["frames"]
+        );
+      } finally {
+        after.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks newer local-registry schemas without migrating them", async () => {
+    await withTempRegistry("newer", async ({ databasePath, registry, surface }) => {
+      registry.close();
+      const raw = new Database(databasePath);
+      raw
+        .prepare("INSERT INTO local_registry_migrations (version, applied_at) VALUES (?, ?)")
+        .run(LOCAL_REGISTRY_SCHEMA_VERSION + 1, NOW);
+      raw.close();
+
+      assert.throws(
+        () => SqliteLocalBindingRegistry.open({ databasePath, executionSurface: surface }),
+        (error: unknown) =>
+          error instanceof LocalRegistryError && error.code === "REGISTRY_SCHEMA_INCOMPATIBLE"
+      );
+    });
+  });
+});

--- a/test/shared/runtime-scope/registry.test.ts
+++ b/test/shared/runtime-scope/registry.test.ts
@@ -329,6 +329,138 @@ describe("SQLite local binding registry", () => {
     });
   });
 
+  test("reopens one Windows registry across native and WSL-interop launches", () => {
+    const root = mkdtempSync(join(tmpdir(), "lex-local-registry-windows-provenance-"));
+    const databasePath = join(root, "registry.db");
+    const identity = ids("windows-provenance");
+    const native = detectExecutionSurface({
+      platform: "win32",
+      installationRef: "windows-installation",
+      launchOrigin: "native-shell",
+    });
+    const interop = detectExecutionSurface({
+      platform: "win32",
+      installationRef: "windows-installation",
+      wslDistribution: "Ubuntu-24.04",
+      launchOrigin: "wsl-interop",
+    });
+
+    const registry = SqliteLocalBindingRegistry.initialize({
+      databasePath,
+      registryInstanceId: identity.registryInstanceId,
+      executionSurfaceId: identity.executionSurfaceId,
+      executionSurface: native,
+      createdAt: NOW,
+    });
+    registry.close();
+    const reopened = SqliteLocalBindingRegistry.open({
+      databasePath,
+      executionSurface: interop,
+    });
+    reopened.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("rejects future contract versions instead of reconstructing them as v1", async () => {
+    await withTempRegistry("future-version", async ({ registry }) => {
+      const futureEvidence = {
+        ...evidence("/srv/lex"),
+        schemaVersion: 2,
+      } as unknown as RepositoryInstanceEvidenceV1;
+      const futureDeclaration = {
+        ...declaration,
+        schemaVersion: 2,
+      } as unknown as RepositoryDeclarationV1;
+
+      await assert.rejects(
+        registry.registerBinding({
+          ...registerRequest("future-version", "/srv/lex"),
+          evidence: futureEvidence,
+        }),
+        (error: unknown) =>
+          error instanceof LocalRegistryError && error.code === "REGISTRY_INVALID_INPUT"
+      );
+      await assert.rejects(
+        registry.findRepositoryInstances({
+          projectRoot: "/srv/lex",
+          repositoryDeclaration: futureDeclaration,
+          evidence: evidence("/srv/lex"),
+        }),
+        /repository declaration schema 2 is not supported/
+      );
+    });
+  });
+
+  test("requires projectRoot to belong to the repository evidence", async () => {
+    await withTempRegistry("root-membership", async ({ registry }) => {
+      await registry.registerBinding(registerRequest("root-membership", "/srv/lex"));
+
+      await assert.rejects(
+        registry.findRepositoryInstances({
+          projectRoot: "/srv/unrelated",
+          repositoryDeclaration: declaration,
+          evidence: evidence("/srv/lex"),
+        }),
+        /projectRoot must identify the repository root or a path nested with it/
+      );
+      assert.equal(
+        (
+          await registry.findRepositoryInstances({
+            projectRoot: "/srv/lex/packages/runtime-scope",
+            repositoryDeclaration: declaration,
+            evidence: evidence("/srv/lex"),
+          })
+        ).length,
+        1
+      );
+    });
+  });
+
+  test("serializes lifecycle decisions across administrative handles", async () => {
+    await withTempRegistry("lifecycle-race", async ({ databasePath, registry, surface }) => {
+      const identity = ids("lifecycle-race");
+      const receipt = await registry.registerBinding(registerRequest("lifecycle-race", "/srv/lex"));
+      const second = SqliteLocalBindingRegistry.open({
+        databasePath,
+        executionSurface: surface,
+        access: "administrative",
+        idFactory: deterministicIds("second-handle"),
+      });
+      try {
+        await registry.revokeBinding({
+          bindingId: receipt.bindingId,
+          revokedByPrincipalId: identity.principalId,
+          revokedAt: "2026-07-18T05:10:00.000Z",
+          reason: "First handle won the lifecycle decision.",
+        });
+        await assert.rejects(
+          second.rebindBinding({
+            bindingId: receipt.bindingId,
+            declaration,
+            evidence: evidence("/srv/lex-moved"),
+            authorityEvidence: authority(),
+            reboundByPrincipalId: identity.principalId,
+            reboundAt: "2026-07-18T05:11:00.000Z",
+            reason: "A stale second handle must not emit a receipt.",
+          }),
+          /revoked binding cannot be rebound/
+        );
+        await second.revokeBinding({
+          bindingId: receipt.bindingId,
+          revokedByPrincipalId: identity.principalId,
+          revokedAt: "2026-07-18T05:12:00.000Z",
+          reason: "Idempotent stale revocation.",
+        });
+        assert.deepEqual(
+          (await registry.inspectReceipts(receipt.bindingId)).map(({ action }) => action),
+          ["register", "revoke"]
+        );
+      } finally {
+        second.close();
+      }
+    });
+  });
+
   test("rejects a copied registry on another surface", async () => {
     await withTempRegistry("copied", async ({ databasePath, registry }) => {
       registry.close();

--- a/test/shared/runtime-scope/resolver.test.ts
+++ b/test/shared/runtime-scope/resolver.test.ts
@@ -72,7 +72,11 @@ function evidence(root = "/srv/lex"): RepositoryInstanceEvidenceV1 {
 }
 
 function authoritySeed(
-  options: { revoked?: boolean; expiresAt?: string } = {}
+  options: {
+    revoked?: boolean;
+    expiresAt?: string;
+    capabilities?: readonly CapabilityId[];
+  } = {}
 ): InMemoryAuthoritySeedV1 {
   return {
     principals: [
@@ -120,7 +124,7 @@ function authoritySeed(
           tenantId: TENANT_ID,
           workspaceId: WORKSPACE_ID,
           principalId: PRINCIPAL_ID,
-          capabilities: [CAPABILITY],
+          capabilities: options.capabilities ?? [CAPABILITY],
           authorityVersion: "authority-v1" as AuthorityVersion,
           scopeVersion: "scope-v1" as ScopeVersion,
           authorityDigest: "sha256:authority" as ContentDigest,
@@ -295,6 +299,63 @@ describe("deterministic runtime-scope resolver", () => {
     });
   });
 
+  test("clones and deeply freezes nested repository declarations", async () => {
+    await withResolver("mutable-declaration", async ({ registry, authority, request }) => {
+      const preferredWorkspace = {
+        tenantSlug: TENANT_SLUG,
+        workspaceSlug: WORKSPACE_SLUG,
+      };
+      const mutableDeclaration = { ...declaration, preferredWorkspace };
+      const result = await resolveRuntimeScope(
+        { ...request, repositoryDeclaration: mutableDeclaration },
+        { authorityDirectory: authority, localRegistry: registry }
+      );
+
+      assert.equal(result.resolved, true);
+      if (!result.resolved || !result.invocationContext.repositoryDeclaration) return;
+      const resolvedDeclaration = result.invocationContext.repositoryDeclaration;
+      assert.notEqual(resolvedDeclaration, mutableDeclaration);
+      assert.notEqual(resolvedDeclaration.preferredWorkspace, preferredWorkspace);
+      assert.equal(Object.isFrozen(resolvedDeclaration), true);
+      assert.equal(Object.isFrozen(resolvedDeclaration.preferredWorkspace), true);
+      assert.equal(
+        Reflect.set(resolvedDeclaration.preferredWorkspace!, "workspaceSlug", "tampered"),
+        false
+      );
+
+      Reflect.set(preferredWorkspace, "workspaceSlug", "tampered");
+      assert.equal(resolvedDeclaration.preferredWorkspace?.workspaceSlug, WORKSPACE_SLUG);
+    });
+  });
+
+  test("attenuates AuthorizedScope to the explicitly requested capabilities", async () => {
+    const write = "frame:write" as CapabilityId;
+    const diagnostics = "diagnostics:full" as CapabilityId;
+    await withResolver(
+      "capability-attenuation",
+      async ({ registry, authority, request }) => {
+        const readOnly = await resolveRuntimeScope(request, {
+          authorityDirectory: authority,
+          localRegistry: registry,
+        });
+        assert.equal(readOnly.resolved, true);
+        if (readOnly.resolved) {
+          assert.deepEqual(readOnly.authorizedScope.capabilities, [CAPABILITY]);
+        }
+
+        const noCapabilities = await resolveRuntimeScope(
+          { ...request, requestedCapabilities: [] },
+          { authorityDirectory: authority, localRegistry: registry }
+        );
+        assert.equal(noCapabilities.resolved, true);
+        if (noCapabilities.resolved) {
+          assert.deepEqual(noCapabilities.authorizedScope.capabilities, []);
+        }
+      },
+      { authority: authoritySeed({ capabilities: [CAPABILITY, write, diagnostics] }) }
+    );
+  });
+
   test("resolves an existing verified binding when no declaration is present", async () => {
     await withResolver("no-declaration-existing", async ({ registry, authority, request }) => {
       const { repositoryDeclaration: _omitted, ...withoutDeclaration } = request;
@@ -353,6 +414,92 @@ describe("deterministic runtime-scope resolver", () => {
           result.error.code,
           WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH
         );
+      }
+    });
+  });
+
+  test("fails closed when projectRoot is unrelated to repository evidence", async () => {
+    await withResolver("unrelated-root", async ({ registry, authority, request }) => {
+      const result = await resolveRuntimeScope(
+        { ...request, projectRoot: "/srv/another-repository" },
+        { authorityDirectory: authority, localRegistry: registry }
+      );
+      assert.equal(result.resolved, false);
+      if (!result.resolved) {
+        assert.equal(
+          result.error.code,
+          WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH
+        );
+      }
+    });
+  });
+
+  test("rejects an injected binding outside the active project root", async () => {
+    await withResolver("injected-unrelated-root", async ({ registry, authority, request }) => {
+      const [storedBinding] = await registry.inspectBindings();
+      assert.ok(storedBinding);
+      const unrelatedBinding = {
+        ...storedBinding,
+        evidence: { ...storedBinding.evidence, canonicalRoot: "/srv/another-repository" },
+      };
+      const permissiveRegistry = new Proxy(registry, {
+        get(target, property) {
+          if (property === "findRepositoryInstances") return async () => [unrelatedBinding];
+          if (property === "verifyBinding") {
+            return async () => ({
+              schemaVersion: 1 as const,
+              status: "verified" as const,
+              bindingId: unrelatedBinding.bindingId,
+              evidenceDigest: "sha256:unrelated" as ContentDigest,
+              verifiedAt: NOW,
+              reasons: [],
+            });
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const result = await resolveRuntimeScope(request, {
+        authorityDirectory: authority,
+        localRegistry: permissiveRegistry,
+      });
+      assert.equal(result.resolved, false);
+      if (!result.resolved) {
+        assert.equal(
+          result.error.code,
+          WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH
+        );
+      }
+    });
+  });
+
+  test("fails closed on unsupported versions at resolver boundaries", async () => {
+    await withResolver("future-version", async ({ registry, authority, request }) => {
+      const futureEvidence = {
+        ...request.repositoryEvidence,
+        schemaVersion: 2,
+      } as unknown as RepositoryInstanceEvidenceV1;
+      const futureRuntimeSurface = {
+        ...request.runtimeSurface,
+        schemaVersion: 2,
+      } as unknown as RuntimeScopeResolutionRequestV1["runtimeSurface"];
+
+      for (const futureRequest of [
+        { ...request, repositoryEvidence: futureEvidence },
+        { ...request, runtimeSurface: futureRuntimeSurface },
+      ]) {
+        const result = await resolveRuntimeScope(futureRequest, {
+          authorityDirectory: authority,
+          localRegistry: registry,
+        });
+        assert.equal(result.resolved, false);
+        if (!result.resolved) {
+          assert.equal(
+            result.error.code,
+            WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH
+          );
+        }
       }
     });
   });

--- a/test/shared/runtime-scope/resolver.test.ts
+++ b/test/shared/runtime-scope/resolver.test.ts
@@ -245,6 +245,56 @@ describe("deterministic runtime-scope resolver", () => {
     });
   });
 
+  test("clones and deeply freezes a binding returned by an injected registry", async () => {
+    await withResolver("mutable-binding", async ({ registry, authority, request }) => {
+      const [storedBinding] = await registry.inspectBindings();
+      assert.ok(storedBinding);
+      const mutableBinding = {
+        ...storedBinding,
+        evidence: {
+          ...storedBinding.evidence,
+          provider: storedBinding.evidence.provider
+            ? { ...storedBinding.evidence.provider }
+            : undefined,
+        },
+        cachedAuthority: storedBinding.cachedAuthority
+          ? { ...storedBinding.cachedAuthority }
+          : undefined,
+      };
+      const mutableRegistry = new Proxy(registry, {
+        get(target, property) {
+          if (property === "findRepositoryInstances") return async () => [mutableBinding];
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const result = await resolveRuntimeScope(request, {
+        authorityDirectory: authority,
+        localRegistry: mutableRegistry,
+      });
+      assert.equal(result.resolved, true);
+      if (!result.resolved || !result.invocationContext.binding) return;
+
+      const resolvedBinding = result.invocationContext.binding;
+      assert.notEqual(resolvedBinding, mutableBinding);
+      assert.notEqual(resolvedBinding.evidence, mutableBinding.evidence);
+      assert.notEqual(resolvedBinding.evidence.provider, mutableBinding.evidence.provider);
+      assert.notEqual(resolvedBinding.cachedAuthority, mutableBinding.cachedAuthority);
+      assert.equal(Object.isFrozen(resolvedBinding), true);
+      assert.equal(Object.isFrozen(resolvedBinding.evidence), true);
+      assert.equal(Object.isFrozen(resolvedBinding.evidence.provider), true);
+      assert.equal(Object.isFrozen(resolvedBinding.cachedAuthority), true);
+      assert.equal(Reflect.set(resolvedBinding, "state", "revoked"), false);
+      assert.equal(Reflect.set(resolvedBinding.evidence, "canonicalRoot", "/srv/tampered"), false);
+
+      Reflect.set(mutableBinding, "state", "revoked");
+      Reflect.set(mutableBinding.evidence, "canonicalRoot", "/srv/tampered");
+      assert.equal(resolvedBinding.state, "active");
+      assert.equal(resolvedBinding.evidence.canonicalRoot, "/srv/lex");
+    });
+  });
+
   test("resolves an existing verified binding when no declaration is present", async () => {
     await withResolver("no-declaration-existing", async ({ registry, authority, request }) => {
       const { repositoryDeclaration: _omitted, ...withoutDeclaration } = request;

--- a/test/shared/runtime-scope/resolver.test.ts
+++ b/test/shared/runtime-scope/resolver.test.ts
@@ -1,0 +1,443 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+
+import {
+  InMemoryAuthorityDirectory,
+  SqliteLocalBindingRegistry,
+  WORKSPACE_AUTHORITY_ERROR_CODES,
+  detectExecutionSurface,
+  resolveRuntimeScope,
+  type AuthenticationRef,
+  type AuthorityGrantId,
+  type AuthorityVersion,
+  type BindingId,
+  type BindingReceiptId,
+  type CapabilityId,
+  type ContentDigest,
+  type ExecutionSurfaceId,
+  type InMemoryAuthoritySeedV1,
+  type LocalRegistryIdFactoryV1,
+  type PrincipalId,
+  type RegistryInstanceId,
+  type RepositoryDeclarationV1,
+  type RepositoryId,
+  type RepositoryInstanceEvidenceV1,
+  type RepositoryInstanceId,
+  type RepositorySlug,
+  type RuntimeId,
+  type RuntimeScopeResolutionRequestV1,
+  type ScopeVersion,
+  type TenantId,
+  type TenantSlug,
+  type WorkspaceId,
+  type WorkspaceInstanceId,
+  type WorkspaceSlug,
+} from "../../../src/shared/runtime-scope/index.js";
+
+const NOW = "2026-07-18T05:00:00.000Z";
+const CACHE_EXPIRES = "2026-07-18T05:30:00.000Z";
+const GRANT_EXPIRES = "2026-07-18T06:00:00.000Z";
+const AUTHENTICATION_REF = "auth:guff" as AuthenticationRef;
+const PRINCIPAL_ID = "principal-guff" as PrincipalId;
+const TENANT_ID = "tenant-platform" as TenantId;
+const TENANT_SLUG = "platform-dogfood" as TenantSlug;
+const WORKSPACE_ID = "workspace-lex" as WorkspaceId;
+const WORKSPACE_SLUG = "lex" as WorkspaceSlug;
+const REPOSITORY_ID = "repository-lex" as RepositoryId;
+const REPOSITORY_SLUG = "lex" as RepositorySlug;
+const CAPABILITY = "frame:read" as CapabilityId;
+
+const declaration: RepositoryDeclarationV1 = {
+  schemaVersion: 1,
+  repositoryId: REPOSITORY_ID,
+  repositorySlug: REPOSITORY_SLUG,
+};
+
+function evidence(root = "/srv/lex"): RepositoryInstanceEvidenceV1 {
+  return {
+    schemaVersion: 1,
+    canonicalRoot: root,
+    manifestDigest: "sha256:manifest" as ContentDigest,
+    gitCommonDirectoryDigest: "sha256:git-common" as ContentDigest,
+    filesystemEvidenceDigest: "sha256:filesystem" as ContentDigest,
+    provider: {
+      provider: "github",
+      providerRepositoryId: "Guffawaffle/lex",
+      remoteDigest: "sha256:remote" as ContentDigest,
+    },
+  };
+}
+
+function authoritySeed(
+  options: { revoked?: boolean; expiresAt?: string } = {}
+): InMemoryAuthoritySeedV1 {
+  return {
+    principals: [
+      {
+        schemaVersion: 1,
+        principalId: PRINCIPAL_ID,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    tenants: [
+      {
+        schemaVersion: 1,
+        tenantId: TENANT_ID,
+        tenantSlug: TENANT_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    workspaces: [
+      {
+        schemaVersion: 1,
+        workspaceId: WORKSPACE_ID,
+        tenantId: TENANT_ID,
+        workspaceSlug: WORKSPACE_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    repositories: [
+      {
+        schemaVersion: 1,
+        repositoryId: REPOSITORY_ID,
+        repositorySlug: REPOSITORY_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    authentication: [{ authenticationRef: AUTHENTICATION_REF, principalId: PRINCIPAL_ID }],
+    grants: [
+      {
+        grant: {
+          schemaVersion: 1,
+          grantId: "grant-lex" as AuthorityGrantId,
+          tenantId: TENANT_ID,
+          workspaceId: WORKSPACE_ID,
+          principalId: PRINCIPAL_ID,
+          capabilities: [CAPABILITY],
+          authorityVersion: "authority-v1" as AuthorityVersion,
+          scopeVersion: "scope-v1" as ScopeVersion,
+          authorityDigest: "sha256:authority" as ContentDigest,
+          verifiedAt: NOW,
+          expiresAt: options.expiresAt ?? GRANT_EXPIRES,
+        },
+        ...(options.revoked ? { revokedAt: NOW } : {}),
+      },
+    ],
+  };
+}
+
+function deterministicIds(prefix: string): LocalRegistryIdFactoryV1 {
+  let binding = 0;
+  let receipt = 0;
+  return {
+    bindingId: () => `${prefix}-binding-${++binding}` as BindingId,
+    receiptId: () => `${prefix}-receipt-${++receipt}` as BindingReceiptId,
+  };
+}
+
+async function withResolver(
+  prefix: string,
+  run: (context: {
+    registry: SqliteLocalBindingRegistry;
+    authority: InMemoryAuthorityDirectory;
+    request: RuntimeScopeResolutionRequestV1;
+  }) => Promise<void>,
+  options: { register?: boolean; authority?: InMemoryAuthoritySeedV1 } = {}
+): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), `lex-runtime-resolver-${prefix}-`));
+  const databasePath = join(root, "registry.db");
+  const surface = detectExecutionSurface({
+    platform: "linux",
+    installationRef: `${prefix}-installation`,
+    wslDistribution: "Ubuntu-24.04",
+  });
+  const registryInstanceId = `${prefix}-registry` as RegistryInstanceId;
+  const executionSurfaceId = `${prefix}-surface` as ExecutionSurfaceId;
+  const registry = SqliteLocalBindingRegistry.initialize({
+    databasePath,
+    registryInstanceId,
+    executionSurfaceId,
+    executionSurface: surface,
+    createdAt: NOW,
+    now: () => NOW,
+    idFactory: deterministicIds(prefix),
+  });
+  const authority = new InMemoryAuthorityDirectory(options.authority ?? authoritySeed(), () => NOW);
+  if (options.register !== false) {
+    await registry.registerBinding({
+      tenantId: TENANT_ID,
+      workspaceId: WORKSPACE_ID,
+      repositoryId: REPOSITORY_ID,
+      repositoryInstanceId: `${prefix}-repository-instance-1` as RepositoryInstanceId,
+      workspaceInstanceId: `${prefix}-workspace-instance-1` as WorkspaceInstanceId,
+      evidence: evidence(),
+      authorityEvidence: {
+        schemaVersion: 1,
+        authoritySource: "authority:test",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+        authorityDigest: "sha256:authority" as ContentDigest,
+        verifiedAt: NOW,
+        expiresAt: CACHE_EXPIRES,
+      },
+      registeredByPrincipalId: PRINCIPAL_ID,
+    });
+  }
+  const request: RuntimeScopeResolutionRequestV1 = {
+    schemaVersion: 1,
+    bootstrap: {
+      schemaVersion: 1,
+      cwd: "/srv/lex",
+      argv: ["lex", "recall"],
+      allowedEnvironment: {},
+      platform: "linux",
+      executionSurface: surface,
+      capturedAt: NOW,
+    },
+    projectRoot: "/srv/lex",
+    authenticationRef: AUTHENTICATION_REF,
+    requestedWorkspace: { workspaceId: WORKSPACE_ID },
+    requestedCapabilities: [CAPABILITY],
+    repositoryDeclaration: declaration,
+    repositoryEvidence: evidence(),
+    runtimeSurface: {
+      schemaVersion: 1,
+      registryInstanceId,
+      executionSurfaceId,
+      runtimeId: `${prefix}-runtime` as RuntimeId,
+    },
+    authoritySource: "authority:test",
+    authorityCacheExpiresAt: CACHE_EXPIRES,
+  };
+
+  try {
+    await run({ registry, authority, request });
+  } finally {
+    registry.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("deterministic runtime-scope resolver", () => {
+  test("resolves one immutable authorized scope without returning diagnostic metadata", async () => {
+    await withResolver("success", async ({ registry, authority, request }) => {
+      const result = await resolveRuntimeScope(request, {
+        authorityDirectory: authority,
+        localRegistry: registry,
+      });
+
+      assert.equal(result.resolved, true);
+      if (!result.resolved) return;
+      assert.equal(result.authorizedScope.tenantId, TENANT_ID);
+      assert.equal(result.authorizedScope.workspaceId, WORKSPACE_ID);
+      assert.equal(result.invocationContext.binding?.repositoryId, REPOSITORY_ID);
+      assert.equal("diagnostics" in result, false);
+      assert.equal(Object.isFrozen(result), true);
+      assert.equal(Object.isFrozen(result.authorizedScope), true);
+      assert.equal(Object.isFrozen(result.authorizedScope.capabilities), true);
+      assert.equal(Object.isFrozen(result.invocationContext), true);
+    });
+  });
+
+  test("resolves an existing verified binding when no declaration is present", async () => {
+    await withResolver("no-declaration-existing", async ({ registry, authority, request }) => {
+      const { repositoryDeclaration: _omitted, ...withoutDeclaration } = request;
+      const result = await resolveRuntimeScope(withoutDeclaration, {
+        authorityDirectory: authority,
+        localRegistry: registry,
+      });
+
+      assert.equal(result.resolved, true);
+      if (result.resolved) {
+        assert.equal(result.invocationContext.repositoryDeclaration, undefined);
+      }
+    });
+  });
+
+  test("leaves a repository with no declaration and no binding explicitly unbound", async () => {
+    await withResolver(
+      "no-declaration-unbound",
+      async ({ registry, authority, request }) => {
+        const { repositoryDeclaration: _omitted, ...withoutDeclaration } = request;
+        const result = await resolveRuntimeScope(withoutDeclaration, {
+          authorityDirectory: authority,
+          localRegistry: registry,
+        });
+        assert.deepEqual(result, {
+          resolved: false,
+          error: {
+            code: WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND,
+            message: "No trusted local workspace binding matched this invocation.",
+          },
+        });
+      },
+      { register: false }
+    );
+  });
+
+  test("fails closed on conflicting repository evidence", async () => {
+    await withResolver("mismatch", async ({ registry, authority, request }) => {
+      const result = await resolveRuntimeScope(
+        {
+          ...request,
+          repositoryEvidence: {
+            ...evidence(),
+            provider: {
+              provider: "github",
+              providerRepositoryId: "someone/fork",
+              remoteDigest: "sha256:fork" as ContentDigest,
+            },
+          },
+        },
+        { authorityDirectory: authority, localRegistry: registry }
+      );
+      assert.equal(result.resolved, false);
+      if (!result.resolved) {
+        assert.equal(
+          result.error.code,
+          WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH
+        );
+      }
+    });
+  });
+
+  test("returns a stable ambiguity error when two verified bindings match", async () => {
+    await withResolver("ambiguous", async ({ registry, authority, request }) => {
+      await registry.registerBinding({
+        tenantId: TENANT_ID,
+        workspaceId: WORKSPACE_ID,
+        repositoryId: REPOSITORY_ID,
+        repositoryInstanceId: "ambiguous-repository-instance-2" as RepositoryInstanceId,
+        workspaceInstanceId: "ambiguous-workspace-instance-2" as WorkspaceInstanceId,
+        evidence: evidence(),
+        authorityEvidence: {
+          schemaVersion: 1,
+          authoritySource: "authority:test",
+          authorityVersion: "authority-v1" as AuthorityVersion,
+          authorityDigest: "sha256:authority" as ContentDigest,
+          verifiedAt: NOW,
+          expiresAt: CACHE_EXPIRES,
+        },
+        registeredByPrincipalId: PRINCIPAL_ID,
+      });
+
+      const result = await resolveRuntimeScope(request, {
+        authorityDirectory: authority,
+        localRegistry: registry,
+      });
+      assert.equal(result.resolved, false);
+      if (!result.resolved) {
+        assert.equal(
+          result.error.code,
+          WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_BINDING_AMBIGUOUS
+        );
+      }
+    });
+  });
+
+  test("maps canonical revocation and expiry to stable fail-closed errors", async () => {
+    for (const scenario of [
+      {
+        name: "revoked",
+        seed: authoritySeed({ revoked: true }),
+        code: WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_GRANT_REVOKED,
+      },
+      {
+        name: "expired",
+        seed: authoritySeed({ expiresAt: NOW }),
+        code: WORKSPACE_AUTHORITY_ERROR_CODES.AUTHORITY_CACHE_EXPIRED,
+      },
+    ] as const) {
+      await withResolver(
+        scenario.name,
+        async ({ registry, authority, request }) => {
+          const result = await resolveRuntimeScope(request, {
+            authorityDirectory: authority,
+            localRegistry: registry,
+          });
+          assert.equal(result.resolved, false);
+          if (!result.resolved) assert.equal(result.error.code, scenario.code);
+        },
+        { authority: scenario.seed }
+      );
+    }
+  });
+
+  test("rejects runtime-surface identity substitution before local lookup", async () => {
+    await withResolver("surface-mismatch", async ({ registry, authority, request }) => {
+      const result = await resolveRuntimeScope(
+        {
+          ...request,
+          runtimeSurface: {
+            ...request.runtimeSurface,
+            registryInstanceId: "copied-registry" as RegistryInstanceId,
+          },
+        },
+        { authorityDirectory: authority, localRegistry: registry }
+      );
+      assert.equal(result.resolved, false);
+      if (!result.resolved) {
+        assert.equal(
+          result.error.code,
+          WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH
+        );
+      }
+    });
+  });
+
+  test("maps dependency exceptions to stable compact failures", async () => {
+    await withResolver("dependency-failure", async ({ registry, authority, request }) => {
+      const throwingAuthority = new Proxy(authority, {
+        get(target, property) {
+          if (property === "resolvePrincipal") {
+            return async () => {
+              throw new Error("credential provider details must stay private");
+            };
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+      const authorityFailure = await resolveRuntimeScope(request, {
+        authorityDirectory: throwingAuthority,
+        localRegistry: registry,
+      });
+      assert.deepEqual(authorityFailure, {
+        resolved: false,
+        error: {
+          code: WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_SELECTOR_UNAUTHORIZED,
+          message: "Canonical authority did not authorize the requested workspace selector.",
+        },
+      });
+
+      const throwingRegistry = new Proxy(registry, {
+        get(target, property) {
+          if (property === "findRepositoryInstances") {
+            return async () => {
+              throw new Error("database path must stay private");
+            };
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+      const registryFailure = await resolveRuntimeScope(request, {
+        authorityDirectory: authority,
+        localRegistry: throwingRegistry,
+      });
+      assert.deepEqual(registryFailure, {
+        resolved: false,
+        error: {
+          code: WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH,
+          message: "Repository identity evidence did not match the trusted local binding.",
+        },
+      });
+    });
+  });
+});

--- a/test/shared/runtime-scope/surface.test.ts
+++ b/test/shared/runtime-scope/surface.test.ts
@@ -22,7 +22,6 @@ describe("runtime-scope execution surfaces", () => {
 
     const location = resolveLocalRegistryLocation({
       executionSurface: surface,
-      homeDirectory: "C:\\Users\\Guff",
       localAppDataDirectory: "C:\\Users\\Guff\\AppData\\Local",
       xdgStateDirectory: "/tmp/must-not-win",
     });
@@ -61,6 +60,23 @@ describe("runtime-scope execution surfaces", () => {
     assert.equal(ubuntuLocation.registryPath, "/home/guff/.local/state/lex/registry.db");
     assert.equal(debianLocation.registryPath, "/home/guff/.debian/state/lex/registry.db");
     assert.notEqual(ubuntuLocation.registryPath, debianLocation.registryPath);
+  });
+
+  test("keeps Windows launch provenance out of persistent surface identity", () => {
+    const native = detectExecutionSurface({
+      platform: "win32",
+      installationRef: "windows-installation",
+      launchOrigin: "native-shell",
+    });
+    const interop = detectExecutionSurface({
+      platform: "win32",
+      installationRef: "windows-installation",
+      wslDistribution: "Ubuntu-24.04",
+      launchOrigin: "wsl-interop",
+    });
+
+    assert.equal(native.evidenceDigest, interop.evidenceDigest);
+    assert.notEqual(native.launchOrigin, interop.launchOrigin);
   });
 
   test("uses deterministic Linux and macOS fallbacks from explicit home directories", () => {
@@ -116,6 +132,51 @@ describe("runtime-scope execution surfaces", () => {
           homeDirectory: "C:\\Users\\Guff",
         }),
       /localAppDataDirectory/
+    );
+  });
+
+  test("rejects relative and cross-surface registry locations", () => {
+    const windows = detectExecutionSurface({
+      platform: "win32",
+      installationRef: "windows-installation",
+    });
+    const wsl = detectExecutionSurface({
+      platform: "linux",
+      installationRef: "wsl-installation",
+      wslDistribution: "Ubuntu-24.04",
+    });
+
+    assert.throws(
+      () =>
+        resolveLocalRegistryLocation({
+          executionSurface: windows,
+          localAppDataDirectory: "AppData\\Local",
+        }),
+      /absolute win32 path/
+    );
+    assert.throws(
+      () =>
+        resolveLocalRegistryLocation({
+          executionSurface: windows,
+          localAppDataDirectory: "\\\\wsl$\\Ubuntu-24.04\\home\\guff",
+        }),
+      /inside the Windows filesystem/
+    );
+    assert.throws(
+      () =>
+        resolveLocalRegistryLocation({
+          executionSurface: wsl,
+          xdgStateDirectory: "state",
+        }),
+      /absolute linux path/
+    );
+    assert.throws(
+      () =>
+        resolveLocalRegistryLocation({
+          executionSurface: wsl,
+          xdgStateDirectory: "/mnt/c/Users/Guff/AppData/Local/Lex",
+        }),
+      /inside the WSL filesystem/
     );
   });
 });

--- a/test/shared/runtime-scope/surface.test.ts
+++ b/test/shared/runtime-scope/surface.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  detectExecutionSurface,
+  resolveLocalRegistryLocation,
+} from "../../../src/shared/runtime-scope/index.js";
+
+describe("runtime-scope execution surfaces", () => {
+  test("classifies native Windows launched through WSL interop as Windows", () => {
+    const surface = detectExecutionSurface({
+      platform: "win32",
+      installationRef: "windows-installation",
+      wslDistribution: "Ubuntu-24.04",
+      launchOrigin: "wsl-interop",
+    });
+
+    assert.equal(surface.nativePlatform, "win32");
+    assert.equal(surface.kind, "windows-native");
+    assert.equal(surface.launchOrigin, "wsl-interop");
+    assert.equal(surface.wslDistribution, "Ubuntu-24.04");
+
+    const location = resolveLocalRegistryLocation({
+      executionSurface: surface,
+      homeDirectory: "C:\\Users\\Guff",
+      localAppDataDirectory: "C:\\Users\\Guff\\AppData\\Local",
+      xdgStateDirectory: "/tmp/must-not-win",
+    });
+
+    assert.equal(location.source, "windows-local-app-data");
+    assert.equal(location.registryPath, "C:\\Users\\Guff\\AppData\\Local\\Lex\\registry.db");
+  });
+
+  test("classifies WSL distributions and keeps their injected state roots separate", () => {
+    const ubuntu = detectExecutionSurface({
+      platform: "linux",
+      installationRef: "wsl-ubuntu-installation",
+      wslDistribution: "Ubuntu-24.04",
+    });
+    const debian = detectExecutionSurface({
+      platform: "linux",
+      installationRef: "wsl-debian-installation",
+      wslDistribution: "Debian",
+    });
+
+    assert.equal(ubuntu.kind, "wsl");
+    assert.equal(debian.kind, "wsl");
+    assert.notEqual(ubuntu.evidenceDigest, debian.evidenceDigest);
+
+    const ubuntuLocation = resolveLocalRegistryLocation({
+      executionSurface: ubuntu,
+      homeDirectory: "/home/guff",
+      xdgStateDirectory: "/home/guff/.local/state",
+    });
+    const debianLocation = resolveLocalRegistryLocation({
+      executionSurface: debian,
+      homeDirectory: "/home/guff",
+      xdgStateDirectory: "/home/guff/.debian/state",
+    });
+
+    assert.equal(ubuntuLocation.registryPath, "/home/guff/.local/state/lex/registry.db");
+    assert.equal(debianLocation.registryPath, "/home/guff/.debian/state/lex/registry.db");
+    assert.notEqual(ubuntuLocation.registryPath, debianLocation.registryPath);
+  });
+
+  test("uses deterministic Linux and macOS fallbacks from explicit home directories", () => {
+    const linux = detectExecutionSurface({
+      platform: "linux",
+      installationRef: "linux-installation",
+    });
+    const macos = detectExecutionSurface({
+      platform: "darwin",
+      installationRef: "macos-installation",
+    });
+
+    assert.deepEqual(
+      resolveLocalRegistryLocation({
+        executionSurface: linux,
+        homeDirectory: "/home/guff",
+      }),
+      {
+        schemaVersion: 1,
+        registryPath: "/home/guff/.local/state/lex/registry.db",
+        source: "linux-home-fallback",
+      }
+    );
+    assert.deepEqual(
+      resolveLocalRegistryLocation({
+        executionSurface: macos,
+        homeDirectory: "/Users/guff",
+      }),
+      {
+        schemaVersion: 1,
+        registryPath: "/Users/guff/Library/Application Support/Lex/registry.db",
+        source: "macos-application-support",
+      }
+    );
+  });
+
+  test("surface evidence is deterministic and rejects missing captured paths", () => {
+    const input = {
+      platform: "linux" as const,
+      installationRef: "stable-installation",
+      wslDistribution: "Ubuntu-24.04",
+      launchOrigin: "native-shell" as const,
+    };
+
+    assert.deepEqual(detectExecutionSurface(input), detectExecutionSurface(input));
+    assert.throws(
+      () =>
+        resolveLocalRegistryLocation({
+          executionSurface: detectExecutionSurface({
+            platform: "win32",
+            installationRef: "windows-installation",
+          }),
+          homeDirectory: "C:\\Users\\Guff",
+        }),
+      /localAppDataDirectory/
+    );
+  });
+});

--- a/test/sql-safety.test.ts
+++ b/test/sql-safety.test.ts
@@ -15,6 +15,7 @@
  * - src/memory/mcp_server/auth/state-storage.ts (OAuth state)
  * - src/memory/mcp_server/routes/*.ts (MCP route handlers)
  * - src/shared/cli/db.ts (CLI database utilities)
+ * - src/shared/runtime-scope/registry-queries.ts (local binding registry)
  *
  * @see .github/copilot-instructions.md for SQL safety rules
  */
@@ -38,6 +39,7 @@ const ALLOWED_PATTERNS = [
   "memory/mcp_server/auth/state-storage.ts",
   "memory/mcp_server/routes/",
   "shared/cli/db.ts",
+  "shared/runtime-scope/registry-queries.ts",
 ];
 
 describe("SQL Safety", () => {
@@ -107,10 +109,10 @@ describe("SQL Safety", () => {
     let grepOutput: string;
     try {
       // Look for .prepare(`...${...}...`) pattern - dynamic SQL
-      grepOutput = execSync(
-        'grep -rn "\\.prepare(\\`[^\\`]*\\${" src/memory/store/ --include="*.ts" || true',
-        { cwd: repoRoot, encoding: "utf8" }
-      );
+      grepOutput = execSync('grep -rn "\\.prepare(\\`[^\\`]*\\${" src/ --include="*.ts" || true', {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
     } catch {
       return; // grep error, skip
     }


### PR DESCRIPTION
Closes #755
Parent epic: #749
Developer-tooling follow-up: #756

## What changed

- add deterministic native Windows, WSL, Linux, and macOS execution-surface detection from captured inputs;
- resolve standard surface-local registry locations without deep ambient reads;
- add a separate, application-identified, versioned SQLite local binding registry;
- provide explicit registration, inspection, verification, rebinding, revocation, and auditable receipts;
- add a pure fail-closed runtime-scope resolver over injected authority and registry contracts;
- add a deterministic in-memory authority implementation for tests and embedding;
- execute every exported Phase 1 conformance fixture through the concrete Phase 2 implementation;
- document the Phase 2 implementation boundary and expand packed-consumer coverage.

## Trust and compatibility boundaries

- canonical authority remains separate from surface-local topology and cached evidence;
- normal resolution is read-only and never creates, repairs, or rebinds state;
- repository declarations remain optional untrusted claims;
- copied registries, expired authority, revoked grants, ambiguity, and conflicting evidence fail closed;
- Windows and each WSL distribution retain separate mutable registries and local identities;
- core resolver and registry code do not reread `process.env`, `cwd`, or platform globals;
- normal results remain compact and contain no diagnostic or topology envelope;
- registry-returned bindings are cloned and deeply frozen at the resolver boundary;
- existing CLI, MCP, Frame, and FrameStore behavior is unchanged.

## Validation

- `LEX_STORE=sqlite npm run ci`
- 46 runtime-scope contract and implementation tests
- all 15 exported implementation-conformance fixtures
- `npm run validate-docs`
- `npm run check:release-drift`
- `LEX_STORE=sqlite npm run test:smoke`
- `npm run guard:pack`
- changed-file Prettier and `git diff --check`

The optional repository-wide Prettier audit still identifies seven untouched files inherited from `main`. Those are intentionally outside this Phase 2 diff; opt-in developer-validation behavior is tracked in #756.
