### PR TITLE
Update ts-morph to 28 without narrowing Node support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "prettier": "^3.7.1",
         "rimraf": "^6.0.0",
         "supertest": "^7.1.4",
-        "ts-morph": "^27.0.2",
+        "ts-morph": "^28.0.0",
         "tsx": "^4.20.6"
       },
       "engines": {
@@ -2620,9 +2620,9 @@
       }
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
-      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.29.0.tgz",
+      "integrity": "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8660,13 +8660,13 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
-      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-28.0.0.tgz",
+      "integrity": "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ts-morph/common": "~0.28.1",
+        "@ts-morph/common": "~0.29.0",
         "code-block-writer": "^13.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
     "prettier": "^3.7.1",
     "rimraf": "^6.0.0",
     "supertest": "^7.1.4",
-    "ts-morph": "^27.0.2",
+    "ts-morph": "^28.0.0",
     "tsx": "^4.20.6"
   },
   "lint-staged": {


### PR DESCRIPTION
## What changed

- update `ts-morph` from `^27.0.2` to `^28.0.0`;
- refresh the npm lockfile, resolving `@ts-morph/common@0.29.0`;
- retain Lex's published Node `>=20 <25` engine contract.

This is the independently executable dependency-baseline slice of #763 and supersedes the compatible change in #743 once merged.

## Compatibility decision

The other queued majors are intentionally not included:

- #744 and #746 require Node 22.12 or newer;
- #745 requires Node 20.19+, Node 22.13+, or Node 24+;
- #747 remains blocked on TypeScript 7 peer-ecosystem support.

Accepting those changes here would silently narrow the Node versions Lex currently promises. They should be handled together through an explicit future Node-floor decision.

## Validation

- `npm ci` and audit: 0 vulnerabilities
- lint and type-check
- full build and default test suite
- integration tests
- schema, docs, and prompt validation
- release drift and changeset status
- pack guard and packed-consumer smoke
- independent coordinator `npm run ci` rerun with SQLite selected

The one lint warning in `runtime-scope/surface.ts` is unchanged from `main`.

## Agent-work evidence

Prepared and executed through a fenced LexRunner Attempt. The worker had edit-only authority; commit, push, and PR delivery remained coordinator-owned. LexRunner receipt `receipt-attempt-763-baseline-a1` binds the worker claim to patch hash `sha256:e1cf44ef6788ab6e8184a7d8315c870c34792ba180fce8d9a5113dcba5f843ed`.