### PR TITLE
Add the Lex 3.0 scoped FrameStore contract

### DIFF
--- a/.changeset/scoped-frame-store-contract.md
+++ b/.changeset/scoped-frame-store-contract.md
@@ -1,0 +1,8 @@
+---
+"@smartergpt/lex": major
+---
+
+Introduce the Lex 3.0 `ScopedFrameStore` and separately authorized `FrameStoreAdmin` contracts,
+including stable read, write, delete, and admin capabilities. Add an in-memory reference backend
+that binds immutable `AuthorizedScope` snapshots, stamps tenant/workspace ownership and creator
+attribution internally, and proves normal operations cannot cross their bound workspace.

--- a/src/memory/store/CONTRACT.md
+++ b/src/memory/store/CONTRACT.md
@@ -6,6 +6,48 @@
 
 This document defines the persistence contract for Frames. All implementations of `FrameStore` must conform to this specification.
 
+## Lex 3.0 Scope-Bound Contract
+
+The v1 contract below describes the legacy physical-adapter surface. Lex 3.0
+introduces `ScopedFrameStore` as the only normal CLI, MCP, and SDK boundary:
+
+```typescript
+const store = backend.bind(authorizedScope);
+await store.saveFrame(frame);
+const visible = await store.listFrames();
+```
+
+`AuthorizedScope` is required at binding time and is copied into an immutable
+view. Normal methods have no tenant, workspace, or principal selector. The
+backend stamps `(tenant_id, workspace_id)` ownership and creator attribution
+from the trusted scope, while ordinary Frame results omit that authority
+metadata. Repository identity remains provenance rather than an ownership
+partition.
+
+The scoped contract checks these named capabilities at operation boundaries:
+
+| Capability | Operations |
+|---|---|
+| `frame:read` | get, recall/search, list/export, count, statistics, and turn-cost metrics |
+| `frame:write` | create, batch create, and update |
+| `frame:delete` | single and bulk deletion, including superseded cleanup |
+| `frame:admin` | the separately typed `FrameStoreAdmin` boundary |
+
+Administrative inspection, migration, repair, and lifecycle operations must
+remain absent from `ScopedFrameStore`. They cannot be reached with a special
+normal selector or type cast.
+
+`MemoryScopedFrameStoreBackend` is the reference implementation for these
+semantics. Its conformance tests establish that equivalent Frame IDs in
+different tenant/workspace partitions do not collide, caller-provided legacy
+`userId` values cannot override creator attribution, and empty or narrow
+capability requests never expand.
+
+The exported unscoped `FrameStore` and physical adapters coexist temporarily so
+the trusted bootstrap, SQLite ownership migration, and PostgreSQL RLS work can
+land independently. This compatibility seam is not the Lex 3.0 normal API and
+must be removed from normal construction/wiring before issue #759 is complete.
+
 ---
 
 ## Schema Version

--- a/src/memory/store/README.md
+++ b/src/memory/store/README.md
@@ -21,7 +21,8 @@ This module is part of the Lex single package. It's not installed separately.
 
 ### Basic CRUD Operations
 
-New CLI and MCP code should use the shared asynchronous `FrameStore` factory:
+The existing CLI and MCP currently use the shared asynchronous `FrameStore`
+factory as a transitional 2.x compatibility path:
 
 ```typescript
 import { createFrameStore } from "../../memory/store/index.js";
@@ -31,6 +32,24 @@ await store.saveFrame(frame);
 const saved = await store.getFrameById(frame.id);
 await store.close();
 ```
+
+Lex 3.0 normal consumers must instead receive a `ScopedFrameStore` created from
+an immutable `AuthorizedScope`. The additive in-memory reference backend shows
+the binding contract while physical SQLite and PostgreSQL adapters are migrated:
+
+```typescript
+import { MemoryScopedFrameStoreBackend } from "@smartergpt/lex/store";
+
+const backend = new MemoryScopedFrameStoreBackend();
+const scopedStore = backend.bind(authorizedScope);
+await scopedStore.saveFrame(frame);
+```
+
+Normal scoped operations cannot accept tenant, workspace, or principal filters.
+Migration, repair, and lifecycle work belongs to the separately authorized
+`FrameStoreAdmin` boundary. Trusted CLI/MCP bootstrap replaces the transitional
+factory wiring; normal code must not bind itself from environment variables or
+`process.cwd()`.
 
 `LEX_STORE` defaults to `sqlite`. When it is `postgres`, `LEX_DATABASE_URL` is required and `LEX_DB_PATH` is not consulted. PostgreSQL images are intentionally unsupported until image persistence no longer requires a raw SQLite connection.
 

--- a/src/memory/store/index.ts
+++ b/src/memory/store/index.ts
@@ -30,6 +30,25 @@ export type {
   FrameStoreMetadata,
   FrameStoreHealth,
 } from "./frame-store.js";
+export {
+  FRAME_STORE_SCOPE_CONTRACT_VERSION,
+  FRAME_STORE_CAPABILITIES,
+  SCOPED_FRAME_STORE_ERROR_CODES,
+  ScopedFrameStoreError,
+} from "./scoped-frame-store.js";
+export type {
+  FrameStoreCapability,
+  FrameOwnershipV1,
+  ScopedFrameInput,
+  ScopedFrameUpdate,
+  ScopedFrameSearchCriteria,
+  ScopedFrameListOptions,
+  ScopedFrameStore,
+  ScopedFrameStoreBinder,
+  FrameStoreAdmin,
+  FrameStoreAdminBinder,
+  ScopedFrameStoreErrorCode,
+} from "./scoped-frame-store.js";
 export type { CodeAtlasStore } from "./code-atlas-store.js";
 
 // SqliteFrameStore - production-ready FrameStore implementation
@@ -45,7 +64,8 @@ export {
 export type { PostgresFrameStoreAccessMode, PostgresFrameStoreOptions } from "./postgres/index.js";
 
 // Memory-based store implementations for testing
-export { MemoryFrameStore } from "./memory/index.js";
+export { MemoryFrameStore, MemoryScopedFrameStoreBackend } from "./memory/index.js";
+export type { MemoryScopedFrameStoreOptions } from "./memory/index.js";
 
 // Import FrameStore interface and SqliteFrameStore for factory function
 import type { FrameStore } from "./frame-store.js";

--- a/src/memory/store/memory/index.ts
+++ b/src/memory/store/memory/index.ts
@@ -5,3 +5,8 @@
  */
 
 export { MemoryFrameStore } from "./frame-store.js";
+
+// Lex 3.0 scope-bound reference backend. The legacy MemoryFrameStore export
+// remains temporarily available until trusted CLI/MCP bootstrap is integrated.
+export { MemoryScopedFrameStoreBackend } from "./scoped-frame-store.js";
+export type { MemoryScopedFrameStoreOptions } from "./scoped-frame-store.js";

--- a/src/memory/store/memory/scoped-frame-store.ts
+++ b/src/memory/store/memory/scoped-frame-store.ts
@@ -1,0 +1,453 @@
+/** In-memory reference implementation of Lex 3.0 scope-bound Frame storage. */
+
+import type { Frame } from "../../frames/types.js";
+import { Frame as FrameSchema } from "../../frames/types.js";
+import type { AuthorizedScopeV1, CapabilityId } from "../../../shared/runtime-scope/index.js";
+import { RUNTIME_SCOPE_CONTRACT_VERSION } from "../../../shared/runtime-scope/index.js";
+import type {
+  FrameListResult,
+  FrameStoreHealth,
+  FrameStoreMetadata,
+  SaveResult,
+  StoreStats,
+  TurnCostMetrics,
+} from "../frame-store.js";
+import {
+  FRAME_STORE_CAPABILITIES,
+  FRAME_STORE_SCOPE_CONTRACT_VERSION,
+  SCOPED_FRAME_STORE_ERROR_CODES,
+  ScopedFrameStoreError,
+  type FrameOwnershipV1,
+  type FrameStoreAdmin,
+  type FrameStoreAdminBinder,
+  type FrameStoreCapability,
+  type ScopedFrameInput,
+  type ScopedFrameListOptions,
+  type ScopedFrameSearchCriteria,
+  type ScopedFrameStore,
+  type ScopedFrameStoreBinder,
+  type ScopedFrameUpdate,
+} from "../scoped-frame-store.js";
+import { MemoryFrameStore } from "./frame-store.js";
+
+interface ScopePartition {
+  readonly store: MemoryFrameStore;
+  readonly ownershipByFrameId: Map<string, FrameOwnershipV1>;
+}
+
+export interface MemoryScopedFrameStoreOptions {
+  /** Explicit clock seam for deterministic expiry and statistics tests. */
+  readonly now?: () => Date;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function immutableScope(scope: AuthorizedScopeV1): AuthorizedScopeV1 {
+  if (
+    !scope ||
+    scope.schemaVersion !== RUNTIME_SCOPE_CONTRACT_VERSION ||
+    !isNonEmptyString(scope.grantId) ||
+    !isNonEmptyString(scope.tenantId) ||
+    !isNonEmptyString(scope.workspaceId) ||
+    !isNonEmptyString(scope.principalId) ||
+    !Array.isArray(scope.capabilities) ||
+    !scope.capabilities.every(isNonEmptyString) ||
+    !isNonEmptyString(scope.authorityVersion) ||
+    !isNonEmptyString(scope.scopeVersion) ||
+    !isNonEmptyString(scope.authorityDigest) ||
+    !isNonEmptyString(scope.verifiedAt) ||
+    (scope.expiresAt !== undefined && !isNonEmptyString(scope.expiresAt)) ||
+    Number.isNaN(Date.parse(scope.verifiedAt)) ||
+    (scope.expiresAt !== undefined && Number.isNaN(Date.parse(scope.expiresAt)))
+  ) {
+    throw new ScopedFrameStoreError(
+      SCOPED_FRAME_STORE_ERROR_CODES.INVALID_SCOPE,
+      "FrameStore binding requires a valid AuthorizedScope v1"
+    );
+  }
+
+  const snapshot: AuthorizedScopeV1 = {
+    schemaVersion: RUNTIME_SCOPE_CONTRACT_VERSION,
+    grantId: scope.grantId,
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    principalId: scope.principalId,
+    capabilities: Object.freeze([...scope.capabilities] as CapabilityId[]),
+    authorityVersion: scope.authorityVersion,
+    scopeVersion: scope.scopeVersion,
+    authorityDigest: scope.authorityDigest,
+    verifiedAt: scope.verifiedAt,
+    ...(scope.expiresAt === undefined ? {} : { expiresAt: scope.expiresAt }),
+  };
+  return Object.freeze(snapshot);
+}
+
+function scopePartitionKey(scope: AuthorizedScopeV1): string {
+  return JSON.stringify([scope.tenantId, scope.workspaceId]);
+}
+
+function stripLegacyOwnership(frame: Frame): Frame {
+  const copy = structuredClone(frame);
+  delete copy.userId;
+  return copy;
+}
+
+function parseScopedInput(frame: ScopedFrameInput): ReturnType<typeof FrameSchema.safeParse> {
+  return FrameSchema.safeParse(stripLegacyOwnership(frame as Frame));
+}
+
+function publicFrame(frame: Frame): Frame {
+  return stripLegacyOwnership(frame);
+}
+
+function ownershipFromScope(scope: AuthorizedScopeV1): FrameOwnershipV1 {
+  return Object.freeze({
+    schemaVersion: FRAME_STORE_SCOPE_CONTRACT_VERSION,
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+    creatorPrincipalId: scope.principalId,
+    scopeVersion: scope.scopeVersion,
+  });
+}
+
+abstract class MemoryBoundView {
+  private closed = false;
+
+  protected constructor(
+    readonly authorizedScope: AuthorizedScopeV1,
+    protected readonly partition: ScopePartition,
+    private readonly backendIsClosed: () => boolean,
+    private readonly now: () => Date
+  ) {}
+
+  protected assertActive(): void {
+    if (this.closed || this.backendIsClosed()) {
+      throw new ScopedFrameStoreError(
+        SCOPED_FRAME_STORE_ERROR_CODES.STORE_CLOSED,
+        "Scope-bound FrameStore is closed"
+      );
+    }
+    const expiresAt = this.authorizedScope.expiresAt;
+    if (expiresAt !== undefined && Date.parse(expiresAt) <= this.now().getTime()) {
+      throw new ScopedFrameStoreError(
+        SCOPED_FRAME_STORE_ERROR_CODES.SCOPE_EXPIRED,
+        "Authorized FrameStore scope has expired"
+      );
+    }
+  }
+
+  protected assertCapability(capability: FrameStoreCapability): void {
+    this.assertActive();
+    if (!this.authorizedScope.capabilities.includes(capability as CapabilityId)) {
+      throw new ScopedFrameStoreError(
+        SCOPED_FRAME_STORE_ERROR_CODES.CAPABILITY_MISSING,
+        `FrameStore operation requires ${capability}`,
+        capability
+      );
+    }
+  }
+
+  protected metadata(): FrameStoreMetadata {
+    this.assertActive();
+    return {
+      backend: "memory",
+      location: "memory-scoped-store",
+      canonicalLocation: "memory-scoped-store",
+      identity: "memory-scoped-v1:ephemeral",
+      capabilities: { encryption: false, images: false },
+    };
+  }
+
+  protected async health(): Promise<FrameStoreHealth> {
+    this.assertActive();
+    return {
+      healthy: true,
+      schemaVersion: "memory-scoped-v1",
+      checkedAt: this.now().toISOString(),
+    };
+  }
+
+  protected closeView(): void {
+    this.closed = true;
+  }
+}
+
+class ScopedMemoryFrameStore extends MemoryBoundView implements ScopedFrameStore {
+  constructor(
+    authorizedScope: AuthorizedScopeV1,
+    partition: ScopePartition,
+    backendIsClosed: () => boolean,
+    now: () => Date
+  ) {
+    super(authorizedScope, partition, backendIsClosed, now);
+  }
+
+  getMetadata(): FrameStoreMetadata {
+    return this.metadata();
+  }
+
+  async getHealth(): Promise<FrameStoreHealth> {
+    return this.health();
+  }
+
+  async saveFrame(frame: ScopedFrameInput): Promise<void> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.WRITE);
+    const result = parseScopedInput(frame);
+    if (!result.success) throw result.error;
+
+    await this.partition.store.saveFrame(result.data);
+    if (!this.partition.ownershipByFrameId.has(result.data.id)) {
+      this.partition.ownershipByFrameId.set(
+        result.data.id,
+        ownershipFromScope(this.authorizedScope)
+      );
+    }
+  }
+
+  async saveFrames(frames: readonly ScopedFrameInput[]): Promise<SaveResult[]> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.WRITE);
+    const parsed = frames.map(parseScopedInput);
+    const invalidIndex = parsed.findIndex((result) => !result.success);
+    if (invalidIndex !== -1) {
+      const invalid = parsed[invalidIndex];
+      return frames.map((frame, index) => ({
+        id: frame.id ?? `frame-${index}`,
+        success: false,
+        error:
+          index === invalidIndex && !invalid.success
+            ? `Validation failed: ${invalid.error.message}`
+            : "Transaction aborted due to validation failure in another frame",
+      }));
+    }
+
+    const validFrames = parsed.map((result) => {
+      if (!result.success) throw new Error("Unreachable scoped Frame validation state");
+      return result.data;
+    });
+    const results = await this.partition.store.saveFrames(validFrames);
+    for (const [index, result] of results.entries()) {
+      if (result.success && !this.partition.ownershipByFrameId.has(result.id)) {
+        this.partition.ownershipByFrameId.set(
+          validFrames[index].id,
+          ownershipFromScope(this.authorizedScope)
+        );
+      }
+    }
+    return results;
+  }
+
+  async getFrameById(id: string): Promise<Frame | null> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.READ);
+    const frame = await this.partition.store.getFrameById(id);
+    return frame ? publicFrame(frame) : null;
+  }
+
+  async searchFrames(criteria: ScopedFrameSearchCriteria): Promise<Frame[]> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.READ);
+    const { userId: _discardedUserId, ...safeCriteria } = criteria as ScopedFrameSearchCriteria & {
+      userId?: unknown;
+    };
+    const frames = await this.partition.store.searchFrames(safeCriteria);
+    return frames.map(publicFrame);
+  }
+
+  async listFrames(options?: ScopedFrameListOptions): Promise<FrameListResult> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.READ);
+    const { userId: _discardedUserId, ...safeOptions } = (options ??
+      {}) as ScopedFrameListOptions & {
+      userId?: unknown;
+    };
+    const result = await this.partition.store.listFrames(safeOptions);
+    return { ...result, frames: result.frames.map(publicFrame) };
+  }
+
+  async deleteFrame(id: string): Promise<boolean> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.DELETE);
+    const deleted = await this.partition.store.deleteFrame(id);
+    if (deleted) this.partition.ownershipByFrameId.delete(id);
+    return deleted;
+  }
+
+  async deleteFramesBefore(date: Date): Promise<number> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.DELETE);
+    const matchingIds = (await this.allFrames())
+      .filter((frame) => new Date(frame.timestamp).getTime() < date.getTime())
+      .map((frame) => frame.id);
+    const deleted = await this.partition.store.deleteFramesBefore(date);
+    this.deleteOwnership(matchingIds);
+    return deleted;
+  }
+
+  async deleteFramesByBranch(branch: string): Promise<number> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.DELETE);
+    const matchingIds = (await this.allFrames())
+      .filter((frame) => frame.branch === branch)
+      .map((frame) => frame.id);
+    const deleted = await this.partition.store.deleteFramesByBranch(branch);
+    this.deleteOwnership(matchingIds);
+    return deleted;
+  }
+
+  async deleteFramesByModule(moduleId: string): Promise<number> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.DELETE);
+    const matchingIds = (await this.allFrames())
+      .filter((frame) => frame.module_scope.includes(moduleId))
+      .map((frame) => frame.id);
+    const deleted = await this.partition.store.deleteFramesByModule(moduleId);
+    this.deleteOwnership(matchingIds);
+    return deleted;
+  }
+
+  async getFrameCount(): Promise<number> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.READ);
+    return this.partition.store.getFrameCount();
+  }
+
+  async getStats(detailed = false): Promise<StoreStats> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.READ);
+    return this.partition.store.getStats(detailed);
+  }
+
+  async getTurnCostMetrics(since?: string): Promise<TurnCostMetrics> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.READ);
+    return this.partition.store.getTurnCostMetrics(since);
+  }
+
+  async updateFrame(id: string, updates: ScopedFrameUpdate): Promise<boolean> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.WRITE);
+    const { userId: _discardedUserId, ...safeUpdates } = updates as ScopedFrameUpdate & {
+      userId?: unknown;
+    };
+    return this.partition.store.updateFrame(id, safeUpdates);
+  }
+
+  async purgeSuperseded(): Promise<number> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.DELETE);
+    const matchingIds = (await this.allFrames())
+      .filter((frame) => Boolean(frame.superseded_by))
+      .map((frame) => frame.id);
+    const deleted = await this.partition.store.purgeSuperseded();
+    this.deleteOwnership(matchingIds);
+    return deleted;
+  }
+
+  async close(): Promise<void> {
+    this.closeView();
+  }
+
+  private async allFrames(): Promise<Frame[]> {
+    const result = await this.partition.store.listFrames({ limit: Number.MAX_SAFE_INTEGER });
+    return result.frames;
+  }
+
+  private deleteOwnership(ids: readonly string[]): void {
+    for (const id of ids) this.partition.ownershipByFrameId.delete(id);
+  }
+}
+
+class MemoryFrameStoreAdminView extends MemoryBoundView implements FrameStoreAdmin {
+  constructor(
+    authorizedScope: AuthorizedScopeV1,
+    partition: ScopePartition,
+    backendIsClosed: () => boolean,
+    now: () => Date
+  ) {
+    super(authorizedScope, partition, backendIsClosed, now);
+  }
+
+  getMetadata(): FrameStoreMetadata {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.ADMIN);
+    return this.metadata();
+  }
+
+  async getHealth(): Promise<FrameStoreHealth> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.ADMIN);
+    return this.health();
+  }
+
+  async getFrameOwnership(id: string): Promise<FrameOwnershipV1 | null> {
+    this.assertCapability(FRAME_STORE_CAPABILITIES.ADMIN);
+    const ownership = this.partition.ownershipByFrameId.get(id);
+    return ownership ? Object.freeze({ ...ownership }) : null;
+  }
+
+  async close(): Promise<void> {
+    this.closeView();
+  }
+}
+
+/**
+ * Shared in-memory backend used to exercise scope isolation before physical
+ * SQLite and PostgreSQL adapters adopt the same binding contract.
+ */
+export class MemoryScopedFrameStoreBackend
+  implements ScopedFrameStoreBinder, FrameStoreAdminBinder
+{
+  private readonly partitions = new Map<string, ScopePartition>();
+  private readonly now: () => Date;
+  private closed = false;
+
+  constructor(options: MemoryScopedFrameStoreOptions = {}) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  bind(authorizedScope: AuthorizedScopeV1): ScopedFrameStore {
+    const scope = this.bindScope(authorizedScope);
+    return new ScopedMemoryFrameStore(scope, this.partitionFor(scope), () => this.closed, this.now);
+  }
+
+  bindAdmin(authorizedScope: AuthorizedScopeV1): FrameStoreAdmin {
+    const scope = this.bindScope(authorizedScope);
+    if (!scope.capabilities.includes(FRAME_STORE_CAPABILITIES.ADMIN)) {
+      throw new ScopedFrameStoreError(
+        SCOPED_FRAME_STORE_ERROR_CODES.CAPABILITY_MISSING,
+        `FrameStore operation requires ${FRAME_STORE_CAPABILITIES.ADMIN}`,
+        FRAME_STORE_CAPABILITIES.ADMIN
+      );
+    }
+    return new MemoryFrameStoreAdminView(
+      scope,
+      this.partitionFor(scope),
+      () => this.closed,
+      this.now
+    );
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    await Promise.all([...this.partitions.values()].map(({ store }) => store.close()));
+  }
+
+  private bindScope(authorizedScope: AuthorizedScopeV1): AuthorizedScopeV1 {
+    if (this.closed) {
+      throw new ScopedFrameStoreError(
+        SCOPED_FRAME_STORE_ERROR_CODES.STORE_CLOSED,
+        "Scope-bound FrameStore backend is closed"
+      );
+    }
+    const scope = immutableScope(authorizedScope);
+    if (scope.expiresAt !== undefined && Date.parse(scope.expiresAt) <= this.now().getTime()) {
+      throw new ScopedFrameStoreError(
+        SCOPED_FRAME_STORE_ERROR_CODES.SCOPE_EXPIRED,
+        "Authorized FrameStore scope has expired"
+      );
+    }
+    return scope;
+  }
+
+  private partitionFor(scope: AuthorizedScopeV1): ScopePartition {
+    const key = scopePartitionKey(scope);
+    let partition = this.partitions.get(key);
+    if (!partition) {
+      partition = {
+        store: new MemoryFrameStore(),
+        ownershipByFrameId: new Map(),
+      };
+      this.partitions.set(key, partition);
+    }
+    return partition;
+  }
+}

--- a/src/memory/store/scoped-frame-store.ts
+++ b/src/memory/store/scoped-frame-store.ts
@@ -1,0 +1,137 @@
+/**
+ * Scope-bound persistence contract for Lex 3.0 Frame operations.
+ *
+ * Normal consumers receive this interface only after trusted bootstrap has
+ * resolved an immutable, attenuated AuthorizedScope. Physical adapters and
+ * administrative operations remain behind separately named boundaries.
+ */
+
+import type { Frame } from "../frames/types.js";
+import type {
+  FrameListOptions,
+  FrameListResult,
+  FrameSearchCriteria,
+  FrameStoreHealth,
+  FrameStoreMetadata,
+  SaveResult,
+  StoreStats,
+  TurnCostMetrics,
+} from "./frame-store.js";
+import type {
+  AuthorizedScopeV1,
+  CapabilityId,
+  PrincipalId,
+  ScopeVersion,
+  TenantId,
+  WorkspaceId,
+} from "../../shared/runtime-scope/index.js";
+
+export const FRAME_STORE_SCOPE_CONTRACT_VERSION = 1 as const;
+
+/** Stable capability names checked by scope-bound FrameStore operations. */
+export const FRAME_STORE_CAPABILITIES = Object.freeze({
+  READ: "frame:read" as CapabilityId,
+  WRITE: "frame:write" as CapabilityId,
+  DELETE: "frame:delete" as CapabilityId,
+  ADMIN: "frame:admin" as CapabilityId,
+});
+
+export type FrameStoreCapability =
+  (typeof FRAME_STORE_CAPABILITIES)[keyof typeof FRAME_STORE_CAPABILITIES];
+
+/** Ownership persisted beside a Frame and omitted from normal Frame results. */
+export interface FrameOwnershipV1 {
+  readonly schemaVersion: typeof FRAME_STORE_SCOPE_CONTRACT_VERSION;
+  readonly tenantId: TenantId;
+  readonly workspaceId: WorkspaceId;
+  readonly creatorPrincipalId: PrincipalId;
+  readonly scopeVersion: ScopeVersion;
+}
+
+/**
+ * Normal writes cannot provide an ownership identity. Runtime implementations
+ * also discard legacy `userId` values before validation and storage.
+ */
+export type ScopedFrameInput = Omit<Frame, "userId">;
+
+/** Normal updates cannot replace immutable identity, time, or ownership. */
+export type ScopedFrameUpdate = Partial<Omit<Frame, "id" | "timestamp" | "userId">>;
+
+/** Workspace/principal filters are invalid after a store has been scope-bound. */
+export type ScopedFrameSearchCriteria = Omit<FrameSearchCriteria, "userId">;
+
+/** Workspace/principal filters are invalid after a store has been scope-bound. */
+export type ScopedFrameListOptions = Omit<FrameListOptions, "userId">;
+
+export const SCOPED_FRAME_STORE_ERROR_CODES = Object.freeze({
+  INVALID_SCOPE: "LEX_FRAME_STORE_INVALID_SCOPE",
+  CAPABILITY_MISSING: "LEX_FRAME_STORE_CAPABILITY_MISSING",
+  SCOPE_EXPIRED: "LEX_FRAME_STORE_SCOPE_EXPIRED",
+  STORE_CLOSED: "LEX_FRAME_STORE_CLOSED",
+});
+
+export type ScopedFrameStoreErrorCode =
+  (typeof SCOPED_FRAME_STORE_ERROR_CODES)[keyof typeof SCOPED_FRAME_STORE_ERROR_CODES];
+
+/** Stable, compact authorization failures for adapters to map at entrypoints. */
+export class ScopedFrameStoreError extends Error {
+  constructor(
+    public readonly code: ScopedFrameStoreErrorCode,
+    message: string,
+    public readonly requiredCapability?: FrameStoreCapability
+  ) {
+    super(message);
+    this.name = "ScopedFrameStoreError";
+  }
+}
+
+/**
+ * The only FrameStore surface intended for normal CLI, MCP, and SDK use in
+ * Lex 3.0. No method accepts a tenant, workspace, or principal selector.
+ */
+export interface ScopedFrameStore {
+  /** Immutable snapshot of the exact attenuated scope used for this view. */
+  readonly authorizedScope: AuthorizedScopeV1;
+
+  getMetadata(): FrameStoreMetadata;
+  getHealth(): Promise<FrameStoreHealth>;
+  saveFrame(frame: ScopedFrameInput): Promise<void>;
+  saveFrames(frames: readonly ScopedFrameInput[]): Promise<SaveResult[]>;
+  getFrameById(id: string): Promise<Frame | null>;
+  searchFrames(criteria: ScopedFrameSearchCriteria): Promise<Frame[]>;
+  listFrames(options?: ScopedFrameListOptions): Promise<FrameListResult>;
+  deleteFrame(id: string): Promise<boolean>;
+  deleteFramesBefore(date: Date): Promise<number>;
+  deleteFramesByBranch(branch: string): Promise<number>;
+  deleteFramesByModule(moduleId: string): Promise<number>;
+  getFrameCount(): Promise<number>;
+  getStats(detailed?: boolean): Promise<StoreStats>;
+  getTurnCostMetrics(since?: string): Promise<TurnCostMetrics>;
+  updateFrame(id: string, updates: ScopedFrameUpdate): Promise<boolean>;
+  purgeSuperseded(): Promise<number>;
+  close(): Promise<void>;
+}
+
+/** Authority-binding boundary implemented by each physical FrameStore. */
+export interface ScopedFrameStoreBinder {
+  bind(authorizedScope: AuthorizedScopeV1): ScopedFrameStore;
+}
+
+/**
+ * Administrative diagnostics are deliberately absent from ScopedFrameStore.
+ * Migration, repair, and lifecycle implementations can extend this separately
+ * authorized interface without special selectors on the normal store.
+ */
+export interface FrameStoreAdmin {
+  readonly authorizedScope: AuthorizedScopeV1;
+
+  getMetadata(): FrameStoreMetadata;
+  getHealth(): Promise<FrameStoreHealth>;
+  getFrameOwnership(id: string): Promise<FrameOwnershipV1 | null>;
+  close(): Promise<void>;
+}
+
+/** Separate binding boundary for explicitly authorized administration. */
+export interface FrameStoreAdminBinder {
+  bindAdmin(authorizedScope: AuthorizedScopeV1): FrameStoreAdmin;
+}

--- a/src/memory/store/tsconfig.json
+++ b/src/memory/store/tsconfig.json
@@ -13,6 +13,7 @@
   "references": [
     { "path": "../../shared/logger" },
     { "path": "../../shared/config" },
+    { "path": "../../shared/runtime-scope" },
     { "path": "../../atlas/schemas" },
     { "path": "../receipts" },
     { "path": "../validation" }

--- a/test/memory/store/scoped-frame-store.test.ts
+++ b/test/memory/store/scoped-frame-store.test.ts
@@ -1,0 +1,351 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import type { Frame } from "@app/memory/frames/types.js";
+import {
+  FRAME_STORE_CAPABILITIES,
+  SCOPED_FRAME_STORE_ERROR_CODES,
+  MemoryScopedFrameStoreBackend,
+  ScopedFrameStoreError,
+  type ScopedFrameInput,
+  type ScopedFrameListOptions,
+  type ScopedFrameSearchCriteria,
+  type ScopedFrameUpdate,
+} from "@app/memory/store/index.js";
+import {
+  RUNTIME_SCOPE_CONTRACT_VERSION,
+  type AuthorityGrantId,
+  type AuthorityVersion,
+  type AuthorizedScopeV1,
+  type CapabilityId,
+  type ContentDigest,
+  type PrincipalId,
+  type ScopeVersion,
+  type TenantId,
+  type WorkspaceId,
+} from "@app/shared/runtime-scope/index.js";
+
+type AssertNever<Value extends never> = Value;
+type ForbiddenSelector = "tenantId" | "workspaceId" | "principalId" | "userId";
+type _SearchHasNoAuthoritySelector = AssertNever<
+  Extract<keyof ScopedFrameSearchCriteria, ForbiddenSelector>
+>;
+type _ListHasNoAuthoritySelector = AssertNever<
+  Extract<keyof ScopedFrameListOptions, ForbiddenSelector>
+>;
+type _WriteHasNoAuthoritySelector = AssertNever<Extract<keyof ScopedFrameInput, ForbiddenSelector>>;
+type _UpdateHasNoAuthoritySelector = AssertNever<
+  Extract<keyof ScopedFrameUpdate, ForbiddenSelector>
+>;
+
+const ALL_NORMAL_CAPABILITIES = [
+  FRAME_STORE_CAPABILITIES.READ,
+  FRAME_STORE_CAPABILITIES.WRITE,
+  FRAME_STORE_CAPABILITIES.DELETE,
+];
+
+function scope(
+  tenant: string,
+  workspace: string,
+  principal: string,
+  capabilities: readonly CapabilityId[] = ALL_NORMAL_CAPABILITIES,
+  overrides: Partial<AuthorizedScopeV1> = {}
+): AuthorizedScopeV1 {
+  return {
+    schemaVersion: RUNTIME_SCOPE_CONTRACT_VERSION,
+    grantId: `grant-${tenant}-${workspace}-${principal}` as AuthorityGrantId,
+    tenantId: tenant as TenantId,
+    workspaceId: workspace as WorkspaceId,
+    principalId: principal as PrincipalId,
+    capabilities,
+    authorityVersion: "authority-v1" as AuthorityVersion,
+    scopeVersion: "scope-v1" as ScopeVersion,
+    authorityDigest: "sha256:authority" as ContentDigest,
+    verifiedAt: "2026-07-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function frame(id: string, overrides: Partial<Frame> = {}): ScopedFrameInput {
+  return {
+    id,
+    timestamp: "2026-07-18T01:00:00.000Z",
+    branch: "agent/759-scoped-frame-store",
+    module_scope: ["memory/store"],
+    summary_caption: `Scoped Frame ${id}`,
+    reference_point: "scope-bound persistence",
+    status_snapshot: { next_action: "verify FrameStore isolation" },
+    ...overrides,
+  };
+}
+
+async function rejectsWithCode(
+  operation: () => Promise<unknown>,
+  code: string,
+  capability?: CapabilityId
+): Promise<void> {
+  await assert.rejects(operation, (error: unknown) => {
+    assert.ok(error instanceof ScopedFrameStoreError);
+    assert.equal(error.code, code);
+    assert.equal(error.requiredCapability, capability);
+    return true;
+  });
+}
+
+describe("MemoryScopedFrameStoreBackend", () => {
+  test("binds an immutable snapshot without expanding attenuated capabilities", async () => {
+    const mutableCapabilities = [FRAME_STORE_CAPABILITIES.READ];
+    const mutableScope = scope("tenant-a", "workspace-a", "principal-a", mutableCapabilities);
+    const backend = new MemoryScopedFrameStoreBackend();
+    const store = backend.bind(mutableScope);
+
+    mutableCapabilities.push(FRAME_STORE_CAPABILITIES.WRITE);
+    assert.notEqual(store.authorizedScope, mutableScope);
+    assert.equal(Object.isFrozen(store.authorizedScope), true);
+    assert.equal(Object.isFrozen(store.authorizedScope.capabilities), true);
+    assert.deepEqual(store.authorizedScope.capabilities, [FRAME_STORE_CAPABILITIES.READ]);
+    await rejectsWithCode(
+      () => store.saveFrame(frame("cannot-write")),
+      SCOPED_FRAME_STORE_ERROR_CODES.CAPABILITY_MISSING,
+      FRAME_STORE_CAPABILITIES.WRITE
+    );
+
+    await backend.close();
+  });
+
+  test("rejects missing, future-version, and already-expired scope", () => {
+    const backend = new MemoryScopedFrameStoreBackend({
+      now: () => new Date("2026-07-18T02:00:00.000Z"),
+    });
+    assert.throws(
+      () => backend.bind(undefined as unknown as AuthorizedScopeV1),
+      (error: unknown) =>
+        error instanceof ScopedFrameStoreError &&
+        error.code === SCOPED_FRAME_STORE_ERROR_CODES.INVALID_SCOPE
+    );
+    assert.throws(
+      () => backend.bind({ ...scope("t", "w", "p"), schemaVersion: 2 } as never),
+      (error: unknown) =>
+        error instanceof ScopedFrameStoreError &&
+        error.code === SCOPED_FRAME_STORE_ERROR_CODES.INVALID_SCOPE
+    );
+    assert.throws(
+      () =>
+        backend.bind(
+          scope("t", "w", "p", ALL_NORMAL_CAPABILITIES, {
+            expiresAt: "2026-07-18T01:59:59.999Z",
+          })
+        ),
+      (error: unknown) =>
+        error instanceof ScopedFrameStoreError &&
+        error.code === SCOPED_FRAME_STORE_ERROR_CODES.SCOPE_EXPIRED
+    );
+  });
+
+  test("isolates identical Frame IDs across tenant and workspace ownership", async () => {
+    const backend = new MemoryScopedFrameStoreBackend();
+    const workspaceA = backend.bind(scope("tenant-a", "workspace-a", "principal-a"));
+    const workspaceB = backend.bind(scope("tenant-a", "workspace-b", "principal-a"));
+    const tenantB = backend.bind(scope("tenant-b", "workspace-a", "principal-a"));
+
+    await workspaceA.saveFrame(frame("same-id", { summary_caption: "owned by workspace A" }));
+    await workspaceB.saveFrame(frame("same-id", { summary_caption: "owned by workspace B" }));
+    await tenantB.saveFrame(frame("same-id", { summary_caption: "owned by tenant B" }));
+
+    assert.equal(
+      (await workspaceA.getFrameById("same-id"))?.summary_caption,
+      "owned by workspace A"
+    );
+    assert.equal(
+      (await workspaceB.getFrameById("same-id"))?.summary_caption,
+      "owned by workspace B"
+    );
+    assert.equal((await tenantB.getFrameById("same-id"))?.summary_caption, "owned by tenant B");
+    assert.equal(await workspaceA.getFrameCount(), 1);
+    assert.equal(await workspaceB.getFrameCount(), 1);
+    assert.equal(await tenantB.getFrameCount(), 1);
+
+    assert.equal(await workspaceA.deleteFrame("same-id"), true);
+    assert.equal(await workspaceA.getFrameById("same-id"), null);
+    assert.equal(
+      (await workspaceB.getFrameById("same-id"))?.summary_caption,
+      "owned by workspace B"
+    );
+    assert.equal((await tenantB.getFrameById("same-id"))?.summary_caption, "owned by tenant B");
+
+    await backend.close();
+  });
+
+  test("stamps creator internally and ignores caller ownership on create and update", async () => {
+    const backend = new MemoryScopedFrameStoreBackend();
+    const writer = backend.bind(scope("tenant-a", "workspace-a", "principal-creator"));
+    const sameWorkspaceWriter = backend.bind(
+      scope("tenant-a", "workspace-a", "principal-collaborator")
+    );
+    const admin = backend.bindAdmin(
+      scope("tenant-a", "workspace-a", "principal-admin", [FRAME_STORE_CAPABILITIES.ADMIN])
+    );
+    const spoofedFrame = {
+      ...frame("creator-stamp"),
+      userId: "caller-controlled-principal",
+      tenantId: "caller-controlled-tenant",
+      workspaceId: "caller-controlled-workspace",
+      creatorPrincipalId: "caller-controlled-principal",
+    } as unknown as ScopedFrameInput;
+
+    await writer.saveFrame(spoofedFrame);
+    const storedFrame = await writer.getFrameById("creator-stamp");
+    assert.ok(storedFrame);
+    assert.equal(storedFrame.userId, undefined);
+    assert.equal("tenantId" in (storedFrame as unknown as Record<string, unknown>), false);
+    assert.equal("workspaceId" in (storedFrame as unknown as Record<string, unknown>), false);
+    assert.equal(
+      "creatorPrincipalId" in (storedFrame as unknown as Record<string, unknown>),
+      false
+    );
+    assert.deepEqual(await admin.getFrameOwnership("creator-stamp"), {
+      schemaVersion: 1,
+      tenantId: "tenant-a",
+      workspaceId: "workspace-a",
+      creatorPrincipalId: "principal-creator",
+      scopeVersion: "scope-v1",
+    });
+
+    await sameWorkspaceWriter.updateFrame("creator-stamp", {
+      summary_caption: "collaborator update",
+      userId: "replacement-principal",
+    } as unknown as ScopedFrameUpdate);
+    assert.equal(
+      (await writer.getFrameById("creator-stamp"))?.summary_caption,
+      "collaborator update"
+    );
+    assert.equal((await writer.getFrameById("creator-stamp"))?.userId, undefined);
+    assert.equal(
+      (await admin.getFrameOwnership("creator-stamp"))?.creatorPrincipalId,
+      "principal-creator"
+    );
+
+    await sameWorkspaceWriter.saveFrame({
+      ...frame("creator-stamp"),
+      summary_caption: "collaborator upsert",
+    });
+    assert.equal(
+      (await admin.getFrameOwnership("creator-stamp"))?.creatorPrincipalId,
+      "principal-creator"
+    );
+
+    await backend.close();
+  });
+
+  test("checks read, write, delete, and admin capabilities at operation boundaries", async () => {
+    const backend = new MemoryScopedFrameStoreBackend();
+    const writer = backend.bind(scope("tenant-a", "workspace-a", "writer"));
+    await writer.saveFrame(frame("capability-frame"));
+    const readOnly = backend.bind(
+      scope("tenant-a", "workspace-a", "reader", [FRAME_STORE_CAPABILITIES.READ])
+    );
+    const empty = backend.bind(scope("tenant-a", "workspace-a", "empty", []));
+
+    assert.equal((await readOnly.listFrames()).frames.length, 1);
+    assert.equal(await readOnly.getFrameCount(), 1);
+    await rejectsWithCode(
+      () => readOnly.updateFrame("capability-frame", { jira: "LEX-759" }),
+      SCOPED_FRAME_STORE_ERROR_CODES.CAPABILITY_MISSING,
+      FRAME_STORE_CAPABILITIES.WRITE
+    );
+    await rejectsWithCode(
+      () => readOnly.deleteFrame("capability-frame"),
+      SCOPED_FRAME_STORE_ERROR_CODES.CAPABILITY_MISSING,
+      FRAME_STORE_CAPABILITIES.DELETE
+    );
+    await rejectsWithCode(
+      () => empty.getFrameById("capability-frame"),
+      SCOPED_FRAME_STORE_ERROR_CODES.CAPABILITY_MISSING,
+      FRAME_STORE_CAPABILITIES.READ
+    );
+    assert.throws(
+      () => backend.bindAdmin(scope("tenant-a", "workspace-a", "not-admin", [])),
+      (error: unknown) =>
+        error instanceof ScopedFrameStoreError &&
+        error.requiredCapability === FRAME_STORE_CAPABILITIES.ADMIN
+    );
+
+    await backend.close();
+  });
+
+  test("keeps list, search, statistics, batch, and bulk deletion inside the bound scope", async () => {
+    const backend = new MemoryScopedFrameStoreBackend();
+    const workspaceA = backend.bind(scope("tenant-a", "workspace-a", "principal-a"));
+    const workspaceB = backend.bind(scope("tenant-a", "workspace-b", "principal-a"));
+    const batch = [
+      frame("old", {
+        timestamp: "2026-06-01T00:00:00.000Z",
+        summary_caption: "Scoped alpha history",
+        spend: { tokens_estimated: 10, prompts: 1 },
+      }),
+      frame("new", {
+        timestamp: "2026-07-18T01:00:00.000Z",
+        summary_caption: "Scoped beta current",
+        module_scope: ["memory/store", "memory/scope"],
+        spend: { tokens_estimated: 20, prompts: 2 },
+        superseded_by: "replacement",
+      }),
+    ];
+    assert.equal(
+      (await workspaceA.saveFrames(batch)).every((result) => result.success),
+      true
+    );
+    await workspaceB.saveFrame(frame("hidden", { summary_caption: "Scoped alpha hidden" }));
+
+    assert.deepEqual(
+      (await workspaceA.searchFrames({ query: "alpha" })).map(({ id }) => id),
+      ["old"]
+    );
+    assert.deepEqual(
+      (await workspaceA.listFrames({ limit: 10 })).frames.map(({ id }) => id),
+      ["new", "old"]
+    );
+    assert.equal((await workspaceA.getStats(true)).totalFrames, 2);
+    assert.deepEqual(await workspaceA.getTurnCostMetrics(), {
+      frameCount: 2,
+      estimatedTokens: 30,
+      prompts: 3,
+    });
+    assert.equal(await workspaceA.purgeSuperseded(), 1);
+    assert.equal(await workspaceA.deleteFramesBefore(new Date("2026-07-01T00:00:00.000Z")), 1);
+    assert.equal(await workspaceA.getFrameCount(), 0);
+    assert.equal(await workspaceB.getFrameCount(), 1);
+
+    await backend.close();
+  });
+
+  test("rechecks expiry and closes views independently from the shared backend", async () => {
+    let now = new Date("2026-07-18T01:00:00.000Z");
+    const backend = new MemoryScopedFrameStoreBackend({ now: () => now });
+    const expiring = scope("tenant-a", "workspace-a", "principal-a", ALL_NORMAL_CAPABILITIES, {
+      expiresAt: "2026-07-18T02:00:00.000Z",
+    });
+    const first = backend.bind(expiring);
+    const second = backend.bind(expiring);
+    await first.saveFrame(frame("lifecycle"));
+
+    await first.close();
+    await rejectsWithCode(
+      () => first.getFrameById("lifecycle"),
+      SCOPED_FRAME_STORE_ERROR_CODES.STORE_CLOSED
+    );
+    assert.equal((await second.getFrameById("lifecycle"))?.id, "lifecycle");
+
+    now = new Date("2026-07-18T02:00:00.000Z");
+    await rejectsWithCode(
+      () => second.getFrameById("lifecycle"),
+      SCOPED_FRAME_STORE_ERROR_CODES.SCOPE_EXPIRED
+    );
+    await backend.close();
+    assert.throws(
+      () => backend.bind(scope("tenant-a", "workspace-a", "principal-a")),
+      (error: unknown) =>
+        error instanceof ScopedFrameStoreError &&
+        error.code === SCOPED_FRAME_STORE_ERROR_CODES.STORE_CLOSED
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- add the public `ScopedFrameStore` and `ScopedFrameStoreBinder` contracts;
- define stable read, write, delete, and admin capabilities/errors;
- keep `FrameStoreAdmin` behind a separately named and capability-gated binder;
- add an in-memory reference backend partitioned by tenant/workspace;
- copy the exact attenuated `AuthorizedScope` into immutable bound views;
- stamp creator attribution internally and strip caller-controlled ownership fields;
- add isolation, capability, expiry, lifecycle, statistics, and bulk-operation tests;
- publish transition documentation and a major changeset.

This is the contract/reference slice of #759. It intentionally does **not** close the issue.

## Dependency and integration boundary

- #758 must wire normal CLI/MCP consumers through `backend.bind(authorizedScope)`.
- #760 must implement physical SQLite ownership and migration against this contract.
- #761 must implement PostgreSQL structural scope and RLS against this contract.
- The legacy unscoped `FrameStore` remains temporarily exported for staged migration, but is explicitly documented as transitional rather than the Lex 3.0 normal API.
- Repository identity remains provenance, not a storage partition.

## Validation

- 7 new scoped-store reference tests
- 151 focused existing store regressions
- type-check and build
- changed-file lint and Prettier
- docs validation
- pack guard
- independent coordinator focused-test, type-check, build, and formatting rerun

A full environment-clean umbrella gate will run after #758 is woven. Worker full-suite attempts were not treated as evidence because inherited PostgreSQL environment selection contaminated nominal SQLite tests.

## Agent-work evidence

Prepared and executed through fenced LexRunner Attempt `attempt-759-a1`. The worker had edit-only authority; commit, push, and PR delivery remained coordinator-owned.

Receipt `receipt-attempt-759-a1` binds the claim to patch hash `sha256:f9a4e8a620c62a0ea0e8ff73452172ebf25358317475de232424296c1c1cc9c8`. The durable receipt remains `verification_pending` pending the public engine-verification surface tracked in Guffawaffle/lexrunner#793.