### PR TITLE
Add the trusted CLI and MCP scope bootstrap

### DIFF
--- a/.changeset/trusted-runtime-scope.md
+++ b/.changeset/trusted-runtime-scope.md
@@ -7,3 +7,6 @@ immutable invocation scope, structured diagnostics, stable resolver errors, and 
 conformance fixtures. Include deterministic execution-surface and registry-location resolution,
 a separate versioned SQLite local registry with explicit lifecycle operations, a fail-closed
 runtime-scope resolver, and concrete conformance coverage for every exported fixture.
+Add a shared, immutable CLI/MCP bootstrap guard that opens the surface-local registry read-only,
+attenuates requested capabilities, fails before command dispatch, and keeps redacted diagnostics
+explicit and capability-gated.

--- a/docs/CONTRACT_SURFACE.md
+++ b/docs/CONTRACT_SURFACE.md
@@ -37,7 +37,7 @@ Lex exposes a contract surface that any runner or tool can target. This document
 - Paths, Git state, manifests, flags, and environment values may select evidence but cannot grant access.
 - Diagnostics are versioned, redacted observability and never change resolution.
 
-**Implementation:** Phase 2 adds opt-in, pure execution-surface and registry-location resolution, a separate versioned SQLite local registry, a deterministic fail-closed runtime-scope resolver, and an in-memory authority implementation for tests and embedding. Registry initialization and binding lifecycle changes are explicit administrative operations; normal resolution is read-only. Existing CLI, MCP, Frame, and FrameStore behavior remains unchanged.
+**Implementation:** Phase 2 adds pure execution-surface and registry-location resolution, a separate versioned SQLite local registry, a deterministic fail-closed runtime-scope resolver, and an in-memory authority implementation for tests and embedding. The Phase 3 foundation adds one immutable, opt-in CLI/MCP bootstrap guard with capability attenuation and redacted diagnostics. Registry initialization and binding lifecycle changes remain explicit administrative operations; normal resolution is read-only. Scope-bound FrameStore behavior is a separate contract phase.
 
 **Conformance:** The package exports deterministic Windows/WSL, clone, worktree, fork, binding, selector, cached-authority, and diagnostic fixtures. Lex runs all exported fixtures against the concrete Phase 2 resolver and registry without changing their expected semantics.
 

--- a/docs/RUNTIME_SCOPE_CONTRACT.md
+++ b/docs/RUNTIME_SCOPE_CONTRACT.md
@@ -9,6 +9,9 @@ import {
   RUNTIME_SCOPE_CONFORMANCE_FIXTURES,
   WORKSPACE_AUTHORITY_ERROR_CODES,
   SqliteLocalBindingRegistry,
+  captureTrustedBootstrapInput,
+  createTrustedRuntimeScopeBootstrap,
+  authorizeTrustedRuntimeEntrypoint,
   detectExecutionSurface,
   resolveLocalRegistryLocation,
   resolveRuntimeScope,
@@ -22,7 +25,7 @@ import {
 } from "@smartergpt/lex/runtime-scope";
 ```
 
-Phase 1 froze the public contract. Phase 2 adds opt-in deterministic resolver and local-registry services. Existing CLI, MCP, Frame, and FrameStore behavior is unchanged; no existing entrypoint invokes these services yet.
+Phase 1 froze the public contract. Phase 2 added the deterministic resolver and local-registry services. Phase 3 begins the opt-in entrypoint integration through one shared guard; existing callers retain compatibility until they supply a trusted discovery and authority adapter.
 
 ## Boundary
 
@@ -144,15 +147,36 @@ Authority and registry exceptions fail closed. Normal results contain no diagnos
 
 `InMemoryAuthorityDirectory` is a deterministic test and embedding implementation of the authority contract. It is not shared PostgreSQL authority and does not establish a production trust boundary.
 
+## Phase 3 trusted bootstrap foundation
+
+`captureTrustedBootstrapInput` freezes `argv`, `cwd`, native platform/surface evidence, and a small compatibility-environment allow-list exactly once. The allow-list contains only home/state and caller-root discovery inputs. Database credentials and registry-path overrides are discarded, and retained environment values remain discovery inputs rather than authority.
+
+`createTrustedRuntimeScopeBootstrap` accepts injected canonical authority and repository discovery adapters. For every CLI or MCP invocation it:
+
+1. clones and freezes the captured input and discovery evidence;
+2. selects the native surface-local registry from standard state directories;
+3. opens that existing registry read-only and always closes the handle;
+4. calls the deterministic resolver with only the explicitly requested capabilities; and
+5. returns an immutable compact result, or an opt-in diagnostic envelope.
+
+`authorizeTrustedRuntimeEntrypoint` is the common integration seam used by `run()` and `MCPServer`. CLI authorization completes before Commander dispatch. MCP authorization completes before tool dispatch, and a denial therefore cannot invoke even a mutating in-memory test store. The successful MCP result stays lexical to that dispatch seam so later scoped-store work does not require shared mutable request state.
+
+Normal calls add no scope metadata to agent output. CLI diagnostics use `--diagnostic` for summary detail and `--diagnostic --diagnostic-level=full` for full detail; MCP tools accept `diagnostics: "summary" | "full"`. Full authority, binding, and selection detail requires an independent `runtime:diagnose` authorization decision, uses opaque hashed references, and never changes the operation capability set or its resolution result. Authentication references and project roots are always omitted.
+
+`authorityMode: "local-offline"` is explicit and still requires an injected authority implementation plus finite cached-authority evidence. It does not pair execution surfaces or turn copied local state into shared authority.
+
 ## Deferred implementation
 
-The following remain intentionally absent after Phase 2:
+The following remain intentionally absent from the Phase 3 foundation:
 
-- CLI/MCP bootstrap integration;
+- the production/default repository declaration and native evidence discovery adapter;
+- CLI commands for explicit bind, inspect, rebind, revoke, and recovery lifecycle operations;
+- mandatory bootstrap activation for existing compatibility entrypoints;
+- passing the lexically resolved scope into a scope-bound FrameStore;
 - Frame ownership columns or migration;
 - PostgreSQL RLS;
 - projections and catalog publication;
 - offline authority pairing;
 - a cross-repository helper package.
 
-See [ADR-0011](./adr/0011-trusted-runtime-scope-and-authority.md), epic [#749](https://github.com/Guffawaffle/lex/issues/749), and Phase 2 issue [#755](https://github.com/Guffawaffle/lex/issues/755).
+See [ADR-0011](./adr/0011-trusted-runtime-scope-and-authority.md), epic [#749](https://github.com/Guffawaffle/lex/issues/749), Phase 2 issue [#755](https://github.com/Guffawaffle/lex/issues/755), and Phase 3 issue [#758](https://github.com/Guffawaffle/lex/issues/758).

--- a/docs/adr/0011-trusted-runtime-scope-and-authority.md
+++ b/docs/adr/0011-trusted-runtime-scope-and-authority.md
@@ -141,7 +141,7 @@ Phase 2 implements pure execution-surface and registry-location resolution, a se
 - UUID generation version.
 - Exact public binding command spelling.
 - Offline authority snapshots and cross-surface pairing.
-- CLI/MCP integration and diagnostics implementation (Phase 3).
+- Production repository-evidence discovery, administrative binding commands, and mandatory bootstrap activation after the shared CLI/MCP Phase 3 guard.
 - Scoped FrameStore behavior and physical ownership migration (Phase 4 and later).
 - PostgreSQL RLS, same-tenant projections, and catalog publication.
 - A shared runtime helper package; contracts must survive implementation in Lex and AXF first.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,11 @@
  */
 
 export { createProgram, run } from "../shared/cli/index.js";
+export type {
+  CreateProgramOptionsV1,
+  CliRuntimeScopeGuardV1,
+  CliRunOptionsV1,
+} from "../shared/cli/index.js";
 export type { RememberOptions } from "../shared/cli/remember.js";
 export type { RecallOptions } from "../shared/cli/recall.js";
 export {

--- a/src/memory/mcp_server/server.ts
+++ b/src/memory/mcp_server/server.ts
@@ -45,6 +45,15 @@ import {
 } from "../renderer/timeline.js";
 // @ts-ignore - importing from compiled dist directories
 import { compactFrame, compactFrameList } from "../renderer/compact.js";
+import {
+  DIAGNOSTIC_CONTRACT_VERSION,
+  authorizeTrustedRuntimeEntrypoint,
+  type CapabilityId,
+  type DiagnosticEnvelopeV1,
+  type DiagnosticRequestV1,
+  type TrustedRuntimeScopeBootstrapResultV1,
+  type TrustedRuntimeScopeEntrypointGuardV1,
+} from "../../shared/runtime-scope/index.js";
 
 const logger = getLogger("memory:mcp_server:server");
 
@@ -179,6 +188,12 @@ export interface MCPServerOptions {
   dbPath?: string;
   /** Repository root path for policy resolution. */
   repoRoot?: string;
+  /** Optional fail-closed trusted scope guard shared with the CLI entrypoint. */
+  runtimeScope?: MCPRuntimeScopeGuardV1;
+}
+
+export interface MCPRuntimeScopeGuardV1 extends TrustedRuntimeScopeEntrypointGuardV1 {
+  readonly requestedCapabilitiesForTool: (toolName: string) => readonly CapabilityId[];
 }
 
 /**
@@ -193,6 +208,7 @@ export class MCPServer {
   private dbPathSource: string;
   private configResolution: ConfigResolution;
   private idempotencyCache: IdempotencyCache; // Idempotency cache for mutation tools
+  private readonly runtimeScope: MCPRuntimeScopeGuardV1 | undefined;
 
   /**
    * Create a new MCPServer instance.
@@ -216,6 +232,7 @@ export class MCPServer {
     }
 
     this.repoRoot = options.repoRoot || null;
+    this.runtimeScope = options.runtimeScope;
     this.configResolution = resolveConfigResolution({
       startPath: process.cwd(),
       explicitRoot: this.repoRoot,
@@ -350,8 +367,25 @@ export class MCPServer {
    * Returns tools sorted by name for deterministic ordering
    */
   private handleToolsList(): MCPResponse {
+    const tools = this.runtimeScope
+      ? MCP_TOOLS.map((tool) => ({
+          ...tool,
+          inputSchema: {
+            ...tool.inputSchema,
+            properties: {
+              ...tool.inputSchema.properties,
+              diagnostics: {
+                type: "string",
+                enum: ["summary", "full"],
+                description:
+                  "Opt-in redacted runtime-scope diagnostics. Full detail requires runtime:diagnose authority.",
+              },
+            },
+          },
+        }))
+      : [...MCP_TOOLS];
     return {
-      tools: [...MCP_TOOLS].sort((a, b) => a.name.localeCompare(b.name)),
+      tools: tools.sort((a, b) => a.name.localeCompare(b.name)),
     };
   }
 
@@ -359,6 +393,75 @@ export class MCPServer {
    * Handle tools/call request
    */
   private async handleToolsCall(params: ToolCallParams): Promise<MCPResponse> {
+    let diagnostics: DiagnosticEnvelopeV1 | undefined;
+    let authorizedRuntimeScope:
+      Extract<TrustedRuntimeScopeBootstrapResultV1, { readonly resolved: true }> | undefined;
+    const requestedLevel = params.arguments.diagnostics;
+    if (requestedLevel !== undefined && requestedLevel !== "summary" && requestedLevel !== "full") {
+      return {
+        error: {
+          code: MCPErrorCode.VALIDATION_INVALID_FORMAT,
+          message: "diagnostics must be either 'summary' or 'full'.",
+        },
+      };
+    }
+    if ((requestedLevel === "summary" || requestedLevel === "full") && !this.runtimeScope) {
+      return {
+        error: {
+          code: "LEX_WORKSPACE_UNBOUND",
+          message: "Runtime-scope diagnostics require a configured trusted bootstrap.",
+        },
+      };
+    }
+    if (this.runtimeScope) {
+      const diagnosticRequest: DiagnosticRequestV1 | undefined =
+        requestedLevel === "summary" || requestedLevel === "full"
+          ? Object.freeze({
+              schemaVersion: DIAGNOSTIC_CONTRACT_VERSION,
+              level: requestedLevel,
+            })
+          : undefined;
+      const resolution = await authorizeTrustedRuntimeEntrypoint(
+        this.runtimeScope,
+        "mcp",
+        this.runtimeScope.requestedCapabilitiesForTool(params.name),
+        diagnosticRequest
+      );
+      diagnostics = resolution.diagnostics;
+      if (!resolution.resolved) {
+        return {
+          error: {
+            code: resolution.error.code,
+            message: resolution.error.message,
+            ...(diagnostics ? { context: { diagnostics } } : {}),
+          },
+        };
+      }
+      authorizedRuntimeScope = resolution;
+    }
+
+    const { diagnostics: _diagnostics, ...toolArguments } = params.arguments;
+    const response = await this.dispatchToolsCall(
+      { ...params, arguments: toolArguments },
+      authorizedRuntimeScope
+    );
+    if (!diagnostics) return response;
+    return {
+      ...response,
+      data: {
+        ...response.data,
+        diagnostics,
+      },
+    };
+  }
+
+  private async dispatchToolsCall(
+    params: ToolCallParams,
+    _authorizedRuntimeScope?: Extract<
+      TrustedRuntimeScopeBootstrapResultV1,
+      { readonly resolved: true }
+    >
+  ): Promise<MCPResponse> {
     const { name, arguments: args } = params;
 
     // Log deprecation warnings for old tool names (AX-014)

--- a/src/memory/mcp_server/tsconfig.json
+++ b/src/memory/mcp_server/tsconfig.json
@@ -24,6 +24,7 @@
     { "path": "../renderer" },
     { "path": "../../shared/module_ids" },
     { "path": "../../shared/aliases" },
-    { "path": "../../shared/errors" }
+    { "path": "../../shared/errors" },
+    { "path": "../../shared/runtime-scope" }
   ]
 }

--- a/src/shared/cli/index.ts
+++ b/src/shared/cli/index.ts
@@ -44,6 +44,16 @@ import { introspect, type IntrospectOptions } from "./introspect.js";
 import { context, type ContextOptions } from "./context.js";
 import { hints, type HintsOptions } from "./hints.js";
 import * as output from "./output.js";
+import { AXErrorException } from "../errors/ax-error.js";
+import {
+  DIAGNOSTIC_CONTRACT_VERSION,
+  authorizeTrustedRuntimeEntrypoint,
+  type CapabilityId,
+  type DiagnosticEnvelopeV1,
+  type DiagnosticRequestV1,
+  type TrustedRuntimeScopeBootstrapResultV1,
+  type TrustedRuntimeScopeEntrypointGuardV1,
+} from "../runtime-scope/index.js";
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -66,7 +76,11 @@ function getVersion(): string {
 /**
  * Create and configure the CLI program
  */
-export function createProgram(): Command {
+export interface CreateProgramOptionsV1 {
+  readonly runtimeScopeDiagnostics?: boolean;
+}
+
+export function createProgram(options: CreateProgramOptionsV1 = {}): Command {
   const program = new Command();
 
   program
@@ -75,6 +89,16 @@ export function createProgram(): Command {
     .version(getVersion())
     .option("--json", "Output results in JSON format")
     .option("--verbose", "Enable diagnostic logging (Pino logs)");
+  if (options.runtimeScopeDiagnostics) {
+    program
+      .option("--diagnostic", "Include a redacted runtime-scope diagnostic summary")
+      .option(
+        "--diagnostic-level <level>",
+        "Runtime-scope diagnostic detail: summary or full (requires --diagnostic)",
+        /^(summary|full)$/,
+        undefined
+      );
+  }
 
   // lex init command
   program
@@ -675,8 +699,86 @@ function parseList(value: string): string[] | undefined {
 /**
  * Run the CLI program
  */
-export async function run(argv: string[] = process.argv): Promise<void> {
-  const program = createProgram();
+export interface CliRuntimeScopeGuardV1 extends TrustedRuntimeScopeEntrypointGuardV1 {
+  readonly requestedCapabilities: readonly CapabilityId[];
+  readonly onResolved?: (
+    result: Extract<TrustedRuntimeScopeBootstrapResultV1, { readonly resolved: true }>
+  ) => void | Promise<void>;
+  readonly emitDiagnostics: (diagnostics: DiagnosticEnvelopeV1) => void | Promise<void>;
+}
+
+export interface CliRunOptionsV1 {
+  readonly runtimeScope?: CliRuntimeScopeGuardV1;
+}
+
+function diagnosticRequestFromArgv(argv: readonly string[]): DiagnosticRequestV1 | undefined {
+  const boundary = argv.indexOf("--");
+  const runtimeArguments = boundary === -1 ? argv : argv.slice(0, boundary);
+  if (!runtimeArguments.includes("--diagnostic")) return undefined;
+  const equalsArgument = runtimeArguments.find((argument) =>
+    argument.startsWith("--diagnostic-level=")
+  );
+  if (equalsArgument) {
+    const level = equalsArgument.slice("--diagnostic-level=".length);
+    if (level !== "summary" && level !== "full") return undefined;
+    return Object.freeze({ schemaVersion: DIAGNOSTIC_CONTRACT_VERSION, level });
+  }
+  const index = runtimeArguments.indexOf("--diagnostic-level");
+  const candidate = index === -1 ? undefined : runtimeArguments[index + 1];
+  const level = candidate === "full" || candidate === "summary" ? candidate : "summary";
+  return Object.freeze({ schemaVersion: DIAGNOSTIC_CONTRACT_VERSION, level });
+}
+
+/**
+ * Run one CLI invocation. When a trusted runtime-scope guard is supplied, it
+ * resolves before Commander dispatches any command and exposes scope only to
+ * the injected callback that Phase 4 will use to bind the store.
+ */
+export async function run(
+  argv: string[] = process.argv,
+  options: CliRunOptionsV1 = {}
+): Promise<void> {
+  const boundary = argv.indexOf("--");
+  const runtimeArguments = boundary === -1 ? argv : argv.slice(0, boundary);
+  const hasDiagnosticLevel = runtimeArguments.some(
+    (argument) => argument === "--diagnostic-level" || argument.startsWith("--diagnostic-level=")
+  );
+  if (hasDiagnosticLevel && !runtimeArguments.includes("--diagnostic")) {
+    throw new AXErrorException(
+      "VALIDATION_INVALID_TYPE",
+      "--diagnostic-level requires --diagnostic.",
+      ["Add --diagnostic or remove --diagnostic-level."]
+    );
+  }
+  const diagnosticRequest = diagnosticRequestFromArgv(argv);
+  if (diagnosticRequest && !options.runtimeScope) {
+    throw new AXErrorException(
+      "LEX_WORKSPACE_UNBOUND",
+      "Runtime-scope diagnostics require a configured trusted bootstrap.",
+      ["Configure trusted workspace bootstrap before requesting --diagnostic."]
+    );
+  }
+  if (options.runtimeScope) {
+    const result = await authorizeTrustedRuntimeEntrypoint(
+      options.runtimeScope,
+      "cli",
+      options.runtimeScope.requestedCapabilities,
+      diagnosticRequest
+    );
+    if (result.diagnostics) {
+      await options.runtimeScope.emitDiagnostics(result.diagnostics);
+    }
+    if (!result.resolved) {
+      throw new AXErrorException(
+        result.error.code,
+        result.error.message,
+        ["Inspect the local workspace binding or perform an explicit administrative bind."],
+        result.diagnostics ? { diagnostics: result.diagnostics } : undefined
+      );
+    }
+    await options.runtimeScope.onResolved?.(result);
+  }
+  const program = createProgram({ runtimeScopeDiagnostics: options.runtimeScope !== undefined });
   await program.parseAsync(argv);
 }
 

--- a/src/shared/cli/tsconfig.json
+++ b/src/shared/cli/tsconfig.json
@@ -23,6 +23,7 @@
     { "path": "../config" },
     { "path": "../instructions" },
     { "path": "../errors" },
+    { "path": "../runtime-scope" },
     { "path": "../../atlas" },
     { "path": "../../memory/store" },
     { "path": "../../memory/renderer" },

--- a/src/shared/runtime-scope/bootstrap.ts
+++ b/src/shared/runtime-scope/bootstrap.ts
@@ -1,0 +1,587 @@
+import { createHash } from "node:crypto";
+
+import type { WorkspaceSelectorV1 } from "./authority.js";
+import type { AuthorityDirectory, WorkspaceAuthorizationDecisionV1 } from "./authority.js";
+import {
+  LOCAL_BINDING_CONTRACT_VERSION,
+  type LocalBindingRegistry,
+  type RepositoryDeclarationV1,
+  type RepositoryInstanceEvidenceV1,
+} from "./bindings.js";
+import {
+  DIAGNOSTIC_CONTRACT_VERSION,
+  type DiagnosticEnvelopeV1,
+  type DiagnosticRequestV1,
+  type DiagnosticSection,
+} from "./diagnostics.js";
+import type { AuthenticationRef, CapabilityId, ContentDigest, RuntimeId, TraceId } from "./ids.js";
+import { SqliteLocalBindingRegistry, type OpenLocalRegistryOptionsV1 } from "./registry.js";
+import {
+  resolveRuntimeScope,
+  runtimeScopeFailureFromRegistryError,
+  type RuntimeScopeResolutionErrorV1,
+  type RuntimeScopeResolutionResultV1,
+} from "./resolver.js";
+import type { SourceRevisionEvidenceV1 } from "./runtime.js";
+import {
+  RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+  detectExecutionSurface,
+  normalizeExecutionSurfacePath,
+  resolveLocalRegistryLocation,
+  type BootstrapInputSnapshotV1,
+  type ResolvedRegistryLocationV1,
+} from "./surface.js";
+
+export const TRUSTED_RUNTIME_BOOTSTRAP_VERSION = 1 as const;
+export const RUNTIME_DIAGNOSTIC_CAPABILITY = "runtime:diagnose" as CapabilityId;
+
+export type TrustedRuntimeEntrypoint = "cli" | "mcp";
+export type RuntimeAuthorityMode = "shared" | "local-offline";
+
+/**
+ * The only environment names the trusted runtime-scope capture boundary retains.
+ * These values may locate configuration or native state. They never mint authority.
+ */
+export const RUNTIME_SCOPE_COMPATIBILITY_ENVIRONMENT = Object.freeze([
+  "HOME",
+  "USERPROFILE",
+  "LOCALAPPDATA",
+  "XDG_STATE_HOME",
+  "WSL_DISTRO_NAME",
+  "WSL_INTEROP",
+  "LEX_WORKSPACE_ROOT",
+  "LEX_APP_ROOT",
+] as const);
+
+export interface TrustedProcessCaptureV1 {
+  readonly argv: readonly string[];
+  readonly cwd: string;
+  readonly environment: Readonly<Record<string, string | undefined>>;
+  readonly platform: NodeJS.Platform;
+  readonly installationRef: string;
+  readonly capturedAt: string;
+}
+
+export interface RuntimeScopeDiscoveryV1 {
+  readonly schemaVersion: typeof TRUSTED_RUNTIME_BOOTSTRAP_VERSION;
+  readonly projectRoot: string;
+  readonly authenticationRef: AuthenticationRef;
+  readonly requestedWorkspace: WorkspaceSelectorV1;
+  readonly repositoryDeclaration?: RepositoryDeclarationV1;
+  readonly repositoryEvidence: RepositoryInstanceEvidenceV1;
+  readonly authorityMode: RuntimeAuthorityMode;
+  readonly authoritySource: string;
+  readonly authorityCacheExpiresAt: string;
+  readonly sourceRevision?: SourceRevisionEvidenceV1;
+}
+
+export interface RuntimeScopeDiscoveryAdapterV1 {
+  discover(request: {
+    readonly entrypoint: TrustedRuntimeEntrypoint;
+    readonly bootstrap: BootstrapInputSnapshotV1;
+  }): Promise<RuntimeScopeDiscoveryV1>;
+}
+
+export interface RuntimeScopeRegistryHandleV1 {
+  readonly registry: LocalBindingRegistry;
+  close(): void;
+}
+
+export interface RuntimeScopeRegistryFactoryV1 {
+  openReadOnly(options: OpenLocalRegistryOptionsV1): RuntimeScopeRegistryHandleV1;
+}
+
+export interface TrustedRuntimeScopeBootstrapDependenciesV1 {
+  readonly authorityDirectory: AuthorityDirectory;
+  readonly discovery: RuntimeScopeDiscoveryAdapterV1;
+  readonly registryFactory?: RuntimeScopeRegistryFactoryV1;
+}
+
+export interface TrustedRuntimeScopeBootstrapRequestV1 {
+  readonly schemaVersion: typeof TRUSTED_RUNTIME_BOOTSTRAP_VERSION;
+  readonly entrypoint: TrustedRuntimeEntrypoint;
+  readonly bootstrap: BootstrapInputSnapshotV1;
+  readonly runtimeId: RuntimeId;
+  readonly traceId: TraceId;
+  readonly requestedCapabilities: readonly CapabilityId[];
+  readonly diagnosticRequest?: DiagnosticRequestV1;
+}
+
+export type TrustedRuntimeScopeBootstrapResultV1 =
+  | {
+      readonly resolved: true;
+      readonly invocationContext: Extract<
+        RuntimeScopeResolutionResultV1,
+        { readonly resolved: true }
+      >["invocationContext"];
+      readonly authorizedScope: Extract<
+        RuntimeScopeResolutionResultV1,
+        { readonly resolved: true }
+      >["authorizedScope"];
+      readonly diagnostics?: DiagnosticEnvelopeV1;
+    }
+  | {
+      readonly resolved: false;
+      readonly error: RuntimeScopeResolutionErrorV1;
+      readonly diagnostics?: DiagnosticEnvelopeV1;
+    };
+
+export interface TrustedRuntimeScopeBootstrapV1 {
+  resolve(
+    request: TrustedRuntimeScopeBootstrapRequestV1
+  ): Promise<TrustedRuntimeScopeBootstrapResultV1>;
+}
+
+export type TrustedRuntimeScopeInvocationRequestV1 = Omit<
+  TrustedRuntimeScopeBootstrapRequestV1,
+  "entrypoint" | "requestedCapabilities" | "diagnosticRequest"
+>;
+
+/** Shared integration seam consumed by both the CLI runner and MCP server. */
+export interface TrustedRuntimeScopeEntrypointGuardV1 {
+  readonly bootstrap: TrustedRuntimeScopeBootstrapV1;
+  readonly request: TrustedRuntimeScopeInvocationRequestV1;
+}
+
+export function authorizeTrustedRuntimeEntrypoint(
+  guard: TrustedRuntimeScopeEntrypointGuardV1,
+  entrypoint: TrustedRuntimeEntrypoint,
+  requestedCapabilities: readonly CapabilityId[],
+  diagnosticRequest?: DiagnosticRequestV1
+): Promise<TrustedRuntimeScopeBootstrapResultV1> {
+  return guard.bootstrap.resolve({
+    ...guard.request,
+    entrypoint,
+    requestedCapabilities: Object.freeze([...requestedCapabilities]),
+    ...(diagnosticRequest ? { diagnosticRequest } : {}),
+  });
+}
+
+function requireNonEmpty(value: string, name: string): string {
+  if (value.trim().length === 0) throw new TypeError(`${name} cannot be empty.`);
+  return value;
+}
+
+function timestamp(value: string, name: string): string {
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new TypeError(`${name} must be an ISO-compatible timestamp.`);
+  }
+  return value;
+}
+
+function normalizeDiscovery(value: RuntimeScopeDiscoveryV1): RuntimeScopeDiscoveryV1 {
+  if (
+    value.schemaVersion !== TRUSTED_RUNTIME_BOOTSTRAP_VERSION ||
+    (value.authorityMode !== "shared" && value.authorityMode !== "local-offline")
+  ) {
+    throw new TypeError("Unsupported runtime discovery contract.");
+  }
+  const requestedWorkspace: WorkspaceSelectorV1 =
+    "workspaceId" in value.requestedWorkspace
+      ? Object.freeze({ workspaceId: value.requestedWorkspace.workspaceId })
+      : Object.freeze({
+          tenant:
+            "tenantId" in value.requestedWorkspace.tenant
+              ? Object.freeze({ tenantId: value.requestedWorkspace.tenant.tenantId })
+              : Object.freeze({ tenantSlug: value.requestedWorkspace.tenant.tenantSlug }),
+          workspaceSlug: value.requestedWorkspace.workspaceSlug,
+        });
+  const repositoryDeclaration = value.repositoryDeclaration
+    ? Object.freeze({
+        schemaVersion: value.repositoryDeclaration.schemaVersion,
+        repositoryId: value.repositoryDeclaration.repositoryId,
+        repositorySlug: value.repositoryDeclaration.repositorySlug,
+        ...(value.repositoryDeclaration.preferredWorkspace
+          ? {
+              preferredWorkspace: Object.freeze({
+                ...(value.repositoryDeclaration.preferredWorkspace.tenantSlug
+                  ? { tenantSlug: value.repositoryDeclaration.preferredWorkspace.tenantSlug }
+                  : {}),
+                workspaceSlug: value.repositoryDeclaration.preferredWorkspace.workspaceSlug,
+              }),
+            }
+          : {}),
+      })
+    : undefined;
+  const repositoryEvidence = Object.freeze({
+    ...value.repositoryEvidence,
+    ...(value.repositoryEvidence.provider
+      ? { provider: Object.freeze({ ...value.repositoryEvidence.provider }) }
+      : {}),
+  });
+  return Object.freeze({
+    schemaVersion: TRUSTED_RUNTIME_BOOTSTRAP_VERSION,
+    projectRoot: requireNonEmpty(value.projectRoot, "projectRoot"),
+    authenticationRef: requireNonEmpty(
+      value.authenticationRef,
+      "authenticationRef"
+    ) as AuthenticationRef,
+    requestedWorkspace,
+    ...(repositoryDeclaration ? { repositoryDeclaration } : {}),
+    repositoryEvidence,
+    authorityMode: value.authorityMode,
+    authoritySource: requireNonEmpty(value.authoritySource, "authoritySource"),
+    authorityCacheExpiresAt: timestamp(value.authorityCacheExpiresAt, "authorityCacheExpiresAt"),
+    ...(value.sourceRevision ? { sourceRevision: Object.freeze({ ...value.sourceRevision }) } : {}),
+  });
+}
+
+function allowedEnvironment(
+  environment: Readonly<Record<string, string | undefined>>
+): Readonly<Record<string, string | undefined>> {
+  const captured: Record<string, string> = {};
+  for (const key of RUNTIME_SCOPE_COMPATIBILITY_ENVIRONMENT) {
+    const value = environment[key];
+    if (value !== undefined && value.trim().length > 0) captured[key] = value;
+  }
+  return Object.freeze(captured);
+}
+
+function normalizeBootstrapSnapshot(value: BootstrapInputSnapshotV1): BootstrapInputSnapshotV1 {
+  if (
+    value.schemaVersion !== RUNTIME_SCOPE_IMPLEMENTATION_VERSION ||
+    value.executionSurface.schemaVersion !== LOCAL_BINDING_CONTRACT_VERSION
+  ) {
+    throw new TypeError("Unsupported trusted runtime bootstrap contract version.");
+  }
+  const executionSurface = Object.freeze({ ...value.executionSurface });
+  return Object.freeze({
+    schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+    cwd: normalizeExecutionSurfacePath(value.cwd, executionSurface, "cwd"),
+    argv: Object.freeze(value.argv.map((argument) => requireNonEmpty(argument, "argv value"))),
+    allowedEnvironment: allowedEnvironment(value.allowedEnvironment),
+    platform: value.platform,
+    executionSurface,
+    capturedAt: timestamp(value.capturedAt, "capturedAt"),
+  });
+}
+
+/**
+ * Capture and freeze process facts once at a CLI or MCP trust boundary.
+ *
+ * The caller supplies the process-like values explicitly so tests and embedders
+ * do not need to mutate globals. No value outside the compatibility allow-list
+ * survives this boundary.
+ */
+export function captureTrustedBootstrapInput(
+  input: TrustedProcessCaptureV1
+): BootstrapInputSnapshotV1 {
+  const environment = allowedEnvironment(input.environment);
+  const executionSurface = detectExecutionSurface({
+    platform: input.platform,
+    installationRef: requireNonEmpty(input.installationRef, "installationRef"),
+    wslDistribution: environment.WSL_DISTRO_NAME,
+    launchOrigin:
+      input.platform === "win32" && environment.WSL_INTEROP ? "wsl-interop" : "native-shell",
+  });
+  const cwd = normalizeExecutionSurfacePath(input.cwd, executionSurface, "cwd");
+
+  return Object.freeze({
+    schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+    cwd,
+    argv: Object.freeze([...input.argv]),
+    allowedEnvironment: environment,
+    platform: input.platform,
+    executionSurface,
+    capturedAt: timestamp(input.capturedAt, "capturedAt"),
+  });
+}
+
+/** Resolve the surface-local registry only from the frozen compatibility snapshot. */
+export function registryLocationFromBootstrap(
+  bootstrap: BootstrapInputSnapshotV1
+): ResolvedRegistryLocationV1 {
+  if (bootstrap.schemaVersion !== RUNTIME_SCOPE_IMPLEMENTATION_VERSION) {
+    throw new TypeError(`Unsupported bootstrap schema: ${String(bootstrap.schemaVersion)}.`);
+  }
+  const environment = bootstrap.allowedEnvironment;
+  return resolveLocalRegistryLocation({
+    executionSurface: bootstrap.executionSurface,
+    homeDirectory: environment.HOME ?? environment.USERPROFILE,
+    localAppDataDirectory: environment.LOCALAPPDATA,
+    xdgStateDirectory: environment.XDG_STATE_HOME,
+  });
+}
+
+function defaultRegistryFactory(): RuntimeScopeRegistryFactoryV1 {
+  return Object.freeze({
+    openReadOnly(options: OpenLocalRegistryOptionsV1): RuntimeScopeRegistryHandleV1 {
+      const registry = SqliteLocalBindingRegistry.open({ ...options, access: "read-only" });
+      return Object.freeze({
+        registry,
+        close: () => registry.close(),
+      });
+    },
+  });
+}
+
+function digest(value: string): ContentDigest {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}` as ContentDigest;
+}
+
+function reference(value: string): string {
+  return digest(value).slice(0, 23);
+}
+
+function stableResolutionDigest(
+  request: TrustedRuntimeScopeBootstrapRequestV1,
+  discovery: RuntimeScopeDiscoveryV1 | null,
+  resolution: RuntimeScopeResolutionResultV1
+): ContentDigest {
+  const payload = resolution.resolved
+    ? {
+        entrypoint: request.entrypoint,
+        result: "resolved",
+        tenantId: resolution.authorizedScope.tenantId,
+        workspaceId: resolution.authorizedScope.workspaceId,
+        principalId: resolution.authorizedScope.principalId,
+        capabilities: [...resolution.authorizedScope.capabilities].sort(),
+        authorityDigest: resolution.authorizedScope.authorityDigest,
+        repositoryId: resolution.invocationContext.binding?.repositoryId ?? null,
+        authorityMode: discovery?.authorityMode ?? null,
+      }
+    : {
+        entrypoint: request.entrypoint,
+        result: "rejected",
+        code: resolution.error.code,
+        authorityMode: discovery?.authorityMode ?? null,
+      };
+  return digest(JSON.stringify(payload));
+}
+
+function requestedSections(request: DiagnosticRequestV1): ReadonlySet<DiagnosticSection> {
+  return new Set(
+    request.sections ?? ["configuration", "authority", "selection", "binding", "projection"]
+  );
+}
+
+async function fullDiagnosticsAreAuthorized(
+  authorityDirectory: AuthorityDirectory,
+  resolution: RuntimeScopeResolutionResultV1
+): Promise<boolean> {
+  if (!resolution.resolved) return false;
+  let decision: WorkspaceAuthorizationDecisionV1;
+  try {
+    decision = await authorityDirectory.authorizeWorkspace({
+      principalId: resolution.authorizedScope.principalId,
+      workspace: { workspaceId: resolution.authorizedScope.workspaceId },
+      requestedCapabilities: [RUNTIME_DIAGNOSTIC_CAPABILITY],
+    });
+  } catch {
+    return false;
+  }
+  return (
+    decision.authorized &&
+    decision.grant.tenantId === resolution.authorizedScope.tenantId &&
+    decision.grant.workspaceId === resolution.authorizedScope.workspaceId &&
+    decision.grant.principalId === resolution.authorizedScope.principalId &&
+    decision.grant.capabilities.includes(RUNTIME_DIAGNOSTIC_CAPABILITY)
+  );
+}
+
+async function diagnosticEnvelope(
+  request: TrustedRuntimeScopeBootstrapRequestV1,
+  discovery: RuntimeScopeDiscoveryV1 | null,
+  resolution: RuntimeScopeResolutionResultV1,
+  authorityDirectory: AuthorityDirectory
+): Promise<DiagnosticEnvelopeV1 | undefined> {
+  const diagnosticRequest = request.diagnosticRequest;
+  if (!diagnosticRequest) return undefined;
+  if (diagnosticRequest.schemaVersion !== DIAGNOSTIC_CONTRACT_VERSION) {
+    return undefined;
+  }
+
+  const sections = requestedSections(diagnosticRequest);
+  const mayViewFull =
+    diagnosticRequest.level === "full" &&
+    (await fullDiagnosticsAreAuthorized(authorityDirectory, resolution));
+  const binding = resolution.resolved ? resolution.invocationContext.binding : undefined;
+  const redactions = [];
+  if (diagnosticRequest.level === "full" && !mayViewFull) {
+    redactions.push(
+      Object.freeze({
+        field: "authority",
+        reason: "capability-required" as const,
+      }),
+      Object.freeze({
+        field: "binding",
+        reason: "capability-required" as const,
+      })
+    );
+  }
+  redactions.push(
+    Object.freeze({ field: "authenticationRef", reason: "secret" as const }),
+    Object.freeze({ field: "projectRoot", reason: "topology" as const })
+  );
+
+  return Object.freeze({
+    schemaVersion: DIAGNOSTIC_CONTRACT_VERSION,
+    runtimeId: request.runtimeId,
+    traceId: request.traceId,
+    resolutionDigest: stableResolutionDigest(request, discovery, resolution),
+    decisions: Object.freeze([
+      resolution.resolved
+        ? Object.freeze({
+            code: "LEX_RUNTIME_SCOPE_RESOLVED",
+            outcome: "accepted" as const,
+            summary: "Trusted runtime scope resolved without changing registry state.",
+          })
+        : Object.freeze({
+            code: resolution.error.code,
+            outcome: "rejected" as const,
+            summary: resolution.error.message,
+          }),
+    ]),
+    warnings: Object.freeze(
+      discovery?.authorityMode === "local-offline"
+        ? [
+            Object.freeze({
+              code: "LEX_LOCAL_OFFLINE_AUTHORITY",
+              summary:
+                "Authority is bounded to this local execution surface and expiring cache evidence.",
+            }),
+          ]
+        : []
+    ),
+    redactions: Object.freeze(redactions),
+    ...(mayViewFull && resolution.resolved && discovery && sections.has("authority")
+      ? {
+          authority: Object.freeze({
+            authoritySource: reference(discovery.authoritySource),
+            authorityVersion: resolution.authorizedScope.authorityVersion,
+            principalRef: reference(resolution.authorizedScope.principalId),
+            tenantRef: reference(resolution.authorizedScope.tenantId),
+            workspaceRef: reference(resolution.authorizedScope.workspaceId),
+            capabilities: Object.freeze([...resolution.authorizedScope.capabilities].sort()),
+          }),
+        }
+      : {}),
+    ...(mayViewFull && binding && sections.has("binding")
+      ? {
+          binding: Object.freeze({
+            bindingRef: reference(binding.bindingId),
+            registryRef: reference(binding.registryInstanceId),
+            executionSurfaceRef: reference(binding.executionSurfaceId),
+            verification: "verified",
+            evidenceRefs: Object.freeze([
+              reference(binding.evidence.manifestDigest ?? "manifest:none"),
+              reference(binding.evidence.gitCommonDirectoryDigest ?? "git-common:none"),
+              reference(binding.evidence.filesystemEvidenceDigest ?? "filesystem:none"),
+            ]),
+          }),
+        }
+      : {}),
+    ...(mayViewFull && resolution.resolved && sections.has("selection")
+      ? {
+          selection: Object.freeze({
+            requestedRef: reference(JSON.stringify(discovery?.requestedWorkspace ?? {})),
+            selectedRef: reference(resolution.authorizedScope.workspaceId),
+            decisions: Object.freeze(["canonical-authority", "verified-local-binding"]),
+          }),
+        }
+      : {}),
+  });
+}
+
+function rejectedBootstrap(error: unknown): RuntimeScopeResolutionResultV1 {
+  return runtimeScopeFailureFromRegistryError(error);
+}
+
+/**
+ * Build the common CLI/MCP bootstrap. Normal resolution always opens the local
+ * registry read-only and closes the handle before returning. Discovery and
+ * canonical authority are injected; neither can be synthesized from env/cwd.
+ */
+export function createTrustedRuntimeScopeBootstrap(
+  dependencies: TrustedRuntimeScopeBootstrapDependenciesV1
+): TrustedRuntimeScopeBootstrapV1 {
+  const registryFactory = dependencies.registryFactory ?? defaultRegistryFactory();
+
+  return Object.freeze({
+    async resolve(
+      request: TrustedRuntimeScopeBootstrapRequestV1
+    ): Promise<TrustedRuntimeScopeBootstrapResultV1> {
+      let discovery: RuntimeScopeDiscoveryV1 | null = null;
+      let resolution: RuntimeScopeResolutionResultV1;
+      let handle: RuntimeScopeRegistryHandleV1 | null = null;
+
+      try {
+        if (request.schemaVersion !== TRUSTED_RUNTIME_BOOTSTRAP_VERSION) {
+          throw new TypeError("Unsupported trusted runtime bootstrap contract version.");
+        }
+        const bootstrap = normalizeBootstrapSnapshot(request.bootstrap);
+        requireNonEmpty(request.runtimeId, "runtimeId");
+        requireNonEmpty(request.traceId, "traceId");
+        discovery = normalizeDiscovery(
+          await dependencies.discovery.discover({
+            entrypoint: request.entrypoint,
+            bootstrap,
+          })
+        );
+        const registryLocation = registryLocationFromBootstrap(bootstrap);
+        handle = registryFactory.openReadOnly({
+          databasePath: registryLocation.registryPath,
+          executionSurface: bootstrap.executionSurface,
+          access: "read-only",
+        });
+        resolution = await resolveRuntimeScope(
+          {
+            schemaVersion: RUNTIME_SCOPE_IMPLEMENTATION_VERSION,
+            bootstrap,
+            projectRoot: discovery.projectRoot,
+            authenticationRef: discovery.authenticationRef,
+            requestedWorkspace: discovery.requestedWorkspace,
+            requestedCapabilities: Object.freeze([...request.requestedCapabilities]),
+            ...(discovery.repositoryDeclaration
+              ? { repositoryDeclaration: discovery.repositoryDeclaration }
+              : {}),
+            repositoryEvidence: discovery.repositoryEvidence,
+            runtimeSurface: {
+              schemaVersion: LOCAL_BINDING_CONTRACT_VERSION,
+              registryInstanceId: handle.registry.registryInstanceId,
+              executionSurfaceId: handle.registry.executionSurfaceId,
+              runtimeId: request.runtimeId,
+            },
+            authoritySource: requireNonEmpty(discovery.authoritySource, "authoritySource"),
+            authorityCacheExpiresAt: timestamp(
+              discovery.authorityCacheExpiresAt,
+              "authorityCacheExpiresAt"
+            ),
+            ...(discovery.sourceRevision ? { sourceRevision: discovery.sourceRevision } : {}),
+          },
+          {
+            authorityDirectory: dependencies.authorityDirectory,
+            localRegistry: handle.registry,
+          }
+        );
+      } catch (error) {
+        resolution = rejectedBootstrap(error);
+      } finally {
+        try {
+          handle?.close();
+        } catch (error) {
+          resolution = rejectedBootstrap(error);
+        }
+      }
+
+      const diagnostics = await diagnosticEnvelope(
+        request,
+        discovery,
+        resolution,
+        dependencies.authorityDirectory
+      );
+      return resolution.resolved
+        ? Object.freeze({
+            resolved: true,
+            invocationContext: resolution.invocationContext,
+            authorizedScope: resolution.authorizedScope,
+            ...(diagnostics ? { diagnostics } : {}),
+          })
+        : Object.freeze({
+            resolved: false,
+            error: resolution.error,
+            ...(diagnostics ? { diagnostics } : {}),
+          });
+    },
+  });
+}

--- a/src/shared/runtime-scope/index.ts
+++ b/src/shared/runtime-scope/index.ts
@@ -175,6 +175,29 @@ export {
 } from "./resolver.js";
 
 export {
+  TRUSTED_RUNTIME_BOOTSTRAP_VERSION,
+  RUNTIME_DIAGNOSTIC_CAPABILITY,
+  RUNTIME_SCOPE_COMPATIBILITY_ENVIRONMENT,
+  captureTrustedBootstrapInput,
+  registryLocationFromBootstrap,
+  createTrustedRuntimeScopeBootstrap,
+  authorizeTrustedRuntimeEntrypoint,
+  type TrustedRuntimeEntrypoint,
+  type RuntimeAuthorityMode,
+  type TrustedProcessCaptureV1,
+  type RuntimeScopeDiscoveryV1,
+  type RuntimeScopeDiscoveryAdapterV1,
+  type RuntimeScopeRegistryHandleV1,
+  type RuntimeScopeRegistryFactoryV1,
+  type TrustedRuntimeScopeBootstrapDependenciesV1,
+  type TrustedRuntimeScopeBootstrapRequestV1,
+  type TrustedRuntimeScopeBootstrapResultV1,
+  type TrustedRuntimeScopeBootstrapV1,
+  type TrustedRuntimeScopeInvocationRequestV1,
+  type TrustedRuntimeScopeEntrypointGuardV1,
+} from "./bootstrap.js";
+
+export {
   WORKSPACE_AUTHORITY_ERROR_CODES,
   type WorkspaceAuthorityErrorCode,
 } from "../errors/error-codes.js";

--- a/test/shared/runtime-scope/bootstrap.test.ts
+++ b/test/shared/runtime-scope/bootstrap.test.ts
@@ -1,0 +1,444 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+
+import {
+  InMemoryAuthorityDirectory,
+  RUNTIME_DIAGNOSTIC_CAPABILITY,
+  SqliteLocalBindingRegistry,
+  WORKSPACE_AUTHORITY_ERROR_CODES,
+  captureTrustedBootstrapInput,
+  createTrustedRuntimeScopeBootstrap,
+  registryLocationFromBootstrap,
+  type AuthenticationRef,
+  type AuthorityGrantId,
+  type AuthorityVersion,
+  type BindingId,
+  type BindingReceiptId,
+  type CapabilityId,
+  type ContentDigest,
+  type ExecutionSurfaceId,
+  type InMemoryAuthoritySeedV1,
+  type LocalRegistryIdFactoryV1,
+  type PrincipalId,
+  type RegistryInstanceId,
+  type RepositoryDeclarationV1,
+  type RepositoryId,
+  type RepositoryInstanceEvidenceV1,
+  type RepositoryInstanceId,
+  type RepositorySlug,
+  type RuntimeId,
+  type RuntimeScopeDiscoveryAdapterV1,
+  type ScopeVersion,
+  type TenantId,
+  type TenantSlug,
+  type TraceId,
+  type TrustedRuntimeEntrypoint,
+  type WorkspaceId,
+  type WorkspaceInstanceId,
+  type WorkspaceSlug,
+} from "../../../src/shared/runtime-scope/index.js";
+
+const NOW = "2026-07-18T12:00:00.000Z";
+const CACHE_EXPIRES = "2026-07-18T12:30:00.000Z";
+const GRANT_EXPIRES = "2026-07-18T13:00:00.000Z";
+const AUTHENTICATION_REF = "auth:guff" as AuthenticationRef;
+const PRINCIPAL_ID = "principal-guff" as PrincipalId;
+const TENANT_ID = "tenant-platform" as TenantId;
+const TENANT_SLUG = "platform-dogfood" as TenantSlug;
+const WORKSPACE_ID = "workspace-lex" as WorkspaceId;
+const WORKSPACE_SLUG = "lex" as WorkspaceSlug;
+const REPOSITORY_ID = "repository-lex" as RepositoryId;
+const REPOSITORY_SLUG = "lex" as RepositorySlug;
+const FRAME_READ = "frame:read" as CapabilityId;
+
+const declaration: RepositoryDeclarationV1 = {
+  schemaVersion: 1,
+  repositoryId: REPOSITORY_ID,
+  repositorySlug: REPOSITORY_SLUG,
+};
+
+function repositoryEvidence(projectRoot: string): RepositoryInstanceEvidenceV1 {
+  return {
+    schemaVersion: 1,
+    canonicalRoot: projectRoot,
+    manifestDigest: "sha256:manifest" as ContentDigest,
+    gitCommonDirectoryDigest: "sha256:git-common" as ContentDigest,
+    filesystemEvidenceDigest: "sha256:filesystem" as ContentDigest,
+    provider: {
+      provider: "github",
+      providerRepositoryId: "Guffawaffle/lex",
+      remoteDigest: "sha256:remote" as ContentDigest,
+    },
+  };
+}
+
+function authoritySeed(capabilities: readonly CapabilityId[]): InMemoryAuthoritySeedV1 {
+  return {
+    principals: [
+      {
+        schemaVersion: 1,
+        principalId: PRINCIPAL_ID,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    tenants: [
+      {
+        schemaVersion: 1,
+        tenantId: TENANT_ID,
+        tenantSlug: TENANT_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    workspaces: [
+      {
+        schemaVersion: 1,
+        workspaceId: WORKSPACE_ID,
+        tenantId: TENANT_ID,
+        workspaceSlug: WORKSPACE_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    repositories: [
+      {
+        schemaVersion: 1,
+        repositoryId: REPOSITORY_ID,
+        repositorySlug: REPOSITORY_SLUG,
+        state: "active",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+      },
+    ],
+    authentication: [{ authenticationRef: AUTHENTICATION_REF, principalId: PRINCIPAL_ID }],
+    grants: [
+      {
+        grant: {
+          schemaVersion: 1,
+          grantId: "grant-lex" as AuthorityGrantId,
+          tenantId: TENANT_ID,
+          workspaceId: WORKSPACE_ID,
+          principalId: PRINCIPAL_ID,
+          capabilities,
+          authorityVersion: "authority-v1" as AuthorityVersion,
+          scopeVersion: "scope-v1" as ScopeVersion,
+          authorityDigest: "sha256:authority" as ContentDigest,
+          verifiedAt: NOW,
+          expiresAt: GRANT_EXPIRES,
+        },
+      },
+    ],
+  };
+}
+
+function deterministicIds(): LocalRegistryIdFactoryV1 {
+  return {
+    bindingId: () => "binding-1" as BindingId,
+    receiptId: () => "receipt-1" as BindingReceiptId,
+  };
+}
+
+interface BootstrapFixture {
+  readonly root: string;
+  readonly projectRoot: string;
+  readonly bootstrap: ReturnType<typeof captureTrustedBootstrapInput>;
+  readonly databasePath: string;
+  readonly registryInstanceId: RegistryInstanceId;
+  readonly executionSurfaceId: ExecutionSurfaceId;
+  readonly discoveryEntrypoints: TrustedRuntimeEntrypoint[];
+  readonly discovery: RuntimeScopeDiscoveryAdapterV1;
+  close(): void;
+}
+
+async function createFixture(options: { register?: boolean } = {}): Promise<BootstrapFixture> {
+  const root = mkdtempSync(join(tmpdir(), "lex-trusted-bootstrap-"));
+  const projectRoot = join(root, "repo");
+  mkdirSync(projectRoot, { recursive: true });
+  const bootstrap = captureTrustedBootstrapInput({
+    argv: ["node", "lex", "recall"],
+    cwd: projectRoot,
+    environment: {
+      HOME: root,
+      XDG_STATE_HOME: join(root, "state"),
+      LEX_WORKSPACE_ROOT: projectRoot,
+      LEX_REGISTRY_PATH: join(root, "forbidden-registry.db"),
+      LEX_DATABASE_URL: "postgresql://secret",
+    },
+    platform: "linux",
+    installationRef: "/usr/local/bin/node",
+    capturedAt: NOW,
+  });
+  const databasePath = registryLocationFromBootstrap(bootstrap).registryPath;
+  const registryInstanceId = "registry-linux" as RegistryInstanceId;
+  const executionSurfaceId = "surface-linux" as ExecutionSurfaceId;
+  const registry = SqliteLocalBindingRegistry.initialize({
+    databasePath,
+    registryInstanceId,
+    executionSurfaceId,
+    executionSurface: bootstrap.executionSurface,
+    createdAt: NOW,
+    now: () => NOW,
+    idFactory: deterministicIds(),
+  });
+  if (options.register !== false) {
+    await registry.registerBinding({
+      tenantId: TENANT_ID,
+      workspaceId: WORKSPACE_ID,
+      repositoryId: REPOSITORY_ID,
+      repositoryInstanceId: "repository-instance-linux" as RepositoryInstanceId,
+      workspaceInstanceId: "workspace-instance-linux" as WorkspaceInstanceId,
+      evidence: repositoryEvidence(projectRoot),
+      authorityEvidence: {
+        schemaVersion: 1,
+        authoritySource: "authority:test",
+        authorityVersion: "authority-v1" as AuthorityVersion,
+        authorityDigest: "sha256:authority" as ContentDigest,
+        verifiedAt: NOW,
+        expiresAt: CACHE_EXPIRES,
+      },
+      registeredByPrincipalId: PRINCIPAL_ID,
+    });
+  }
+  registry.close();
+
+  const discoveryEntrypoints: TrustedRuntimeEntrypoint[] = [];
+  const discovery: RuntimeScopeDiscoveryAdapterV1 = {
+    async discover(request) {
+      discoveryEntrypoints.push(request.entrypoint);
+      return {
+        schemaVersion: 1,
+        projectRoot,
+        authenticationRef: AUTHENTICATION_REF,
+        requestedWorkspace: { workspaceId: WORKSPACE_ID },
+        repositoryDeclaration: declaration,
+        repositoryEvidence: repositoryEvidence(projectRoot),
+        authorityMode: "shared",
+        authoritySource: "authority:test",
+        authorityCacheExpiresAt: CACHE_EXPIRES,
+      };
+    },
+  };
+
+  return {
+    root,
+    projectRoot,
+    bootstrap,
+    databasePath,
+    registryInstanceId,
+    executionSurfaceId,
+    discoveryEntrypoints,
+    discovery,
+    close: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function request(
+  fixture: BootstrapFixture,
+  entrypoint: TrustedRuntimeEntrypoint,
+  diagnosticRequest?: { readonly schemaVersion: 1; readonly level: "summary" | "full" }
+) {
+  return {
+    schemaVersion: 1 as const,
+    entrypoint,
+    bootstrap: fixture.bootstrap,
+    runtimeId: "runtime-1" as RuntimeId,
+    traceId: "trace-1" as TraceId,
+    requestedCapabilities: [FRAME_READ],
+    ...(diagnosticRequest ? { diagnosticRequest } : {}),
+  };
+}
+
+describe("trusted runtime-scope bootstrap", () => {
+  test("captures one deeply immutable allow-listed snapshot", () => {
+    const environment: Record<string, string> = {
+      HOME: "/home/guff",
+      XDG_STATE_HOME: "/home/guff/.state",
+      LEX_WORKSPACE_ROOT: "/srv/lex",
+      LEX_REGISTRY_PATH: "/tmp/authority-substitution.db",
+      LEX_DATABASE_URL: "postgresql://secret",
+    };
+    const argv = ["node", "lex", "recall"];
+    const bootstrap = captureTrustedBootstrapInput({
+      argv,
+      cwd: "/srv/lex",
+      environment,
+      platform: "linux",
+      installationRef: "/usr/bin/node",
+      capturedAt: NOW,
+    });
+
+    argv.push("--later");
+    environment.HOME = "/changed";
+    assert.deepEqual(bootstrap.argv, ["node", "lex", "recall"]);
+    assert.equal(bootstrap.allowedEnvironment.HOME, "/home/guff");
+    assert.equal("LEX_REGISTRY_PATH" in bootstrap.allowedEnvironment, false);
+    assert.equal("LEX_DATABASE_URL" in bootstrap.allowedEnvironment, false);
+    assert.equal(Object.isFrozen(bootstrap), true);
+    assert.equal(Object.isFrozen(bootstrap.argv), true);
+    assert.equal(Object.isFrozen(bootstrap.allowedEnvironment), true);
+    assert.equal(Object.isFrozen(bootstrap.executionSurface), true);
+  });
+
+  test("gives CLI and MCP equivalent attenuated scope without mutating registry state", async () => {
+    const fixture = await createFixture();
+    try {
+      const authority = new InMemoryAuthorityDirectory(
+        authoritySeed([FRAME_READ, RUNTIME_DIAGNOSTIC_CAPABILITY]),
+        () => NOW
+      );
+      const bootstrap = createTrustedRuntimeScopeBootstrap({
+        authorityDirectory: authority,
+        discovery: fixture.discovery,
+      });
+
+      const cli = await bootstrap.resolve(request(fixture, "cli"));
+      const mcp = await bootstrap.resolve(request(fixture, "mcp"));
+      const empty = await bootstrap.resolve({
+        ...request(fixture, "cli"),
+        requestedCapabilities: [],
+      });
+      assert.equal(cli.resolved, true);
+      assert.equal(mcp.resolved, true);
+      assert.equal(empty.resolved, true);
+      if (!cli.resolved || !mcp.resolved || !empty.resolved) return;
+      assert.deepEqual(cli.authorizedScope, mcp.authorizedScope);
+      assert.deepEqual(cli.authorizedScope.capabilities, [FRAME_READ]);
+      assert.deepEqual(empty.authorizedScope.capabilities, []);
+      assert.equal("diagnostics" in cli, false);
+      assert.equal("diagnostics" in mcp, false);
+      assert.deepEqual(fixture.discoveryEntrypoints, ["cli", "mcp", "cli"]);
+
+      const registry = SqliteLocalBindingRegistry.open({
+        databasePath: fixture.databasePath,
+        executionSurface: fixture.bootstrap.executionSurface,
+      });
+      assert.equal((await registry.inspectBindings()).length, 1);
+      assert.equal((await registry.inspectReceipts()).length, 1);
+      registry.close();
+    } finally {
+      fixture.close();
+    }
+  });
+
+  test("keeps full diagnostics opt-in, redacted, and behavior-neutral", async () => {
+    const fixture = await createFixture();
+    try {
+      const withoutDiagnosticGrant = createTrustedRuntimeScopeBootstrap({
+        authorityDirectory: new InMemoryAuthorityDirectory(authoritySeed([FRAME_READ]), () => NOW),
+        discovery: fixture.discovery,
+      });
+      const redacted = await withoutDiagnosticGrant.resolve(
+        request(fixture, "cli", { schemaVersion: 1, level: "full" })
+      );
+      assert.equal(redacted.resolved, true);
+      assert.ok(redacted.diagnostics);
+      assert.equal(redacted.diagnostics.authority, undefined);
+      assert.equal(redacted.diagnostics.binding, undefined);
+      assert.ok(
+        redacted.diagnostics.redactions.some(
+          ({ field, reason }) => field === "authority" && reason === "capability-required"
+        )
+      );
+
+      const withDiagnosticGrant = createTrustedRuntimeScopeBootstrap({
+        authorityDirectory: new InMemoryAuthorityDirectory(
+          authoritySeed([FRAME_READ, RUNTIME_DIAGNOSTIC_CAPABILITY]),
+          () => NOW
+        ),
+        discovery: fixture.discovery,
+      });
+      const detailed = await withDiagnosticGrant.resolve(
+        request(fixture, "mcp", { schemaVersion: 1, level: "full" })
+      );
+      assert.equal(detailed.resolved, true);
+      assert.ok(detailed.diagnostics?.authority);
+      assert.ok(detailed.diagnostics.binding);
+      assert.equal(JSON.stringify(detailed.diagnostics).includes(fixture.projectRoot), false);
+      assert.equal(JSON.stringify(detailed.diagnostics).includes(AUTHENTICATION_REF), false);
+      assert.deepEqual(
+        detailed.resolved ? detailed.authorizedScope.capabilities : [],
+        redacted.resolved ? redacted.authorizedScope.capabilities : []
+      );
+    } finally {
+      fixture.close();
+    }
+  });
+
+  test("fails closed without creating a missing local registry", async () => {
+    const fixture = await createFixture();
+    try {
+      rmSync(fixture.databasePath, { force: true });
+      const bootstrap = createTrustedRuntimeScopeBootstrap({
+        authorityDirectory: new InMemoryAuthorityDirectory(authoritySeed([FRAME_READ]), () => NOW),
+        discovery: fixture.discovery,
+      });
+      const result = await bootstrap.resolve(
+        request(fixture, "cli", { schemaVersion: 1, level: "summary" })
+      );
+
+      assert.equal(result.resolved, false);
+      if (result.resolved) return;
+      assert.equal(result.error.code, WORKSPACE_AUTHORITY_ERROR_CODES.WORKSPACE_UNBOUND);
+      assert.equal(result.diagnostics?.decisions[0]?.code, result.error.code);
+      assert.throws(() =>
+        SqliteLocalBindingRegistry.open({
+          databasePath: fixture.databasePath,
+          executionSurface: fixture.bootstrap.executionSurface,
+        })
+      );
+    } finally {
+      fixture.close();
+    }
+  });
+
+  test("marks local-offline authority as bounded and still requires expiring evidence", async () => {
+    const fixture = await createFixture();
+    try {
+      const offlineDiscovery: RuntimeScopeDiscoveryAdapterV1 = {
+        async discover(request) {
+          const discovered = await fixture.discovery.discover(request);
+          return {
+            ...discovered,
+            authorityMode: "local-offline",
+          };
+        },
+      };
+      const bootstrap = createTrustedRuntimeScopeBootstrap({
+        authorityDirectory: new InMemoryAuthorityDirectory(authoritySeed([FRAME_READ]), () => NOW),
+        discovery: offlineDiscovery,
+      });
+      const result = await bootstrap.resolve(
+        request(fixture, "cli", { schemaVersion: 1, level: "summary" })
+      );
+
+      assert.equal(result.resolved, true);
+      assert.equal(result.diagnostics?.warnings[0]?.code, "LEX_LOCAL_OFFLINE_AUTHORITY");
+    } finally {
+      fixture.close();
+    }
+  });
+
+  test("rejects future bootstrap versions before discovery", async () => {
+    const fixture = await createFixture();
+    try {
+      const bootstrap = createTrustedRuntimeScopeBootstrap({
+        authorityDirectory: new InMemoryAuthorityDirectory(authoritySeed([FRAME_READ]), () => NOW),
+        discovery: fixture.discovery,
+      });
+      const result = await bootstrap.resolve({
+        ...request(fixture, "cli"),
+        schemaVersion: 2 as 1,
+      });
+
+      assert.equal(result.resolved, false);
+      if (result.resolved) return;
+      assert.equal(result.error.code, WORKSPACE_AUTHORITY_ERROR_CODES.REPOSITORY_BINDING_MISMATCH);
+      assert.deepEqual(fixture.discoveryEntrypoints, []);
+    } finally {
+      fixture.close();
+    }
+  });
+});

--- a/test/shared/runtime-scope/entrypoints.test.ts
+++ b/test/shared/runtime-scope/entrypoints.test.ts
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { MCPServer } from "../../../src/memory/mcp_server/server.js";
+import { MemoryFrameStore } from "../../../src/memory/store/memory/index.js";
+import { run } from "../../../src/shared/cli/index.js";
+import { AXErrorException } from "../../../src/shared/errors/ax-error.js";
+import {
+  DIAGNOSTIC_CONTRACT_VERSION,
+  type AuthorizedScopeV1,
+  type BootstrapInputSnapshotV1,
+  type CapabilityId,
+  type ContentDigest,
+  type DiagnosticEnvelopeV1,
+  type InvocationContextV1,
+  type RuntimeId,
+  type TraceId,
+  type TrustedRuntimeScopeBootstrapRequestV1,
+  type TrustedRuntimeScopeBootstrapResultV1,
+  type TrustedRuntimeScopeBootstrapV1,
+} from "../../../src/shared/runtime-scope/index.js";
+
+const FRAME_READ = "frame:read" as CapabilityId;
+const FRAME_WRITE = "frame:write" as CapabilityId;
+
+function fakeInvocationContext(): InvocationContextV1 {
+  return {
+    schemaVersion: 1,
+    projectRoot: "/srv/lex",
+    requestedWorkspace: { workspaceId: "workspace-lex" as never },
+    repositoryEvidence: {
+      schemaVersion: 1,
+      canonicalRoot: "/srv/lex",
+    },
+    runtimeSurface: {
+      schemaVersion: 1,
+      executionSurfaceId: "surface-1" as never,
+      registryInstanceId: "registry-1" as never,
+      runtimeId: "runtime-1" as RuntimeId,
+    },
+  };
+}
+
+function fakeAuthorizedScope(capabilities: readonly CapabilityId[]): AuthorizedScopeV1 {
+  return {
+    schemaVersion: 1,
+    grantId: "grant-1" as never,
+    tenantId: "tenant-1" as never,
+    workspaceId: "workspace-lex" as never,
+    principalId: "principal-1" as never,
+    capabilities,
+    authorityVersion: "authority-v1" as never,
+    scopeVersion: "scope-v1" as never,
+    authorityDigest: "sha256:authority" as ContentDigest,
+    verifiedAt: "2026-07-18T12:00:00.000Z",
+  };
+}
+
+function fakeDiagnostics(request: TrustedRuntimeScopeBootstrapRequestV1): DiagnosticEnvelopeV1 {
+  return {
+    schemaVersion: DIAGNOSTIC_CONTRACT_VERSION,
+    runtimeId: request.runtimeId,
+    traceId: request.traceId,
+    resolutionDigest: "sha256:resolution" as ContentDigest,
+    decisions: [
+      {
+        code: "LEX_RUNTIME_SCOPE_RESOLVED",
+        outcome: "accepted",
+        summary: "Resolved.",
+      },
+    ],
+    warnings: [],
+    redactions: [{ field: "projectRoot", reason: "topology" }],
+  };
+}
+
+function successfulBootstrap(seen: TrustedRuntimeScopeBootstrapRequestV1[]) {
+  const bootstrap: TrustedRuntimeScopeBootstrapV1 = {
+    async resolve(request): Promise<TrustedRuntimeScopeBootstrapResultV1> {
+      seen.push(request);
+      return {
+        resolved: true,
+        invocationContext: fakeInvocationContext(),
+        authorizedScope: fakeAuthorizedScope(request.requestedCapabilities),
+        ...(request.diagnosticRequest ? { diagnostics: fakeDiagnostics(request) } : {}),
+      };
+    },
+  };
+  return bootstrap;
+}
+
+function deniedBootstrap(seen: TrustedRuntimeScopeBootstrapRequestV1[]) {
+  const bootstrap: TrustedRuntimeScopeBootstrapV1 = {
+    async resolve(request): Promise<TrustedRuntimeScopeBootstrapResultV1> {
+      seen.push(request);
+      return {
+        resolved: false,
+        error: {
+          code: "LEX_WORKSPACE_UNBOUND",
+          message: "No trusted local workspace binding matched this invocation.",
+        },
+      };
+    },
+  };
+  return bootstrap;
+}
+
+const invocationRequest = {
+  schemaVersion: 1 as const,
+  bootstrap: {
+    schemaVersion: 1,
+    cwd: "/srv/lex",
+    argv: ["node", "lex"],
+    allowedEnvironment: {},
+    platform: "linux",
+    executionSurface: {
+      schemaVersion: 1,
+      nativePlatform: "linux",
+      kind: "linux-native",
+      installationRef: "/usr/bin/node",
+      evidenceDigest: "sha256:surface" as ContentDigest,
+    },
+    capturedAt: "2026-07-18T12:00:00.000Z",
+  } as BootstrapInputSnapshotV1,
+  runtimeId: "runtime-1" as RuntimeId,
+  traceId: "trace-1" as TraceId,
+};
+
+describe("trusted runtime-scope entrypoint guards", () => {
+  test("CLI resolves before dispatch and emits diagnostics only when requested", async () => {
+    const seen: TrustedRuntimeScopeBootstrapRequestV1[] = [];
+    const emitted: DiagnosticEnvelopeV1[] = [];
+    let resolved = false;
+
+    await run(["node", "lex", "--diagnostic", "hints", "--list"], {
+      runtimeScope: {
+        bootstrap: successfulBootstrap(seen),
+        request: invocationRequest,
+        requestedCapabilities: [FRAME_READ],
+        onResolved: () => {
+          resolved = true;
+        },
+        emitDiagnostics: (diagnostics) => {
+          emitted.push(diagnostics);
+        },
+      },
+    });
+
+    assert.equal(resolved, true);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0]?.entrypoint, "cli");
+    assert.deepEqual(seen[0]?.requestedCapabilities, [FRAME_READ]);
+    assert.equal(seen[0]?.diagnosticRequest?.level, "summary");
+    assert.equal(emitted.length, 1);
+  });
+
+  test("CLI denial prevents command dispatch with the stable scope error", async () => {
+    const seen: TrustedRuntimeScopeBootstrapRequestV1[] = [];
+    await assert.rejects(
+      () =>
+        run(["node", "lex", "hints", "--list"], {
+          runtimeScope: {
+            bootstrap: deniedBootstrap(seen),
+            request: invocationRequest,
+            requestedCapabilities: [FRAME_READ],
+            emitDiagnostics: () => {},
+          },
+        }),
+      (error: unknown) =>
+        error instanceof AXErrorException && error.axError.code === "LEX_WORKSPACE_UNBOUND"
+    );
+    assert.equal(seen.length, 1);
+  });
+
+  test("CLI diagnostic controls do not cross the passthrough boundary", async () => {
+    const seen: TrustedRuntimeScopeBootstrapRequestV1[] = [];
+
+    await assert.rejects(
+      () =>
+        run(["node", "lex", "hints", "--", "--diagnostic", "--diagnostic-level=full"], {
+          runtimeScope: {
+            bootstrap: deniedBootstrap(seen),
+            request: invocationRequest,
+            requestedCapabilities: [FRAME_READ],
+            emitDiagnostics: () => {},
+          },
+        }),
+      (error: unknown) =>
+        error instanceof AXErrorException && error.axError.code === "LEX_WORKSPACE_UNBOUND"
+    );
+
+    assert.equal(seen[0]?.diagnosticRequest, undefined);
+  });
+
+  test("MCP resolves per tool call and attaches opt-in diagnostics", async () => {
+    const seen: TrustedRuntimeScopeBootstrapRequestV1[] = [];
+    const server = new MCPServer({
+      frameStore: new MemoryFrameStore(),
+      runtimeScope: {
+        bootstrap: successfulBootstrap(seen),
+        request: invocationRequest,
+        requestedCapabilitiesForTool: (name) =>
+          name === "frame_create" ? [FRAME_WRITE] : [FRAME_READ],
+      },
+    });
+    try {
+      const response = await server.handleRequest({
+        method: "tools/call",
+        params: {
+          name: "frame_list",
+          arguments: { diagnostics: "summary" },
+        },
+      });
+
+      assert.equal(response.error, undefined);
+      assert.ok(response.data?.diagnostics);
+      assert.equal(seen[0]?.entrypoint, "mcp");
+      assert.deepEqual(seen[0]?.requestedCapabilities, [FRAME_READ]);
+      assert.equal(seen[0]?.diagnosticRequest?.level, "summary");
+
+      const tools = await server.handleRequest({ method: "tools/list" });
+      const listed = tools.tools as Array<{
+        name: string;
+        inputSchema: { properties: Record<string, unknown> };
+      }>;
+      assert.ok(listed.every((tool) => "diagnostics" in tool.inputSchema.properties));
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("MCP removes diagnostic controls before public tool validation", async () => {
+    const seen: TrustedRuntimeScopeBootstrapRequestV1[] = [];
+    const server = new MCPServer({
+      frameStore: new MemoryFrameStore(),
+      runtimeScope: {
+        bootstrap: successfulBootstrap(seen),
+        request: invocationRequest,
+        requestedCapabilitiesForTool: () => [FRAME_WRITE],
+      },
+    });
+    try {
+      const response = await server.handleRequest({
+        method: "tools/call",
+        params: {
+          name: "frame_validate",
+          arguments: {
+            diagnostics: "summary",
+            reference_point: "diagnostic-control-boundary",
+            summary_caption: "Diagnostic metadata is not a Frame field",
+            status_snapshot: { next_action: "none" },
+            module_scope: ["runtime-scope"],
+          },
+        },
+      });
+
+      assert.equal(response.error, undefined);
+      assert.ok(response.data?.diagnostics);
+      const validated = response.data?.frame as Record<string, unknown> | undefined;
+      assert.equal(validated?.diagnostics, undefined);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("MCP denial blocks a mutating tool before the store is called", async () => {
+    const seen: TrustedRuntimeScopeBootstrapRequestV1[] = [];
+    const store = new MemoryFrameStore();
+    const server = new MCPServer({
+      frameStore: store,
+      runtimeScope: {
+        bootstrap: deniedBootstrap(seen),
+        request: invocationRequest,
+        requestedCapabilitiesForTool: () => [FRAME_WRITE],
+      },
+    });
+    try {
+      const response = await server.handleRequest({
+        method: "tools/call",
+        params: {
+          name: "frame_create",
+          arguments: {
+            reference_point: "must-not-write",
+            summary_caption: "Denied before dispatch",
+            status_snapshot: { next_action: "none" },
+            module_scope: ["runtime-scope"],
+          },
+        },
+      });
+
+      assert.equal(response.error?.code, "LEX_WORKSPACE_UNBOUND");
+      assert.equal(store.size(), 0);
+      assert.equal(seen.length, 1);
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- capture and freeze one allow-listed process snapshot at the CLI/MCP trust boundary
- resolve only through injected discovery, canonical authority, and the native surface-local registry opened read-only
- attenuate capabilities and fail before command/tool dispatch
- keep normal agent responses compact while exposing explicit, redacted, capability-gated diagnostics
- preserve an explicit bounded local-offline authority mode

## Scope

This is the shared Phase 3 foundation for #758 and intentionally keeps the issue open. A follow-up Attempt will add production repository/native-Git discovery, the administrative binding lifecycle, default CLI/MCP activation and command/tool capability mapping, and thread the resolved scope into the scoped FrameStore from #765.

The coordinator pass also ensures:

- CLI diagnostic controls do not cross the `--` passthrough boundary
- MCP diagnostic controls are stripped before public tool validation/dispatch

## Validation

- focused trusted-bootstrap and entrypoint tests: 12 passed
- `npm run type-check`
- `npm run build`
- ESLint on changed TypeScript files
- Prettier check on every changed file
- `git diff --check`

## LexRunner dogfood evidence

- Attempt: `attempt-758-a1`
- Receipt: `receipt-attempt-758-a1`
- Patch hash: `sha256:3f9088c0f065bff4e4658e449d5e4179b1a3a44e8923f33557d2f70f29d386c1`
- Receipt hash: `sha256:70b82d440aad091e07d043894bf330840b004f10221075cdb73e1b86258d02fd`

Refs #749
