### PR TITLE
Add opt-in developer Prettier audit

### DIFF
--- a/.changeset/optional-prettier-audit.md
+++ b/.changeset/optional-prettier-audit.md
@@ -1,0 +1,6 @@
+---
+"@smartergpt/lex": patch
+---
+
+Add opt-in `--pretty` and `--prettier` aliases to the developer-validation driver for a
+check-only repository-wide Prettier audit while leaving the default validation gate unchanged.

--- a/README.md
+++ b/README.md
@@ -560,9 +560,14 @@ Run CI checks locally without touching GitHub:
 ```bash
 npm run local-ci          # Run full CI suite locally
 npm run local-ci:nonet    # Run without network access
+npm run local-ci -- --pretty       # Add a check-only repository-wide Prettier audit
+npm run local-ci -- --prettier     # Exact alias for --pretty
 ```
 
 This uses `ci.Dockerfile` for local parity with CI checks.
+The formatting audit is opt-in and runs after the required validation sequence. It never rewrites
+files; use the separate `npm run format` command only when formatting mutation is intended. The
+default `npm run ci` gate remains unchanged and does not run a repository-wide Prettier audit.
 
 ### Multi-language policy scanning
 

--- a/docs/dev/sqlite-bindings.md
+++ b/docs/dev/sqlite-bindings.md
@@ -52,6 +52,11 @@ The `scripts/ci.sh` script (used by `npm run local-ci`) automatically:
 2. Runs the health check before tests
 3. Fails fast with clear instructions if bindings are broken
 
+Pass `--pretty` (or its exact `--prettier` alias) through `npm run local-ci --` to add the
+repository-wide `npm run format:check` audit after required validation. This audit is check-only;
+it never invokes `prettier --write` or `npm run format`. Without either flag, the formatting audit
+does not run.
+
 ## Doctrine
 
 **We treat broken SQLite bindings as a failing gate, not a shrug.**

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "ci:minimal": "npm run lint && npm run type-check",
     "ci": "npm run lint && npm run type-check && npm test && npm run build && npm run check:public-api",
     "ci:full": "npm run lint && npm run type-check && npm test && npm run test:integration && npm run build && npm run check:public-api && npm run guard:pack",
-    "local-ci": "npm run ci",
+    "local-ci": "./scripts/local-ci-run.sh",
     "local-ci:nonet": "./scripts/ci-nonet.sh",
     "generate:test-frames": "node scripts/generate-test-frames.mjs",
     "changeset": "changeset",

--- a/scripts/ci-nonet.sh
+++ b/scripts/ci-nonet.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Run ci.sh in the same container image but disable network
-IMAGE="${1:-lex-ci:local}"
+IMAGE="lex-ci:local"
+if [[ $# -gt 0 && "$1" != --* ]]; then
+  IMAGE="$1"
+  shift
+fi
 docker run --rm --network=none \
   --user "$(id -u):$(id -g)" \
   -v "$PWD":/work -w /work \
   "${IMAGE}" \
-  bash -lc "./scripts/ci.sh"
+  ./scripts/ci.sh "$@"

--- a/scripts/ci-options.sh
+++ b/scripts/ci-options.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+LEX_CI_PRETTY=0
+
+lex_ci_usage() {
+  cat >&2 <<'EOF'
+Usage: ./scripts/ci.sh [--pretty|--prettier]
+
+  --pretty    Add a check-only repository-wide Prettier audit.
+  --prettier  Exact alias for --pretty.
+EOF
+}
+
+lex_ci_parse_options() {
+  local option
+  for option in "$@"; do
+    case "$option" in
+      --pretty | --prettier)
+        LEX_CI_PRETTY=1
+        ;;
+      *)
+        echo "Unknown developer-validation option: $option" >&2
+        lex_ci_usage
+        return 2
+        ;;
+    esac
+  done
+}
+
+lex_ci_run_optional_audits() {
+  if [[ "$LEX_CI_PRETTY" -eq 1 ]]; then
+    echo "==> Required validation completed OK"
+    echo "==> Optional repository-wide Prettier audit (check-only)"
+    npm run format:check
+  fi
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/ci-options.sh
+source "$SCRIPT_DIR/ci-options.sh"
+lex_ci_parse_options "$@"
+
 echo "==> Local CI replica starting"
 echo "pwd: $(pwd)"
 node -v
@@ -53,4 +58,5 @@ else
   if npm run | rg -q '^  test(:|$)'; then npm test; fi
 fi
 
+lex_ci_run_optional_audits
 echo "==> Local CI replica completed OK"

--- a/scripts/local-ci-run.sh
+++ b/scripts/local-ci-run.sh
@@ -12,4 +12,4 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   -v "$PWD":/work -w /work \
   "${IMAGE}" \
-  bash -lc "./scripts/ci.sh"
+  ./scripts/ci.sh "$@"

--- a/test/scripts/ci-options.test.mjs
+++ b/test/scripts/ci-options.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+
+function runBash(script, args = [], options = {}) {
+  return spawnSync("bash", ["-c", script, "bash", ...args], {
+    cwd: REPOSITORY_ROOT,
+    encoding: "utf8",
+    ...options,
+  });
+}
+
+const parseAndRun = `
+source ./scripts/ci-options.sh
+lex_ci_parse_options "$@" || exit $?
+npm() { printf 'npm:%s\\n' "$*"; }
+lex_ci_run_optional_audits
+`;
+
+test("default developer validation does not invoke Prettier", () => {
+  const result = runBash(parseAndRun);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+});
+
+test("--pretty and --prettier are exact check-only aliases", () => {
+  for (const alias of ["--pretty", "--prettier"]) {
+    const result = runBash(parseAndRun, [alias]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Required validation completed OK/);
+    assert.match(result.stdout, /Optional repository-wide Prettier audit \(check-only\)/);
+    assert.equal(result.stdout.match(/^npm:run format:check$/gm)?.length, 1);
+    assert.doesNotMatch(result.stdout, /npm:run format$/m);
+    assert.doesNotMatch(result.stdout, /--write/);
+  }
+});
+
+test("both aliases request only one Prettier audit", () => {
+  const result = runBash(parseAndRun, ["--pretty", "--prettier"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.match(/^npm:run format:check$/gm)?.length, 1);
+});
+
+test("unknown developer-validation options fail fast with usage", () => {
+  const result = runBash(parseAndRun, ["--rewrite"]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Unknown developer-validation option: --rewrite/);
+  assert.match(result.stderr, /Usage: \.\/scripts\/ci\.sh \[--pretty\|--prettier\]/);
+  assert.equal(result.stdout, "");
+});
+
+function withFakeDocker(operation) {
+  const root = mkdtempSync(join(tmpdir(), "lex-ci-wrapper-"));
+  const docker = join(root, "docker");
+  const argumentsPath = join(root, "arguments");
+  writeFileSync(
+    docker,
+    `#!/usr/bin/env bash
+if [[ "$1" == "image" ]]; then exit 0; fi
+printf '%s\\0' "$@" > "$LEX_CI_DOCKER_ARGUMENTS"
+`,
+    "utf8"
+  );
+  chmodSync(docker, 0o755);
+  try {
+    operation({
+      argumentsPath,
+      environment: {
+        ...process.env,
+        PATH: `${root}${delimiter}${process.env.PATH}`,
+        LEX_CI_DOCKER_ARGUMENTS: argumentsPath,
+      },
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function recordedArguments(path) {
+  return readFileSync(path, "utf8").split("\0").filter(Boolean);
+}
+
+test("documented Docker wrappers forward validation aliases verbatim", () => {
+  withFakeDocker(({ argumentsPath, environment }) => {
+    const local = spawnSync("bash", ["./scripts/local-ci-run.sh", "--pretty", "--prettier"], {
+      cwd: REPOSITORY_ROOT,
+      env: environment,
+      encoding: "utf8",
+    });
+    assert.equal(local.status, 0, local.stderr);
+    assert.deepEqual(recordedArguments(argumentsPath).slice(-3), [
+      "./scripts/ci.sh",
+      "--pretty",
+      "--prettier",
+    ]);
+
+    const nonet = spawnSync("bash", ["./scripts/ci-nonet.sh", "lex-ci:test", "--prettier"], {
+      cwd: REPOSITORY_ROOT,
+      env: environment,
+      encoding: "utf8",
+    });
+    assert.equal(nonet.status, 0, nonet.stderr);
+    const nonetArguments = recordedArguments(argumentsPath);
+    assert.ok(nonetArguments.includes("lex-ci:test"));
+    assert.deepEqual(nonetArguments.slice(-2), ["./scripts/ci.sh", "--prettier"]);
+  });
+});
+
+test("npm local-ci scripts route through the supported Docker wrappers", () => {
+  const packageJson = JSON.parse(readFileSync(join(REPOSITORY_ROOT, "package.json"), "utf8"));
+  assert.equal(packageJson.scripts["local-ci"], "./scripts/local-ci-run.sh");
+  assert.equal(packageJson.scripts["local-ci:nonet"], "./scripts/ci-nonet.sh");
+});


### PR DESCRIPTION
## Summary

- add `--pretty` and the exact `--prettier` alias to the developer validation driver
- run one check-only repository-wide Prettier audit after required validation
- forward supported flags through both Docker wrappers and document the opt-in surface
- cover default behavior, alias equivalence/deduplication, unknown flags, non-mutation, and wrapper forwarding

## Impact

The default `npm run ci` gate is unchanged. Formatting mutations remain exclusively explicit through `npm run format`.

The optional audit currently reports seven untouched files inherited from `main`; this PR deliberately does not broaden into formatting those files.

## Validation

- `npm run ci`
- `node --test test/scripts/ci-options.test.mjs`
- `shellcheck -x scripts/ci.sh scripts/ci-options.sh scripts/local-ci-run.sh scripts/ci-nonet.sh`
- `npm run validate-docs`
- `npm run validate-schemas`
- `npm run guard:pack`
- `npm run format:check` (expected audit result: seven inherited files, no mutation)
- `git diff --check`

Closes #756