### PR TITLE
Release Lex 3.0.1 documentation update

### DIFF
--- a/.changeset/bright-frames-remember.md
+++ b/.changeset/bright-frames-remember.md
@@ -1,5 +1,0 @@
----
-"@smartergpt/lex": patch
----
-
-Rewrite Lex's documentation around the agent continuity story, add a bounded agent evaluation path, and align the prominent operator and contract references with Lex 3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.1
+
+### Patch Changes
+
+- 2d79248: Rewrite Lex's documentation around the agent continuity story, add a bounded agent evaluation path, and align the prominent operator and contract references with Lex 3.
+
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -902,7 +908,8 @@ Initial release with unified single-package structure after monorepo consolidati
 - TypeScript with strict type checking
 - Comprehensive test coverage
 
-[Unreleased]: https://github.com/Guffawaffle/lex/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/Guffawaffle/lex/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/Guffawaffle/lex/releases/tag/v3.0.1
 [3.0.0]: https://github.com/Guffawaffle/lex/releases/tag/v3.0.0
 [0.3.0]: https://github.com/Guffawaffle/lex/releases/tag/v0.3.0
 [0.2.0]: https://github.com/Guffawaffle/lex/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ rather than reconstructing them from ambient environment variables.
 
 ## Project status
 
-**Current Version:** `3.0.0`
+**Current Version:** `3.0.1`
 
 Lex 3 adds explicit runtime identity and authority, scope-bound Frame stores, PostgreSQL row-level
 security support, and trusted-host composition while retaining the local SQLite workflow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartergpt/lex",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartergpt/lex",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartergpt/lex",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "MIT-licensed memory, policy, and atlas framework with MCP server. For local dev and private automation.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Guffawaffle/lex",
     "source": "github"
   },
-  "version": "3.0.0",
+  "version": "3.0.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@smartergpt/lex-mcp",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- release the story-first Lex documentation from #772 as 3.0.1
- consume the patch changeset and align package, lockfile, README, changelog, and MCP registry metadata
- retain the Lex 3 runtime and public contract unchanged

## User impact

The npm package and repository documentation now lead with agent continuity, provide a bounded evaluation path, and present the prominent operator and contract references consistently.

## Validation

- `npm run build`
- `npm run validate-docs` (87 checks)
- `npm run check:mcp-registry-contract`
- `npm run guard:pack`
- `npm run test:smoke`

Closes #771.