### PR TITLE
Fix PostgreSQL compatibility storage isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Patch Changes
 
 - 2d79248: Rewrite Lex's documentation around the agent continuity story, add a bounded agent evaluation path, and align the prominent operator and contract references with Lex 3.
+- Restore environment-selected PostgreSQL writes after the Lex 3 scoped migration by moving the
+  unscoped compatibility adapter onto a distinct versioned relation and migration ledger. Direct
+  Lex 2.x upgrades copy only demonstrably unowned Frames; scoped and quarantined data remain behind
+  an explicit administrative ownership decision. ([#774](https://github.com/Guffawaffle/lex/issues/774))
 
 All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project follows

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -52,6 +52,10 @@ export LEX_DB_PATH=/absolute/path/to/frames.db
 Connection URL used by the compatibility PostgreSQL adapter when `LEX_STORE=postgres`.
 Introspection redacts its password and query parameters.
 
+This adapter uses dedicated `lex_compat_*` relations and a separate migration ledger. It may
+coexist with the Lex 3 scoped/RLS store in one PostgreSQL schema, but it is not a tenant boundary
+and never auto-adopts scoped or quarantined legacy Frames.
+
 ```bash
 export LEX_STORE=postgres
 export LEX_DATABASE_URL=postgresql://lex@127.0.0.1:5433/lex

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -82,6 +82,10 @@ multi-workspace hosts must use explicit runtime authority and a scope-bound Post
 [Runtime Scope](./RUNTIME_SCOPE_CONTRACT.md) and
 [PostgreSQL Scope Security](./POSTGRES_SCOPE_SECURITY.md).
 
+The compatibility adapter uses dedicated `lex_compat_*` relations and a separate migration ledger.
+It may coexist in the same PostgreSQL schema as the Lex 3 scoped/RLS store, but it never reads the
+scoped relation or automatically assigns ownership to scoped or quarantined legacy Frames.
+
 Installed CLI and MCP consumers discover `.lex.config.json` from the caller project root. This provides a file-based alternative when the host does not support environment wiring:
 
 ```json

--- a/docs/STORE_CONTRACTS.md
+++ b/docs/STORE_CONTRACTS.md
@@ -123,8 +123,17 @@ that read and replace serialize that merge with an immediate transaction or row 
 partial updates cannot erase unrelated fields.
 
 The following behavior describes the transitional unscoped 2.x adapter. It must not be wired to
-Lex 3.0 trusted CLI/MCP dispatch, and it cannot serve a database after schema v3 enables forced
-RLS without an authorized scope:
+Lex 3.0 trusted CLI/MCP dispatch. The compatibility and scope-bound PostgreSQL stores may use the
+same database and schema name, but they use separate physical contracts:
+
+| Contract | Relations | Migration ledger | Current version |
+|---|---|---|---:|
+| Unscoped compatibility | `lex_compat_frames` and `lex_compat_*` support objects | `lex_compat_frame_store_migrations` | 2 |
+| Scope-bound/RLS | `frames` and scoped support objects | `lex_frame_store_migrations` | 3 |
+
+The compatibility adapter therefore neither bypasses RLS on the scoped relation nor interprets
+scoped ownership as unscoped data. Its credential-free backend identity includes this physical
+contract, so a launcher cannot report false parity with the former shared relation.
 
 `new PostgresFrameStore(url)` keeps the default `read-write` behavior and may apply PostgreSQL
 schema migrations before serving operations. The compatibility target defaults to `public`; an
@@ -135,6 +144,13 @@ existing target schema is exactly the supported version and never starts a migra
 Missing, older, or newer schemas fail with a diagnostic instead of being changed.
 The transitional `createFrameStore()` factory forwards the same explicit `schema` option when
 PostgreSQL is selected.
+
+When upgrading directly from an unscoped Lex 2.x schema at migration version 1, the compatibility
+migration copies legacy Frames transactionally into `lex_compat_frames` without deleting or
+changing the source relation. It adopts only a source with no tenant ownership columns. A Lex 3
+scoped relation—and any quarantined legacy rows—are never adopted automatically because doing so
+would invent tenant/workspace ownership. Moving those records requires an explicit administrative
+inventory and ownership decision.
 
 PostgreSQL read-only mode is an application-level no-write contract rather than a replacement for
 database permissions.

--- a/src/memory/store/CONTRACT.md
+++ b/src/memory/store/CONTRACT.md
@@ -19,6 +19,7 @@ These values are independent and must not be substituted for one another:
 | Scoped ownership contract | `FRAME_STORE_SCOPE_CONTRACT_VERSION = 1` | Scope binding, capability, and ownership semantics |
 | Legacy/unowned SQLite | `DATABASE_SCHEMA_VERSION = 14` | Last physical schema accepted by the unscoped adapter |
 | Scope-owned SQLite | `SCOPED_SQLITE_SCHEMA_VERSION = 15` | Per-workspace physical schema with immutable ownership |
+| Unscoped compatibility PostgreSQL | `POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION = 2` | Dedicated `lex_compat_*` relations without tenant authorization |
 | Scope-owned PostgreSQL | `POSTGRES_FRAME_STORE_SCHEMA_VERSION = 3` | Explicit qualified schema with forced RLS |
 
 Physical migration versions are monotonic backend histories. A recorded version is not sufficient
@@ -81,6 +82,12 @@ Administrative inspection, migration, repair, and lifecycle operations remain ab
 `SqliteScopedFrameStoreBackend` binds one SQLite v15 file permanently to one tenant/workspace.
 `PostgresScopedFrameStoreBackend` applies the same contract to PostgreSQL v3 with explicit scope
 predicates and forced RLS. All run the shared normal-operation conformance suite.
+
+The exported unscoped `PostgresFrameStore` uses a separate version-2 compatibility domain:
+`lex_compat_frames`, its own migration ledger, and compatibility-specific support objects. It may
+coexist with the scoped/RLS domain in one PostgreSQL schema, but it never reads that domain or
+assigns ownership to scoped or quarantined records. Its backend identity includes the compatibility
+contract version.
 
 Trusted MCP does not currently expose attachment creation through scoped stores. Until a
 scope-bound attachment service exists, trusted tool schemas and help omit `images`, direct

--- a/src/memory/store/index.ts
+++ b/src/memory/store/index.ts
@@ -93,6 +93,7 @@ export {
   PostgresScopedFrameStoreBackend,
   migratePostgresFrameStore,
   planPostgresFrameStoreMigration,
+  POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION,
   POSTGRES_FRAME_STORE_SCHEMA_VERSION,
 } from "./postgres/index.js";
 export type {

--- a/src/memory/store/postgres/compatibility-migrations.ts
+++ b/src/memory/store/postgres/compatibility-migrations.ts
@@ -1,0 +1,240 @@
+import type { PoolClient } from "pg";
+
+import {
+  createPostgresSchemaTarget,
+  type PostgresSchemaTargetV1,
+} from "../../../shared/runtime-scope/postgres-schema.js";
+
+export const POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION = 2;
+
+const COMPATIBILITY_OBJECTS = Object.freeze({
+  frames: "lex_compat_frames",
+  migrations: "lex_compat_frame_store_migrations",
+  updateSearchVector: "lex_compat_update_frame_search_vector",
+});
+
+/**
+ * Keep the environment-configured compatibility store physically distinct from
+ * the Lex 3 scoped/RLS store. Both may live in one PostgreSQL schema, but they
+ * never share relations, migration ledgers, ownership semantics, or functions.
+ */
+export function createPostgresCompatibilitySchemaTarget(schema: string): PostgresSchemaTargetV1 {
+  const target = createPostgresSchemaTarget(schema);
+  return Object.freeze({
+    schema: target.schema,
+    quotedSchema: target.quotedSchema,
+    relation: (name: string) =>
+      target.relation(
+        name === "frames"
+          ? COMPATIBILITY_OBJECTS.frames
+          : name === "lex_frame_store_migrations"
+            ? COMPATIBILITY_OBJECTS.migrations
+            : name
+      ),
+    function: (name: string) =>
+      target.function(
+        name === "lex_update_frame_search_vector" ? COMPATIBILITY_OBJECTS.updateSearchVector : name
+      ),
+  });
+}
+
+function compatibilityMigrations(
+  target: PostgresSchemaTargetV1
+): ReadonlyArray<{ version: number; sql: string }> {
+  const frames = target.relation("frames");
+  const updateSearchVector = target.function("lex_update_frame_search_vector");
+  return [
+    {
+      version: 1,
+      sql: `
+      CREATE TABLE IF NOT EXISTS ${frames} (
+        id TEXT PRIMARY KEY,
+        "timestamp" TEXT NOT NULL,
+        branch TEXT NOT NULL,
+        jira TEXT,
+        module_scope TEXT[] NOT NULL,
+        summary_caption TEXT NOT NULL,
+        reference_point TEXT NOT NULL,
+        status_snapshot JSONB NOT NULL,
+        keywords TEXT[],
+        atlas_frame_id TEXT,
+        feature_flags TEXT[],
+        permissions TEXT[],
+        module_attribution JSONB,
+        run_id TEXT,
+        plan_hash TEXT,
+        spend JSONB,
+        user_id TEXT,
+        superseded_by TEXT,
+        merged_from TEXT[],
+        search_vector TSVECTOR NOT NULL DEFAULT ''::tsvector
+      );
+
+      CREATE INDEX IF NOT EXISTS lex_compat_frames_timestamp
+        ON ${frames} ("timestamp" DESC, id DESC);
+      CREATE INDEX IF NOT EXISTS lex_compat_frames_branch ON ${frames} (branch);
+      CREATE INDEX IF NOT EXISTS lex_compat_frames_jira ON ${frames} (jira);
+      CREATE INDEX IF NOT EXISTS lex_compat_frames_atlas_frame_id ON ${frames} (atlas_frame_id);
+      CREATE INDEX IF NOT EXISTS lex_compat_frames_user_id ON ${frames} (user_id);
+      CREATE INDEX IF NOT EXISTS lex_compat_frames_module_scope
+        ON ${frames} USING GIN (module_scope);
+      CREATE INDEX IF NOT EXISTS lex_compat_frames_search_vector
+        ON ${frames} USING GIN (search_vector);
+
+      CREATE OR REPLACE FUNCTION ${updateSearchVector}()
+      RETURNS TRIGGER
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        NEW.search_vector := to_tsvector(
+          'simple',
+          coalesce(NEW.reference_point, '') || ' ' ||
+          coalesce(NEW.summary_caption, '') || ' ' ||
+          coalesce(array_to_string(NEW.keywords, ' '), '') || ' ' ||
+          coalesce(NEW.status_snapshot ->> 'next_action', '') || ' ' ||
+          coalesce(array_to_string(NEW.module_scope, ' '), '') || ' ' ||
+          coalesce(NEW.jira, '') || ' ' ||
+          coalesce(NEW.branch, '')
+        );
+        RETURN NEW;
+      END;
+      $$;
+
+      DROP TRIGGER IF EXISTS lex_compat_frames_search_vector_update ON ${frames};
+      CREATE TRIGGER lex_compat_frames_search_vector_update
+        BEFORE INSERT OR UPDATE OF reference_point, summary_caption, keywords,
+          status_snapshot, module_scope, jira, branch
+        ON ${frames}
+        FOR EACH ROW
+        EXECUTE FUNCTION ${updateSearchVector}();
+    `,
+    },
+    {
+      version: 2,
+      sql: `
+      ALTER TABLE ${frames}
+        ADD COLUMN frame_metadata JSONB NOT NULL DEFAULT '{"schemaVersion":1}'::jsonb,
+        ADD CONSTRAINT lex_compat_frames_metadata_object
+          CHECK (jsonb_typeof(frame_metadata) = 'object'),
+        ADD CONSTRAINT lex_compat_frames_metadata_version
+          CHECK (frame_metadata ->> 'schemaVersion' = '1');
+    `,
+    },
+  ];
+}
+
+interface LegacySourceInspection {
+  readonly frames_exists: string | null;
+  readonly migrations_exists: string | null;
+  readonly has_tenant_id: boolean;
+}
+
+async function canAdoptLegacyCompatibilityFrames(
+  client: PoolClient,
+  legacy: PostgresSchemaTargetV1
+): Promise<boolean> {
+  const inspection = await client.query<LegacySourceInspection>(
+    `SELECT
+      to_regclass($1)::text AS frames_exists,
+      to_regclass($2)::text AS migrations_exists,
+      EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = $3 AND table_name = 'frames' AND column_name = 'tenant_id'
+      ) AS has_tenant_id`,
+    [legacy.relation("frames"), legacy.relation("lex_frame_store_migrations"), legacy.schema]
+  );
+  const row = inspection.rows[0];
+  if (!row?.frames_exists || !row.migrations_exists || row.has_tenant_id) return false;
+  const version = await client.query<{ version: number | null }>(
+    `SELECT MAX(version) AS version FROM ${legacy.relation("lex_frame_store_migrations")}`
+  );
+  return version.rows[0]?.version === 1;
+}
+
+async function adoptLegacyCompatibilityFrames(
+  client: PoolClient,
+  legacy: PostgresSchemaTargetV1,
+  compatibility: PostgresSchemaTargetV1
+): Promise<void> {
+  await client.query(`
+    INSERT INTO ${compatibility.relation("frames")} (
+      id, "timestamp", branch, jira, module_scope, summary_caption,
+      reference_point, status_snapshot, keywords, atlas_frame_id, feature_flags,
+      permissions, module_attribution, run_id, plan_hash, spend, user_id,
+      superseded_by, merged_from, frame_metadata
+    )
+    SELECT
+      source.id, source."timestamp", source.branch, source.jira, source.module_scope,
+      source.summary_caption, source.reference_point, source.status_snapshot,
+      source.keywords, source.atlas_frame_id, source.feature_flags, source.permissions,
+      source.module_attribution, source.run_id, source.plan_hash, source.spend,
+      source.user_id, source.superseded_by, source.merged_from,
+      CASE
+        WHEN jsonb_typeof(to_jsonb(source) -> 'frame_metadata') = 'object'
+          THEN to_jsonb(source) -> 'frame_metadata'
+        ELSE '{"schemaVersion":1}'::jsonb
+      END
+    FROM ${legacy.relation("frames")} AS source
+    ON CONFLICT (id) DO NOTHING
+  `);
+}
+
+/**
+ * Apply the unscoped compatibility migration line. A directly upgraded Lex
+ * 2.x schema is copied without mutation into the compatibility relation. A
+ * scoped/RLS schema is never adopted because doing so would invent ownership.
+ */
+export async function migratePostgresCompatibilityFrameStore(
+  client: PoolClient,
+  schema: string
+): Promise<void> {
+  const legacy = createPostgresSchemaTarget(schema);
+  const target = createPostgresCompatibilitySchemaTarget(schema);
+  const migrations = compatibilityMigrations(target);
+  await client.query("BEGIN");
+  try {
+    // Serialize with the former/shared migration line before taking the new
+    // compatibility-specific lock. This prevents a concurrent scoped migration
+    // from changing the legacy source while it is inspected or copied.
+    await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [
+      `lex-frame-store-migrations:${legacy.schema}`,
+    ]);
+    await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [
+      `lex-compat-frame-store-migrations:${target.schema}`,
+    ]);
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS ${target.relation("lex_frame_store_migrations")} (
+        version INTEGER PRIMARY KEY,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+
+    const result = await client.query<{ version: number | null }>(
+      `SELECT MAX(version) AS version FROM ${target.relation("lex_frame_store_migrations")}`
+    );
+    const currentVersion = result.rows[0]?.version ?? 0;
+    if (currentVersion > POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION) {
+      throw new Error(
+        `PostgreSQL compatibility FrameStore schema ${currentVersion} is newer than supported schema ${POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION}`
+      );
+    }
+    const adoptLegacy =
+      currentVersion === 0 && (await canAdoptLegacyCompatibilityFrames(client, legacy));
+
+    for (const migration of migrations) {
+      if (migration.version <= currentVersion) continue;
+      await client.query(migration.sql);
+      await client.query(
+        `INSERT INTO ${target.relation("lex_frame_store_migrations")} (version) VALUES ($1)`,
+        [migration.version]
+      );
+    }
+    if (adoptLegacy) await adoptLegacyCompatibilityFrames(client, legacy, target);
+
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  }
+}

--- a/src/memory/store/postgres/frame-store.ts
+++ b/src/memory/store/postgres/frame-store.ts
@@ -13,13 +13,14 @@ import type {
 } from "../frame-store.js";
 import type { Frame, FrameStatusSnapshot, FrameSpendMetadata } from "../../frames/types.js";
 import { Frame as FrameSchema } from "../../frames/types.js";
-import {
-  createPostgresSchemaTarget,
-  type PostgresSchemaTargetV1,
-} from "../../../shared/runtime-scope/postgres-schema.js";
+import { type PostgresSchemaTargetV1 } from "../../../shared/runtime-scope/postgres-schema.js";
 import { durableFrameMetadata, parseDurableFrameMetadata } from "../durable-frame-metadata.js";
 import { normalizeSearchTerms } from "../search-utils.js";
-import { migratePostgresFrameStore, POSTGRES_FRAME_STORE_SCHEMA_VERSION } from "./migrations.js";
+import {
+  createPostgresCompatibilitySchemaTarget,
+  migratePostgresCompatibilityFrameStore,
+  POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION,
+} from "./compatibility-migrations.js";
 
 interface PaginationCursor {
   timestamp: string;
@@ -198,6 +199,12 @@ function postgresIdentity(location: string): string {
   return `postgres-v1:${createHash("sha256").update(location).digest("hex").slice(0, 16)}`;
 }
 
+function compatibilityIdentity(location: string, schema: string): string {
+  return postgresIdentity(
+    `${location}|schema=${schema}|contract=compat-v${POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION}`
+  );
+}
+
 /** Translate the existing FTS5 normalization contract to a PostgreSQL tsquery. */
 function toPostgresTsQuery(criteria: FrameSearchCriteria): string | null {
   const terms = normalizeSearchTerms(criteria).map((term) =>
@@ -220,7 +227,7 @@ export class PostgresFrameStore implements FrameStore {
 
   constructor(connectionStringOrPool?: string | Pool, options: PostgresFrameStoreOptions = {}) {
     this._accessMode = options.accessMode ?? "read-write";
-    this.target = createPostgresSchemaTarget(options.schema ?? "public");
+    this.target = createPostgresCompatibilitySchemaTarget(options.schema ?? "public");
     this.upsertSql = upsertFrameSql(this.target);
     if (typeof connectionStringOrPool === "object") {
       this.pool = connectionStringOrPool;
@@ -230,7 +237,7 @@ export class PostgresFrameStore implements FrameStore {
         backend: "postgres",
         location,
         canonicalLocation: location,
-        identity: postgresIdentity(`${location}|schema=${this.target.schema}`),
+        identity: compatibilityIdentity(location, this.target.schema),
         capabilities: { encryption: false, images: false },
       };
       return;
@@ -261,7 +268,7 @@ export class PostgresFrameStore implements FrameStore {
       backend: "postgres",
       location,
       canonicalLocation: location,
-      identity: postgresIdentity(`${location}|schema=${this.target.schema}`),
+      identity: compatibilityIdentity(location, this.target.schema),
       capabilities: { encryption: false, images: false },
     };
   }
@@ -322,9 +329,9 @@ export class PostgresFrameStore implements FrameStore {
       `SELECT MAX(version) AS version FROM ${this.target.relation("lex_frame_store_migrations")}`
     );
     const currentVersion = result.rows[0]?.version ?? 0;
-    if (currentVersion !== POSTGRES_FRAME_STORE_SCHEMA_VERSION) {
+    if (currentVersion !== POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION) {
       throw new Error(
-        `PostgreSQL FrameStore schema ${currentVersion} is not the required schema ${POSTGRES_FRAME_STORE_SCHEMA_VERSION}; run an explicit writable Lex command to migrate it`
+        `PostgreSQL compatibility FrameStore schema ${currentVersion} is not the required schema ${POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION}; run an explicit writable Lex command to migrate it`
       );
     }
   }
@@ -337,7 +344,7 @@ export class PostgresFrameStore implements FrameStore {
           const client = await this.pool.connect();
           try {
             if (this._accessMode === "read-only") await this.verifySchema(client);
-            else await migratePostgresFrameStore(client, this.target.schema);
+            else await migratePostgresCompatibilityFrameStore(client, this.target.schema);
           } finally {
             client.release();
           }

--- a/src/memory/store/postgres/index.ts
+++ b/src/memory/store/postgres/index.ts
@@ -1,5 +1,6 @@
 export { PostgresFrameStore } from "./frame-store.js";
 export type { PostgresFrameStoreAccessMode, PostgresFrameStoreOptions } from "./frame-store.js";
+export { POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION } from "./compatibility-migrations.js";
 export {
   PostgresFrameStoreAdministration,
   PostgresScopedFrameStoreBackend,

--- a/test/memory/store/frame-store-factory.test.ts
+++ b/test/memory/store/frame-store-factory.test.ts
@@ -2,13 +2,14 @@ import { afterEach, test } from "node:test";
 import assert from "node:assert/strict";
 import {
   createFrameStore,
-  POSTGRES_FRAME_STORE_SCHEMA_VERSION,
+  POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION,
   PostgresFrameStore,
   resolveFrameStoreBackend,
   SqliteFrameStore,
 } from "@app/memory/store/index.js";
-import type { Pool } from "pg";
+import type { Pool, PoolClient } from "pg";
 import type { Frame } from "../../../src/memory/frames/types.js";
+import { migratePostgresCompatibilityFrameStore } from "@app/memory/store/postgres/compatibility-migrations.js";
 
 const originalStore = process.env.LEX_STORE;
 const originalUrl = process.env.LEX_DATABASE_URL;
@@ -99,7 +100,7 @@ test("PostgresFrameStore read-only mode validates schema without migrations and 
   const client = {
     query: async (sql: string) => {
       queries.push(sql);
-      return { rows: [{ version: POSTGRES_FRAME_STORE_SCHEMA_VERSION }] };
+      return { rows: [{ version: POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION }] };
     },
     release: () => undefined,
   };
@@ -116,6 +117,90 @@ test("PostgresFrameStore read-only mode validates schema without migrations and 
   assert.ok(!queries.some((sql) => /\b(?:BEGIN|CREATE|INSERT|ALTER)\b/i.test(sql)));
   await assert.rejects(store.deleteFrame("frame-1"), /read-only/i);
   await store.close();
+});
+
+test("PostgreSQL compatibility migration uses distinct objects and safely adopts a v1 source", async () => {
+  const queries: Array<{ sql: string; params: readonly unknown[] }> = [];
+  const client = {
+    query: async (sql: string, params: readonly unknown[] = []) => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      queries.push({ sql: normalized, params });
+      if (
+        normalized.includes("SELECT MAX(version)") &&
+        normalized.includes('"lex_compat"."lex_compat_frame_store_migrations"')
+      ) {
+        return { rows: [{ version: 0 }], rowCount: 1 };
+      }
+      if (normalized.startsWith("SELECT to_regclass")) {
+        return {
+          rows: [
+            {
+              frames_exists: "lex_compat.frames",
+              migrations_exists: "lex_compat.lex_frame_store_migrations",
+              has_tenant_id: false,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (
+        normalized.includes("SELECT MAX(version)") &&
+        normalized.includes('"lex_compat"."lex_frame_store_migrations"')
+      ) {
+        return { rows: [{ version: 1 }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 1 };
+    },
+  } as unknown as PoolClient;
+
+  await migratePostgresCompatibilityFrameStore(client, "lex_compat");
+
+  const sql = queries.map(({ sql }) => sql).join("\n");
+  assert.match(sql, /"lex_compat"\."lex_compat_frame_store_migrations"/);
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS "lex_compat"\."lex_compat_frames"/);
+  assert.match(sql, /PRIMARY KEY/);
+  assert.match(sql, /FROM "lex_compat"\."frames" AS source/);
+  assert.match(sql, /ON CONFLICT \(id\) DO NOTHING/);
+  assert.doesNotMatch(sql, /ALTER TABLE "lex_compat"\."frames"/);
+  assert.equal(queries[0]?.sql, "BEGIN");
+  assert.equal(queries.at(-1)?.sql, "COMMIT");
+});
+
+test("PostgreSQL compatibility migration never adopts a scoped ownership table", async () => {
+  const queries: string[] = [];
+  const client = {
+    query: async (sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      queries.push(normalized);
+      if (
+        normalized.includes("SELECT MAX(version)") &&
+        normalized.includes("lex_compat_frame_store_migrations")
+      ) {
+        return { rows: [{ version: 0 }], rowCount: 1 };
+      }
+      if (normalized.startsWith("SELECT to_regclass")) {
+        return {
+          rows: [
+            {
+              frames_exists: "lex_compat.frames",
+              migrations_exists: "lex_compat.lex_frame_store_migrations",
+              has_tenant_id: true,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 1 };
+    },
+  } as unknown as PoolClient;
+
+  await migratePostgresCompatibilityFrameStore(client, "lex_compat");
+
+  assert.equal(
+    queries.some((sql) => sql.includes('"frames" AS source')),
+    false
+  );
+  assert.equal(queries.at(-1), "COMMIT");
 });
 
 test("PostgresFrameStore pins compatibility CRUD and durable Frame metadata to its schema", async () => {
@@ -205,7 +290,10 @@ test("PostgresFrameStore pins compatibility CRUD and durable Frame metadata to i
     query: async (sql: string, params: readonly unknown[] = []) => {
       record(sql, params);
       if (sql.includes("SELECT MAX(version)")) {
-        return { rows: [{ version: POSTGRES_FRAME_STORE_SCHEMA_VERSION }], rowCount: 1 };
+        return {
+          rows: [{ version: POSTGRES_COMPATIBILITY_FRAME_STORE_SCHEMA_VERSION }],
+          rowCount: 1,
+        };
       }
       if (sql.includes("FOR UPDATE")) return { rows: [row], rowCount: 1 };
       return { rows: [], rowCount: 1 };
@@ -216,7 +304,7 @@ test("PostgresFrameStore pins compatibility CRUD and durable Frame metadata to i
     connect: async () => client,
     query: async (sql: string, params: readonly unknown[] = []) => {
       record(sql, params);
-      if (sql.includes("SELECT") && sql.includes('"lex_compat"."frames"')) {
+      if (sql.includes("SELECT") && sql.includes('"lex_compat"."lex_compat_frames"')) {
         return { rows: [row], rowCount: 1 };
       }
       return { rows: [], rowCount: 1 };
@@ -228,9 +316,9 @@ test("PostgresFrameStore pins compatibility CRUD and durable Frame metadata to i
   assert.deepEqual(await store.getFrameById(frame.id), frame);
   assert.equal(await store.updateFrame(frame.id, { guardrailProfile: "updated" }), true);
 
-  const frameSql = queries.filter(({ sql }) => /\bframes\b/.test(sql));
+  const frameSql = queries.filter(({ sql }) => sql.includes('"lex_compat"."lex_compat_frames"'));
   assert.ok(frameSql.length > 0);
-  assert.ok(frameSql.every(({ sql }) => sql.includes('"lex_compat"."frames"')));
+  assert.ok(frameSql.every(({ sql }) => sql.includes('"lex_compat"."lex_compat_frames"')));
   const writes = queries.filter(({ sql }) => sql.startsWith("INSERT INTO"));
   assert.deepEqual(
     (writes[0]?.params[19] as { guardrailProfile?: string }).guardrailProfile,

--- a/test/memory/store/postgres/scoped-frame-store.integration.test.ts
+++ b/test/memory/store/postgres/scoped-frame-store.integration.test.ts
@@ -4,6 +4,7 @@ import { randomBytes } from "node:crypto";
 import { Pool } from "pg";
 import {
   FRAME_STORE_CAPABILITIES,
+  PostgresFrameStore,
   PostgresFrameStoreAdministration,
   PostgresScopedFrameStoreBackend,
 } from "@app/memory/store/index.js";
@@ -31,6 +32,7 @@ let scopedAdminPool: Pool;
 let runtimePool: Pool;
 let administration: PostgresFrameStoreAdministration;
 let backend: PostgresScopedFrameStoreBackend;
+let compatibilityStore: PostgresFrameStore;
 
 function scopedUrl(value: string): string {
   const url = new URL(value);
@@ -96,6 +98,7 @@ integration("PostgreSQL scoped FrameStore live RLS", () => {
     });
     administration = new PostgresFrameStoreAdministration(scopedAdminPool, { schema });
     await administration.migrate();
+    compatibilityStore = new PostgresFrameStore(scopedAdminPool, { schema });
 
     runtimePool = new Pool({
       connectionString: scopedUrl(runtimeUrl as string),
@@ -120,12 +123,50 @@ integration("PostgreSQL scoped FrameStore live RLS", () => {
 
   after(async () => {
     await backend?.close();
+    await compatibilityStore?.close();
     await administration?.close();
     await runtimePool?.end();
     await scopedAdminPool?.end();
     await adminPool?.query(`DROP SCHEMA IF EXISTS ${quoteIdentifier(shadowSchema)} CASCADE`);
     await adminPool?.query(`DROP SCHEMA IF EXISTS ${quoteIdentifier(schema)} CASCADE`);
     await adminPool?.end();
+  });
+
+  test("keeps compatibility writes separate from the scoped/RLS ownership domain", async () => {
+    const compatibilityFrame = {
+      id: "compatibility-frame",
+      timestamp: "2026-07-18T03:30:00.000Z",
+      branch: "main",
+      module_scope: ["memory/store/postgres"],
+      summary_caption: "Compatibility PostgreSQL Frame",
+      reference_point: "separate persistence domains",
+      status_snapshot: { next_action: "verify scoped isolation" },
+    };
+    await compatibilityStore.saveFrame(compatibilityFrame);
+    assert.deepEqual(
+      await compatibilityStore.getFrameById(compatibilityFrame.id),
+      compatibilityFrame
+    );
+
+    const scoped = backend.bind(
+      scope(
+        "01900000-0000-7000-8000-000000000001",
+        "01900000-0000-7000-8000-000000000101",
+        "01900000-0000-7000-8000-000000000201"
+      )
+    );
+    assert.equal(await scoped.getFrameById(compatibilityFrame.id), null);
+    const relations = await adminPool.query<{
+      scoped: string | null;
+      compatibility: string | null;
+    }>(
+      `SELECT
+        to_regclass($1)::text AS scoped,
+        to_regclass($2)::text AS compatibility`,
+      [`${schema}.frames`, `${schema}.lex_compat_frames`]
+    );
+    assert.ok(relations.rows[0]?.scoped);
+    assert.ok(relations.rows[0]?.compatibility);
   });
 
   test("isolates collisions while rapidly alternating tenants and workspaces on one client", async () => {


### PR DESCRIPTION
## What changed

- move the environment-selected, unscoped PostgreSQL adapter onto dedicated `lex_compat_*` relations and a separate version-2 migration ledger;
- give that physical compatibility contract its own backend identity;
- conservatively copy a direct Lex 2.x schema-v1 source without mutation, only when it is demonstrably unowned;
- never auto-adopt Lex 3 scoped/RLS or quarantined records;
- document the two coexisting PostgreSQL persistence domains and export the compatibility schema version;
- add unit and live integration coverage for migration/adoption and compatibility/scoped isolation.

## Root cause

Lex 3's scoped migration changed the shared `frames` key from `id` to `(tenant_id, workspace_id, id)` and enabled ownership/RLS. The transitional `PostgresFrameStore` continued issuing unscoped `ON CONFLICT (id)` writes against that same physical relation, so normal environment-selected PostgreSQL writes failed after migration.

The fix separates the contracts physically rather than weakening the scoped ownership boundary or fabricating ownership for legacy data.

## Impact

Standalone CLI/MCP compatibility consumers can write to PostgreSQL again after a Lex 3 scoped migration. Scoped tenants/workspaces remain isolated. Existing quarantined rows remain preserved for an explicit administrative recovery decision tracked in #775.

Closes #774.

## Validation

- `npm run lint`
- `npm run type-check`
- full functional suite: all tests passed
- `npm run build`
- `npm run check:public-api`
- `npm run test:dogfood:postgres` — full two-tenant/five-workspace live canary green with cleanup proven
- exact branch-local PostgreSQL CLI smoke: write, introspection/health, and recall green against PostgreSQL 16.11
- isolated Atlas 10,000-frame performance rerun green at 67.10s (the first full-suite pass measured 72.07s against its 70s timing threshold; no functional failure)
