### PR TITLE
Add the Ecosystem 3.1 release manifest gate

### DIFF
--- a/.changeset/calm-frames-coordinate.md
+++ b/.changeset/calm-frames-coordinate.md
@@ -1,0 +1,6 @@
+---
+"@smartergpt/lex": minor
+---
+
+Add the schema-validated Ecosystem 3.1 compatibility manifest and coupled cross-repository release
+SOP.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
           cache: "npm"
       - run: npm ci --ignore-scripts
       - run: npm run check:mcp-registry-contract
+      - run: npm run check:ecosystem-release
 
   # Standard gates: build + tests (only on workflow_dispatch with level >= standard)
   build-and-test:

--- a/canon/schemas/ecosystem-release-v1.schema.json
+++ b/canon/schemas/ecosystem-release-v1.schema.json
@@ -1,0 +1,292 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://smartergpt.dev/schemas/ecosystem-release-v1.schema.json",
+  "title": "EcosystemReleaseManifest_v1",
+  "description": "A cross-repository compatibility and release-evidence manifest for the Lex toolset.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "releaseId",
+    "displayName",
+    "state",
+    "runtime",
+    "components",
+    "edges",
+    "gates"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "releaseId": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "state": {
+      "enum": ["draft", "sealed"]
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nodeMinimumMajor", "nodeUpperBoundExclusive"],
+      "properties": {
+        "nodeMinimumMajor": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "nodeUpperBoundExclusive": {
+          "type": ["integer", "null"],
+          "minimum": 2
+        }
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/component"
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/edge"
+      }
+    },
+    "gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/gate"
+      }
+    }
+  },
+  "definitions": {
+    "nullableSemver": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"
+    },
+    "nullableSha512": {
+      "type": ["string", "null"],
+      "pattern": "^sha512-[A-Za-z0-9+/]+={0,2}$"
+    },
+    "nullableCommit": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "repository",
+        "role",
+        "participation",
+        "runtimeRequirement",
+        "status",
+        "issues",
+        "package",
+        "source",
+        "evidence"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "repository": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "participation": {
+          "enum": ["required-package", "required-source-proof"]
+        },
+        "runtimeRequirement": {
+          "enum": ["required", "optional", "none"]
+        },
+        "status": {
+          "enum": ["baseline", "planned", "candidate", "published", "verified", "excluded"]
+        },
+        "issues": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/[0-9]+$"
+          }
+        },
+        "package": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "registry",
+                "access",
+                "baselineVersion",
+                "targetVersion",
+                "publishedVersion",
+                "integrity"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^@smartergpt/[a-z0-9-]+$"
+                },
+                "registry": {
+                  "const": "https://registry.npmjs.org"
+                },
+                "access": {
+                  "enum": ["public", "restricted"]
+                },
+                "baselineVersion": {
+                  "$ref": "#/definitions/nullableSemver"
+                },
+                "targetVersion": {
+                  "$ref": "#/definitions/nullableSemver"
+                },
+                "publishedVersion": {
+                  "$ref": "#/definitions/nullableSemver"
+                },
+                "integrity": {
+                  "$ref": "#/definitions/nullableSha512"
+                }
+              }
+            }
+          ]
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["commit", "tag"],
+          "properties": {
+            "commit": {
+              "$ref": "#/definitions/nullableCommit"
+            },
+            "tag": {
+              "type": ["string", "null"],
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+            }
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://"
+          }
+        }
+      }
+    },
+    "edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to", "kind", "releaseRequired", "constraint"],
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "kind": {
+          "enum": ["runtime", "peer", "optional", "conformance", "downstream-proof"]
+        },
+        "releaseRequired": {
+          "type": "boolean"
+        },
+        "constraint": {
+          "type": ["string", "null"],
+          "maxLength": 120
+        }
+      }
+    },
+    "gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "required", "status", "evidence"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "status": {
+          "enum": ["planned", "passed", "excluded"]
+        },
+        "evidence": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://"
+          }
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "$schema": "../canon/schemas/ecosystem-release-v1.schema.json",
+      "schemaVersion": 1,
+      "releaseId": "ecosystem-example",
+      "displayName": "Example ecosystem release",
+      "state": "draft",
+      "runtime": {
+        "nodeMinimumMajor": 24,
+        "nodeUpperBoundExclusive": null
+      },
+      "components": [
+        {
+          "id": "example-proof",
+          "repository": "example/project",
+          "role": "Illustrative source-proof component.",
+          "participation": "required-source-proof",
+          "runtimeRequirement": "none",
+          "status": "planned",
+          "issues": ["https://github.com/example/project/issues/1"],
+          "package": null,
+          "source": {
+            "commit": null,
+            "tag": null
+          },
+          "evidence": []
+        }
+      ],
+      "edges": [],
+      "gates": [
+        {
+          "id": "example-gate",
+          "required": true,
+          "status": "planned",
+          "evidence": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -43,6 +43,7 @@ and compiles imports for every declaration path.
 | `@smartergpt/lex/lexsona` | Behavioral-memory integration |
 | `@smartergpt/lex/mcp-server` | Embeddable MCP server |
 | `@smartergpt/lex/schemas/cli-output.v1.schema.json` | Versioned CLI output JSON Schema |
+| `@smartergpt/lex/schemas/ecosystem-release-v1.schema.json` | Ecosystem release manifest JSON Schema |
 | `@smartergpt/lex/schemas/feature-spec-v0.json` | Versioned feature specification JSON Schema |
 | `@smartergpt/lex/schemas/profile.schema.json` | Lex profile JSON Schema |
 

--- a/docs/releases/ecosystem-3.1.md
+++ b/docs/releases/ecosystem-3.1.md
@@ -1,0 +1,245 @@
+# Ecosystem 3.1 release dependency and publication SOP
+
+Ecosystem 3.1 is a compatibility release train across the Lex toolset. It is not a shared package
+version. Each repository selects semver from its own reviewed user-visible delta, while the release
+manifest records the exact set proven to work together.
+
+The canonical machine-readable draft is [`releases/ecosystem-3.1.json`](../../releases/ecosystem-3.1.json).
+Its schema is
+[`canon/schemas/ecosystem-release-v1.schema.json`](../../canon/schemas/ecosystem-release-v1.schema.json).
+
+Validate the draft at any time:
+
+```bash
+npm run check:ecosystem-release
+```
+
+The final release gate additionally requires sealed evidence:
+
+```bash
+node scripts/validate-ecosystem-release.mjs --sealed
+```
+
+## What “required” means
+
+A component can be required for the release train without becoming a mandatory runtime dependency.
+
+| Component   | Release-train role                                                        | Runtime relationship |
+| ----------- | ------------------------------------------------------------------------- | -------------------- |
+| Lex         | Memory, authority, scoped storage, and KnowledgeFrame provider semantics  | Required foundation  |
+| Lex-MCP     | Exact-version transport for Lex's MCP server and Registry entry           | Requires exact Lex   |
+| LexSona     | Deterministic, scoped behavioral constraints                             | Optional             |
+| LexRunner   | Attempt lifecycle and immutable constraint-snapshot consumption           | Works with LexSona off or enabled |
+| AXF         | Provider-neutral routing, budgeting, fallback, and conformance             | No Lex runtime dependency |
+| STFC-Mod    | Real-corpus knowledge-context proof                                       | Source proof only    |
+
+LexSona is therefore required in the *tested compatible set* while remaining optional during an
+ordinary LexRunner execution. AXF and STFC-Mod evidence must never be encoded as npm dependencies.
+
+## Product dependency graph
+
+### Knowledge context
+
+```text
+Lex #734 KnowledgeFrame_v1
+        ↓
+AXF #42 off/shadow provider routing
+        ↓
+STFC-Mod #165 real-corpus shadow pilot
+```
+
+### Behavioral constraints
+
+```text
+LexSona #126 snapshot contract ─┐
+LexSona #128 content audit ─────┼─→ LexSona #127 scoped bindings
+Lex #779 authorized store ──────┘              ↓
+                                     LexRunner #820 lifecycle binding
+                                                ↓
+                                      LexSona #125 dogfood gates
+```
+
+Lex #775 separately completes the supported operator path for quarantined legacy Frames. The
+release cannot describe scoped migration as operationally complete while that preserved data has no
+explicit inspect/plan/apply recovery path.
+
+## Release-manifest states
+
+The manifest has two top-level states:
+
+- `draft` permits unknown target versions and incomplete evidence. It must still contain the entire
+  component set, a valid graph, the Node 24 policy, and an exact Lex-MCP-to-Lex edge.
+- `sealed` permits no unresolved component. Every component is `verified`; every required gate is
+  `passed`; package versions and integrity, source commits and tags, and evidence links are complete.
+
+Component status progresses monotonically:
+
+```text
+baseline or planned → candidate → published → verified
+```
+
+`excluded` is not a quiet escape hatch. Changing a required component to excluded requires a
+reviewed scope change to the umbrella issue, release notes, schema-valid manifest, and advertised
+compatible set.
+
+## Evidence rules
+
+The sealed record uses immutable evidence:
+
+- full commit SHA, never a branch name;
+- repository-approved signed annotated tag for every packaged component;
+- exact commit plus immutable proof evidence for source-proof components;
+- exact npm version and `sha512-` integrity;
+- non-draft GitHub release;
+- completed CI/release/registry run URL;
+- downstream proof issue or immutable artifact tied to a commit;
+- no local `file:` dependency, workspace link, mutable `latest` assertion, or unreviewed output.
+
+Normal validator output reports only the state, component count, and edge count. Failures identify
+the inconsistent field or edge. Credentials, environment values, database URLs, and secret-bearing
+logs do not belong in the manifest or issue receipts.
+
+## Candidate preparation
+
+For each participating repository:
+
+1. inventory CLI, MCP, exports, schemas, storage, configuration, runtime, and documentation changes;
+2. write the semver and migration decision before changing package identity;
+3. raise active metadata, workflows, and current guidance to Node 24;
+4. validate touched and adjacent behavior during implementation;
+5. run the repository's exhaustive release gate at the release candidate;
+6. pack the candidate and validate a clean consumer without workspace links;
+7. merge the reviewed, signed release commit;
+8. record its full SHA in the draft manifest.
+
+Full-suite release evidence is mandatory even when implementation uses deterministic touched and
+adjacent gates for iteration speed.
+
+## Publication order
+
+The final package sequence follows real dependency direction:
+
+1. Publish Lex.
+2. Refresh every dependent lock from the public Lex artifact and verify its integrity.
+3. Publish LexSona after its selected Lex contract and packed consumers pass.
+4. Publish LexRunner after both its no-LexSona baseline and selected LexSona modes pass.
+5. Publish AXF after provider conformance and the STFC shadow proof pass; AXF does not add Lex as a
+   runtime dependency.
+6. Publish Lex-MCP last with an exact dependency on the published Lex version.
+7. Push signed tags and verify GitHub releases.
+8. Approve and verify the protected MCP Registry publication for Lex-MCP.
+9. Re-run native consumers against public artifacts.
+10. Seal the manifest and merge the immutable evidence update.
+
+Publishing order may wait between steps. It must not reverse a dependency edge or use unpublished
+local state to manufacture a dependent lock.
+
+## Human-only checkpoints
+
+An agent may prepare commits, run gates, pack artifacts, perform dry runs, verify public metadata,
+and print the next command. The authenticated maintainer performs non-dry-run npm publication,
+signed tag creation/push, and protected deployment approval.
+
+Before any npm publication, the maintainer runs:
+
+```bash
+npm whoami
+npm access list packages smartergpt --json
+git status --short
+git rev-parse HEAD
+```
+
+The expected npm identity is `guffawaffle`. The worktree must be clean and `HEAD` must equal the
+reviewed release commit recorded in the candidate manifest.
+
+From that exact checkout, the maintainer runs the applicable command:
+
+```bash
+# Public packages
+npm publish --access public
+
+# Restricted packages
+npm publish --access restricted
+```
+
+Use public access for Lex and Lex-MCP. Preserve the reviewed access policy for AXF. Use restricted
+access for LexSona and LexRunner unless their release issue explicitly changes that policy.
+
+After npm reports success, verify before continuing:
+
+```bash
+npm view <package>@<version> version engines dist.integrity --json
+```
+
+For a dependency edge, also query the relevant dependency or peer dependency. Do not rely on the
+mutable `latest` tag as the sole proof.
+
+## Signed refs and GitHub releases
+
+Tags are created only after npm exposes the immutable package and the repository release workflow's
+preconditions pass. Use the tag format enforced by that repository's workflow. Lex and Lex-MCP use
+`v<version>`; LexRunner uses `lexrunner-v<version>`.
+
+The maintainer creates and verifies an annotated signed tag from the exact release commit:
+
+```bash
+git tag -s "<approved-tag>" -m "Release <approved-tag>"
+git tag -v "<approved-tag>"
+git push origin "<approved-tag>"
+```
+
+The GitHub release must be non-draft and point through the tag to the recorded commit. A successful
+tag push is not by itself a successful release.
+
+## MCP Registry boundary
+
+Only the Lex/Lex-MCP server entry is published as part of this release train. After both exact npm
+packages and their GitHub releases exist:
+
+1. approve the protected `mcp-publish` environment for the tag-triggered run;
+2. wait for the publisher's live-entry verification;
+3. independently run the repository verification script for the exact version;
+4. record the completed run and live version evidence in the manifest.
+
+Participation does not automatically authorize AXF, LexSona, or LexRunner MCP Registry entries.
+
+## Partial-publication recovery
+
+Published npm versions and pushed tags are immutable. Recovery advances from observed state; it does
+not overwrite history.
+
+| Observed state | Recovery |
+| -------------- | -------- |
+| Candidate merged, package absent | Re-run gates against the same commit, then ask the maintainer to publish. |
+| Package published, tag absent | Verify package integrity and commit identity, then create the signed tag. |
+| Tag pushed, GitHub release failed | Re-run or repair the release workflow against the same immutable tag. |
+| Lex published, dependent lock stale | Refresh the dependent lock from npm, review/merge that commit, then publish the dependent. |
+| Dependent package published with wrong metadata | Stop the train; create a new patch version. Never republish the same version. |
+| MCP Registry approval pending | Leave the manifest unsealed and request the protected-environment approval. |
+| Registry publication failed | Diagnose/retry the immutable release workflow; do not publish a replacement npm artifact unless metadata is wrong. |
+| Native consumer fails | Keep the component below `verified`; fix through a new reviewed package version when published bytes are at fault. |
+
+Every recovery receipt identifies the observed immutable artifact, the missing transition, and why
+the next action is safe.
+
+## Sealing the release
+
+The final manifest update occurs after all external systems are already verified. It changes:
+
+- top-level state to `sealed`;
+- every component to `verified`;
+- package target/published versions and integrity;
+- exact source commits and signed tags;
+- immutable evidence links;
+- every required gate to `passed` with evidence.
+
+Run both validators, review the diff, and merge the signed manifest commit:
+
+```bash
+npm run check:ecosystem-release
+node scripts/validate-ecosystem-release.mjs --sealed
+```
+
+The sealed manifest is a release receipt and compatibility statement. It is not an authority
+database, credential vault, runtime orchestrator, or substitute for each repository's own release
+contract.

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
       "import": "./dist/memory/mcp_server/server.js"
     },
     "./schemas/cli-output.v1.schema.json": "./schemas/cli-output.v1.schema.json",
+    "./schemas/ecosystem-release-v1.schema.json": "./schemas/ecosystem-release-v1.schema.json",
     "./schemas/feature-spec-v0.json": "./schemas/feature-spec-v0.json",
     "./schemas/profile.schema.json": "./schemas/profile.schema.json"
   },
@@ -163,6 +164,7 @@
     "check:public-api": "node scripts/verify-public-api.mjs",
     "guard:pack": "node scripts/create-pack-json.js && node scripts/pack-guard.js && rm pack.json *.tgz",
     "check:release-drift": "node scripts/check-release-drift.mjs",
+    "check:ecosystem-release": "node scripts/validate-ecosystem-release.mjs",
     "check:mcp-registry-contract": "node scripts/verify-mcp-registry-contract.mjs --version $(node -p \"require('./package.json').version\")",
     "coverage": "c8 -r text -r lcov npm test",
     "check:coverage": "c8 --check-coverage --branches 60 --functions 60 --lines 60 --statements 60 npm test",

--- a/releases/ecosystem-3.1.json
+++ b/releases/ecosystem-3.1.json
@@ -1,0 +1,278 @@
+{
+  "$schema": "../canon/schemas/ecosystem-release-v1.schema.json",
+  "schemaVersion": 1,
+  "releaseId": "ecosystem-3.1",
+  "displayName": "Lex Ecosystem 3.1",
+  "state": "draft",
+  "runtime": {
+    "nodeMinimumMajor": 24,
+    "nodeUpperBoundExclusive": null
+  },
+  "components": [
+    {
+      "id": "lex",
+      "repository": "Guffawaffle/lex",
+      "role": "Canonical memory, trusted workspace authority, scoped stores, and KnowledgeFrame provider semantics.",
+      "participation": "required-package",
+      "runtimeRequirement": "required",
+      "status": "baseline",
+      "issues": [
+        "https://github.com/Guffawaffle/lex/issues/734",
+        "https://github.com/Guffawaffle/lex/issues/775",
+        "https://github.com/Guffawaffle/lex/issues/779",
+        "https://github.com/Guffawaffle/lex/issues/780",
+        "https://github.com/Guffawaffle/lex/issues/781",
+        "https://github.com/Guffawaffle/lex/issues/782"
+      ],
+      "package": {
+        "name": "@smartergpt/lex",
+        "registry": "https://registry.npmjs.org",
+        "access": "public",
+        "baselineVersion": "3.0.1",
+        "targetVersion": "3.1.0",
+        "publishedVersion": "3.0.1",
+        "integrity": "sha512-iHjxhYIHSva9CSgG4Cdn0DDR9TH60LCMrSsJ0ueqYi20IZT9env2852UBcf57qjTvDGHfKXRThgYzYVtUdDMzw=="
+      },
+      "source": {
+        "commit": "67839108ebc73564c78c7e71304eed0c602b1c28",
+        "tag": "v3.0.1"
+      },
+      "evidence": [
+        "https://github.com/Guffawaffle/lex/releases/tag/v3.0.1"
+      ]
+    },
+    {
+      "id": "lex-mcp",
+      "repository": "Guffawaffle/lex-mcp",
+      "role": "Thin exact-version wrapper that transports Lex's MCP server through npm and the MCP Registry.",
+      "participation": "required-package",
+      "runtimeRequirement": "required",
+      "status": "baseline",
+      "issues": [
+        "https://github.com/Guffawaffle/lex-mcp/issues/11"
+      ],
+      "package": {
+        "name": "@smartergpt/lex-mcp",
+        "registry": "https://registry.npmjs.org",
+        "access": "public",
+        "baselineVersion": "3.0.1",
+        "targetVersion": "3.1.0",
+        "publishedVersion": "3.0.1",
+        "integrity": "sha512-jz+t3O8ru7ZPZ5n7hKt8rxlbUc8F7Zr7FBoMy9t+qXgw78ieFBC+Hx5D0UtxKC+tb57nIrDHfD1yDsoHEGoERA=="
+      },
+      "source": {
+        "commit": "d0b20dab0d651aad6faac03fb2639f0902c56bef",
+        "tag": "v3.0.1"
+      },
+      "evidence": [
+        "https://github.com/Guffawaffle/lex-mcp/releases/tag/v3.0.1"
+      ]
+    },
+    {
+      "id": "lexsona",
+      "repository": "Guffawaffle/lexsona",
+      "role": "Optional deterministic constraint engine with immutable scoped snapshot output.",
+      "participation": "required-package",
+      "runtimeRequirement": "optional",
+      "status": "planned",
+      "issues": [
+        "https://github.com/Guffawaffle/lexsona/issues/125",
+        "https://github.com/Guffawaffle/lexsona/issues/126",
+        "https://github.com/Guffawaffle/lexsona/issues/127",
+        "https://github.com/Guffawaffle/lexsona/issues/128",
+        "https://github.com/Guffawaffle/lexsona/issues/130"
+      ],
+      "package": {
+        "name": "@smartergpt/lexsona",
+        "registry": "https://registry.npmjs.org",
+        "access": "restricted",
+        "baselineVersion": "1.0.0",
+        "targetVersion": null,
+        "publishedVersion": "1.0.0",
+        "integrity": "sha512-g5U7P2A+uq8bqGuV2rbVa9+BJ3t12ZhmE807odSVPog51z0Nxo5amo4tPhm74QohDQp65tEc9Y3spMSiL/CzzA=="
+      },
+      "source": {
+        "commit": "81c2b000806ff673053f0b33f74424205d3447cc",
+        "tag": "v1.0.0"
+      },
+      "evidence": [
+        "https://github.com/Guffawaffle/lexsona/releases/tag/v1.0.0"
+      ]
+    },
+    {
+      "id": "lexrunner",
+      "repository": "Guffawaffle/lexrunner",
+      "role": "Optional execution coordinator that pins LexSona snapshots without deriving authority from them.",
+      "participation": "required-package",
+      "runtimeRequirement": "required",
+      "status": "baseline",
+      "issues": [
+        "https://github.com/Guffawaffle/lexrunner/issues/820",
+        "https://github.com/Guffawaffle/lexrunner/issues/834"
+      ],
+      "package": {
+        "name": "@smartergpt/lexrunner",
+        "registry": "https://registry.npmjs.org",
+        "access": "restricted",
+        "baselineVersion": "1.2.1",
+        "targetVersion": null,
+        "publishedVersion": "1.2.1",
+        "integrity": "sha512-Gny9mrz/u/RCXOpDoU/q4HwPnQLEjB+cO5roI4Tru5pW1e1WAZSkD013XMfevHRXqEhFkMlPMSO8Sbj0liXKEQ=="
+      },
+      "source": {
+        "commit": "3316d38ad09aab21f55a896c8fa027f42046c8db",
+        "tag": "lexrunner-v1.2.1"
+      },
+      "evidence": [
+        "https://github.com/Guffawaffle/lexrunner/issues/823",
+        "https://github.com/Guffawaffle/lexrunner/releases/tag/lexrunner-v1.2.1"
+      ]
+    },
+    {
+      "id": "axf",
+      "repository": "Guffawaffle/axf",
+      "role": "Provider-neutral capability routing, context composition, budgeting, fallback, and conformance.",
+      "participation": "required-package",
+      "runtimeRequirement": "required",
+      "status": "baseline",
+      "issues": [
+        "https://github.com/Guffawaffle/axf/issues/42",
+        "https://github.com/Guffawaffle/axf/issues/49"
+      ],
+      "package": {
+        "name": "@smartergpt/axf",
+        "registry": "https://registry.npmjs.org",
+        "access": "public",
+        "baselineVersion": "2.0.0",
+        "targetVersion": null,
+        "publishedVersion": "2.0.0",
+        "integrity": "sha512-I9DmlJMytzdYeGjQlFXrWf4I6Njmab5LzDWhOB1dFNzTVu+uKGkcB8hKhb2FJ8+vt0uBgJ777VYbDPF7K1lpXg=="
+      },
+      "source": {
+        "commit": "67a2e0a00cf2360e97b0a1993dd659f89f9c0f5b",
+        "tag": "v2.0.0"
+      },
+      "evidence": [
+        "https://github.com/Guffawaffle/axf/releases/tag/v2.0.0"
+      ]
+    },
+    {
+      "id": "stfc-mod",
+      "repository": "Guffawaffle/stfc-mod",
+      "role": "Real-corpus downstream proof for KnowledgeFrame retrieval and AXF shadow routing.",
+      "participation": "required-source-proof",
+      "runtimeRequirement": "none",
+      "status": "planned",
+      "issues": [
+        "https://github.com/Guffawaffle/stfc-mod/issues/165"
+      ],
+      "package": null,
+      "source": {
+        "commit": null,
+        "tag": null
+      },
+      "evidence": []
+    }
+  ],
+  "edges": [
+    {
+      "from": "lex-mcp",
+      "to": "lex",
+      "kind": "runtime",
+      "releaseRequired": true,
+      "constraint": "exact"
+    },
+    {
+      "from": "lexsona",
+      "to": "lex",
+      "kind": "peer",
+      "releaseRequired": true,
+      "constraint": "manifest-selected"
+    },
+    {
+      "from": "lexrunner",
+      "to": "lex",
+      "kind": "runtime",
+      "releaseRequired": true,
+      "constraint": "manifest-selected"
+    },
+    {
+      "from": "lexrunner",
+      "to": "lexsona",
+      "kind": "optional",
+      "releaseRequired": true,
+      "constraint": "off-mode-remains-valid"
+    },
+    {
+      "from": "axf",
+      "to": "lex",
+      "kind": "conformance",
+      "releaseRequired": true,
+      "constraint": "no-runtime-dependency"
+    },
+    {
+      "from": "stfc-mod",
+      "to": "lex",
+      "kind": "downstream-proof",
+      "releaseRequired": true,
+      "constraint": "knowledge-shadow"
+    },
+    {
+      "from": "stfc-mod",
+      "to": "axf",
+      "kind": "downstream-proof",
+      "releaseRequired": true,
+      "constraint": "off-or-shadow"
+    }
+  ],
+  "gates": [
+    {
+      "id": "node-24",
+      "required": true,
+      "status": "planned",
+      "evidence": []
+    },
+    {
+      "id": "knowledge-context",
+      "required": true,
+      "status": "planned",
+      "evidence": []
+    },
+    {
+      "id": "behavioral-constraints",
+      "required": true,
+      "status": "planned",
+      "evidence": []
+    },
+    {
+      "id": "operator-recovery",
+      "required": true,
+      "status": "planned",
+      "evidence": []
+    },
+    {
+      "id": "linux-consumers",
+      "required": true,
+      "status": "planned",
+      "evidence": []
+    },
+    {
+      "id": "windows-consumers",
+      "required": true,
+      "status": "planned",
+      "evidence": []
+    },
+    {
+      "id": "sqlite-postgres-topology",
+      "required": true,
+      "status": "planned",
+      "evidence": []
+    },
+    {
+      "id": "signed-publication",
+      "required": true,
+      "status": "planned",
+      "evidence": []
+    }
+  ]
+}

--- a/scripts/public-api-contract.mjs
+++ b/scripts/public-api-contract.mjs
@@ -117,6 +117,11 @@ export const PUBLIC_EXPORT_CONTRACT = Object.freeze([
     anchors: [],
   },
   {
+    subpath: "./schemas/ecosystem-release-v1.schema.json",
+    purpose: "Ecosystem release manifest JSON Schema",
+    anchors: [],
+  },
+  {
     subpath: "./schemas/feature-spec-v0.json",
     purpose: "Versioned feature specification JSON Schema",
     anchors: [],

--- a/scripts/validate-ecosystem-release.mjs
+++ b/scripts/validate-ecosystem-release.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/* eslint-disable no-console -- this file is a CLI validator */
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const defaultManifestPath = resolve(rootDir, "releases/ecosystem-3.1.json");
+const schemaPath = resolve(rootDir, "canon/schemas/ecosystem-release-v1.schema.json");
+
+export const expectedComponentIds = ["axf", "lex", "lex-mcp", "lexrunner", "lexsona", "stfc-mod"];
+
+function formatSchemaError(error) {
+  const location = error.instancePath || "/";
+  return `${location} ${error.message}`;
+}
+
+function duplicateValues(values) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates].sort();
+}
+
+function containsPlaceholder(value) {
+  if (typeof value === "string") return /\b(?:TBD|TODO|PLACEHOLDER)\b/i.test(value);
+  if (Array.isArray(value)) return value.some(containsPlaceholder);
+  if (value && typeof value === "object") return Object.values(value).some(containsPlaceholder);
+  return false;
+}
+
+export function semanticErrors(manifest, { requireSealed = false } = {}) {
+  const errors = [];
+  const components = new Map(manifest.components.map((component) => [component.id, component]));
+  const componentIds = [...components.keys()].sort();
+
+  const duplicateComponents = duplicateValues(manifest.components.map((component) => component.id));
+  if (duplicateComponents.length > 0) {
+    errors.push(`duplicate component ids: ${duplicateComponents.join(", ")}`);
+  }
+
+  const missingComponents = expectedComponentIds.filter((id) => !components.has(id));
+  const unknownComponents = componentIds.filter((id) => !expectedComponentIds.includes(id));
+  if (missingComponents.length > 0) {
+    errors.push(`missing required components: ${missingComponents.join(", ")}`);
+  }
+  if (unknownComponents.length > 0) {
+    errors.push(`unknown components: ${unknownComponents.join(", ")}`);
+  }
+
+  if (manifest.runtime.nodeMinimumMajor !== 24) {
+    errors.push(`runtime.nodeMinimumMajor must be 24, got ${manifest.runtime.nodeMinimumMajor}`);
+  }
+  if (manifest.runtime.nodeUpperBoundExclusive !== null) {
+    errors.push(
+      "runtime.nodeUpperBoundExclusive must remain null unless a reviewed issue changes policy"
+    );
+  }
+
+  for (const component of manifest.components) {
+    const packageRequired = component.participation === "required-package";
+    if (packageRequired && component.package === null) {
+      errors.push(`${component.id} participates as a package but has no package record`);
+    }
+    if (!packageRequired && component.package !== null) {
+      errors.push(`${component.id} participates as source proof and must not declare a package`);
+    }
+  }
+
+  const edgeKeys = manifest.edges.map((edge) => `${edge.from}:${edge.to}:${edge.kind}`);
+  const duplicateEdges = duplicateValues(edgeKeys);
+  if (duplicateEdges.length > 0) {
+    errors.push(`duplicate dependency edges: ${duplicateEdges.join(", ")}`);
+  }
+
+  for (const edge of manifest.edges) {
+    if (!components.has(edge.from)) errors.push(`edge source does not exist: ${edge.from}`);
+    if (!components.has(edge.to)) errors.push(`edge target does not exist: ${edge.to}`);
+    if (edge.from === edge.to) errors.push(`self-referential edge is not allowed: ${edge.from}`);
+  }
+
+  const lex = components.get("lex");
+  const lexMcp = components.get("lex-mcp");
+  const exactLexEdge = manifest.edges.find(
+    (edge) =>
+      edge.from === "lex-mcp" &&
+      edge.to === "lex" &&
+      edge.kind === "runtime" &&
+      edge.releaseRequired === true &&
+      edge.constraint === "exact"
+  );
+  if (!exactLexEdge) {
+    errors.push("lex-mcp must have one release-required exact runtime edge to lex");
+  }
+  if (lex?.package?.targetVersion !== lexMcp?.package?.targetVersion) {
+    errors.push(
+      `lex and lex-mcp target versions must match exactly (${lex?.package?.targetVersion ?? "null"} != ${lexMcp?.package?.targetVersion ?? "null"})`
+    );
+  }
+
+  if (requireSealed && manifest.state !== "sealed") {
+    errors.push(`manifest must be sealed, got ${manifest.state}`);
+  }
+
+  if (manifest.state === "sealed") {
+    if (containsPlaceholder(manifest)) {
+      errors.push("sealed manifest contains a TBD, TODO, or PLACEHOLDER value");
+    }
+
+    for (const component of manifest.components) {
+      if (component.status !== "verified") {
+        errors.push(`${component.id} must be verified before sealing`);
+      }
+      if (!component.source.commit) {
+        errors.push(`${component.id} must identify an immutable commit before sealing`);
+      }
+      if (component.package && !component.source.tag) {
+        errors.push(`${component.id} must identify a signed package-release tag before sealing`);
+      }
+      if (component.evidence.length === 0) {
+        errors.push(`${component.id} must include immutable verification evidence before sealing`);
+      }
+      if (component.package) {
+        const { targetVersion, publishedVersion, integrity } = component.package;
+        if (!targetVersion || !publishedVersion || !integrity) {
+          errors.push(`${component.id} package evidence is incomplete before sealing`);
+        } else if (targetVersion !== publishedVersion) {
+          errors.push(
+            `${component.id} target version ${targetVersion} does not match published version ${publishedVersion}`
+          );
+        }
+      }
+    }
+
+    for (const gate of manifest.gates) {
+      if (gate.required && gate.status !== "passed") {
+        errors.push(`required gate ${gate.id} must pass before sealing`);
+      }
+      if (gate.required && gate.evidence.length === 0) {
+        errors.push(`required gate ${gate.id} must include immutable evidence before sealing`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+export async function validateManifest(manifest, options = {}) {
+  const schema = JSON.parse(await readFile(schemaPath, "utf8"));
+  const ajv = new Ajv({ allErrors: true, strict: true });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const valid = validate(manifest);
+  const errors = valid ? [] : validate.errors.map(formatSchemaError);
+  errors.push(...semanticErrors(manifest, options));
+  return errors;
+}
+
+function parseArgs(argv) {
+  let manifestPath = defaultManifestPath;
+  let requireSealed = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--sealed") {
+      requireSealed = true;
+    } else if (arg === "--manifest") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--manifest requires a path");
+      manifestPath = resolve(process.cwd(), value);
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return { manifestPath, requireSealed };
+}
+
+async function main() {
+  const { manifestPath, requireSealed } = parseArgs(process.argv.slice(2));
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const errors = await validateManifest(manifest, { requireSealed });
+
+  if (errors.length > 0) {
+    console.error(`❌ Ecosystem release manifest is invalid (${errors.length} issue(s)):`);
+    for (const error of errors) console.error(`- ${error}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `✅ ${manifest.displayName} manifest is valid (${manifest.state}, ${manifest.components.length} components, ${manifest.edges.length} edges)`
+  );
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().catch((error) => {
+    console.error(`❌ Ecosystem release validation failed: ${error.message}`);
+    process.exit(2);
+  });
+}

--- a/test/scripts/ecosystem-release-manifest.test.mjs
+++ b/test/scripts/ecosystem-release-manifest.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+import { semanticErrors, validateManifest } from "../../scripts/validate-ecosystem-release.mjs";
+
+const manifestUrl = new URL("../../releases/ecosystem-3.1.json", import.meta.url);
+
+async function draftManifest() {
+  return JSON.parse(await readFile(manifestUrl, "utf8"));
+}
+
+test("the checked-in draft manifest is structurally and semantically valid", async () => {
+  const manifest = await draftManifest();
+  assert.deepEqual(await validateManifest(manifest), []);
+});
+
+test("the semantic validator requires every ecosystem component", async () => {
+  const manifest = await draftManifest();
+  manifest.components = manifest.components.filter((component) => component.id !== "lexsona");
+  assert.match(semanticErrors(manifest).join("\n"), /missing required components: lexsona/);
+});
+
+test("Lex and Lex-MCP target versions must remain exact", async () => {
+  const manifest = await draftManifest();
+  const wrapper = manifest.components.find((component) => component.id === "lex-mcp");
+  wrapper.package.targetVersion = "3.1.1";
+  assert.match(semanticErrors(manifest).join("\n"), /target versions must match exactly/);
+});
+
+test("sealed manifests require immutable package, source, gate, and evidence receipts", async () => {
+  const manifest = await draftManifest();
+  manifest.state = "sealed";
+  const errors = await validateManifest(manifest, { requireSealed: true });
+  assert.ok(errors.some((error) => error.includes("lexsona must be verified")));
+  assert.ok(errors.some((error) => error.includes("package evidence is incomplete")));
+  assert.ok(errors.some((error) => error.includes("required gate node-24 must pass")));
+});
+
+test("a fully evidenced manifest can be sealed", async () => {
+  const manifest = await draftManifest();
+  manifest.state = "sealed";
+
+  for (const [index, component] of manifest.components.entries()) {
+    component.status = "verified";
+    component.source.commit = String(index + 1).padStart(40, "0");
+    component.source.tag = component.package ? `${component.id}-verified` : null;
+    component.evidence = [`https://github.com/Guffawaffle/lex/issues/${780 + index}`];
+    if (component.package) {
+      component.package.targetVersion ??= `1.${index}.0`;
+      component.package.publishedVersion = component.package.targetVersion;
+      component.package.integrity = "sha512-YWJjZA==";
+    }
+  }
+
+  const lex = manifest.components.find((component) => component.id === "lex");
+  const wrapper = manifest.components.find((component) => component.id === "lex-mcp");
+  wrapper.package.targetVersion = lex.package.targetVersion;
+  wrapper.package.publishedVersion = lex.package.targetVersion;
+
+  for (const gate of manifest.gates) {
+    gate.status = "passed";
+    gate.evidence = ["https://github.com/Guffawaffle/lex/issues/780"];
+  }
+
+  assert.deepEqual(await validateManifest(manifest, { requireSealed: true }), []);
+});
+
+test("--sealed semantics reject a valid draft", async () => {
+  const manifest = await draftManifest();
+  assert.match(semanticErrors(manifest, { requireSealed: true }).join("\n"), /must be sealed/);
+});


### PR DESCRIPTION
## What changed

- add the canonical Ecosystem 3.1 narrative dependency graph and coupled publication/recovery SOP
- add `EcosystemReleaseManifest_v1`, a six-component draft manifest, and seven typed compatibility/proof edges
- add structural plus semantic validation, including stricter sealed-release evidence rules
- publish the manifest schema through Lex's public export contract
- run draft manifest validation in CI
- add a minor changeset for the new public release-contract surface

## Why

Ecosystem 3.1 spans Lex, Lex-MCP, LexSona, LexRunner, AXF, and downstream STFC-Mod proof. Package versions remain independently honest, but release completion needs one machine-checkable compatible set and an explicit human publication boundary.

## Validation

- `npm run check:ecosystem-release`
- `node --test test/scripts/ecosystem-release-manifest.test.mjs` — 6 passing
- `npm run validate-schemas`
- `npm run validate-docs`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run check:public-api` — 29 exports
- `npm run guard:pack` — 701 files, 12 packaged schemas
- `git diff --check`

All commands ran with Node 24.18.0 / npm 11.16.0. Existing schema-hardening warnings remain on four pre-existing schemas; the new schema introduces none.

Closes #782