### PR TITLE
feat: require Node 24 runtime

### DIFF
--- a/.changeset/brave-nodes-align.md
+++ b/.changeset/brave-nodes-align.md
@@ -1,0 +1,5 @@
+---
+"@smartergpt/lex": minor
+---
+
+Raise the supported Node.js runtime floor to Node 24 and remove the unproven `<25` upper bound.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - run: npm ci --ignore-scripts
       - run: npm run lint
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - run: npm ci --ignore-scripts
       - run: npm run build
@@ -110,10 +110,11 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - run: npm ci --ignore-scripts
       - run: npm run check:mcp-registry-contract
+      - run: npm run check:node-runtime
       - run: npm run check:ecosystem-release
 
   # Standard gates: build + tests (only on workflow_dispatch with level >= standard)
@@ -128,7 +129,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - run: npm ci --ignore-scripts
       - run: npm rebuild better-sqlite3-multiple-ciphers
@@ -148,7 +149,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - run: npm ci --ignore-scripts
       - run: npm rebuild better-sqlite3-multiple-ciphers
@@ -167,7 +168,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - run: npm ci --ignore-scripts
       - run: npm run setup-local

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -3,7 +3,7 @@ name: Dependency Updates
 on:
   schedule:
     # Run every Monday at 10 AM UTC
-    - cron: '0 10 * * 1'
+    - cron: "0 10 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "24"
 
       - name: Check for outdated dependencies
         id: check

--- a/.github/workflows/determinism.yml
+++ b/.github/workflows/determinism.yml
@@ -2,7 +2,7 @@ name: Build Determinism
 
 on:
   push:
-    branches: [main, develop, 'copilot/**']
+    branches: [main, develop, "copilot/**"]
   pull_request:
 
 jobs:
@@ -12,26 +12,26 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
-      
+          node-version: "24"
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Build twice and compare
         run: |
           # First build
           npm run build
           cp -r prompts prompts.first
           cp -r schemas schemas.first
-          
+
           # Clean and rebuild
           rm -rf prompts schemas
           npm run copy-canon
-          
+
           # Compare outputs
           diff -r prompts.first prompts || exit 1
           diff -r schemas.first schemas || exit 1

--- a/.github/workflows/lint-budget.yml
+++ b/.github/workflows/lint-budget.yml
@@ -2,9 +2,9 @@ name: Lint Budget Guard
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -33,8 +33,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
 
       - name: Install dependencies (hermetic)
         run: npm ci --ignore-scripts

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies (hermetic)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
@@ -120,7 +120,7 @@ jobs:
   #
   #     - uses: actions/setup-node@v6
   #       with:
-  #         node-version: "20"
+  #         node-version: "24"
   #         registry-url: "https://registry.npmjs.org"
   #
   #     - name: Download artifacts

--- a/.github/workflows/test-aliasing.yml
+++ b/.github/workflows/test-aliasing.yml
@@ -2,9 +2,9 @@ name: Alias Resolution Tests
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 # Limit permissions to read-only by default
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test-aliases:
-    name: Alias Tests (Node 20)
+    name: Alias Tests (Node 24)
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +23,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
 
       - name: Install dependencies (hermetic)
         run: npm ci --ignore-scripts
@@ -70,8 +70,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
 
       - name: Install dependencies (hermetic)
         run: npm ci --ignore-scripts
@@ -108,8 +108,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
 
       - name: Install dependencies (hermetic)
         run: npm ci --ignore-scripts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["20", "22", "24"]
+        node: ["24"]
 
     steps:
       - name: Checkout code
@@ -61,7 +61,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: test
-    # Keep deeper suites on the lowest supported runtime; the matrix above validates 22/24 compatibility.
+    # Keep deeper suites on the supported runtime contract.
 
     steps:
       - name: Checkout code
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies (hermetic)
@@ -103,7 +103,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies (hermetic)

--- a/.github/workflows/validate-canon.yml
+++ b/.github/workflows/validate-canon.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm ci

--- a/CONFLICT_RESOLUTION.md
+++ b/CONFLICT_RESOLUTION.md
@@ -122,7 +122,7 @@ npm install lex
 
 ### Prerequisites
 
-Node.js 20+
+Node.js 24+
 
 ## Usage
 
@@ -137,7 +137,7 @@ npm install lex
 
 ### Prerequisites
 
-Node.js 20+
+Node.js 24+
 
 ## Usage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Before committing, ensure:
 
 ### Prerequisites
 
-- **Node.js**: 20.x, 22.x, or 24.x (we recommend 24 for development)
+- **Node.js**: 24.x or newer (24 is the minimum supported release line)
 - **npm**: 9+ (comes with Node.js)
 - **Git**: 2.30+
 
@@ -588,7 +588,7 @@ For the complete release workflow, tag signing, and rollback procedures, see [RE
 GitHub divides validation across focused workflows. The primary PR surface includes signed-commit
 verification, lint, type checking, MCP registry-contract checks, build/coverage, integration
 tests, and package validation. Separate workflows enforce the lint budget, canonical artifacts and
-documentation, determinism, aliases, and the Node 20/22/24 test matrix.
+documentation, determinism, aliases, and the Node 24 runtime contract.
 
 ### Checks
 1. **Type Check** - `npm run type-check`

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -10,7 +10,7 @@ projection, AXF, LexRunner, or LexSona.
 
 You need:
 
-- Node.js 20 through 24;
+- Node.js 24 or newer;
 - a Git repository;
 - a disposable branch, worktree, or clone if you want complete filesystem isolation;
 - approval to create `.smartergpt/lex/memory.db` in the pilot workspace.

--- a/README.mcp.md
+++ b/README.mcp.md
@@ -112,7 +112,7 @@ existing attachment behavior.
 ## Process boundary
 
 - **Transport:** stdio using JSON-RPC 2.0
-- **Runtime:** Node.js 20 through 24
+- **Runtime:** Node.js 24 or newer
 - **Implementation:** `@smartergpt/lex-mcp` is a thin launcher around the server exported by
   `@smartergpt/lex`
 - **Network:** the MCP transport itself does not open a listening port; PostgreSQL and your MCP

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ boundaries surrounding that code—then recalls only what the next session needs
 [![MIT License](https://img.shields.io/badge/License-MIT-green)](./LICENSE)
 [![npm version](https://img.shields.io/npm/v/@smartergpt/lex)](https://www.npmjs.com/package/@smartergpt/lex)
 [![CI Status](https://img.shields.io/badge/CI-passing-success)](https://github.com/Guffawaffle/lex/actions)
-[![Node.js](https://img.shields.io/badge/Node.js-20--24-339933)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-24%2B-339933)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6)](https://www.typescriptlang.org/)
 
 [See the core loop](#remember--recall--continue) · [Should I use Lex?](#should-i-use-lex) · [Five-minute pilot](#five-minute-pilot) · [Agent evaluation](./docs/agent-evaluation.md) · [Documentation](#choose-your-next-step)
@@ -114,7 +114,9 @@ The complete rubric and local-file version are in
 Ready to test the claim? Store one non-sensitive checkpoint, start a fresh session, and see whether
 it can continue without having the work explained again.
 
-Requires Node.js 20 through 24.
+Requires Node.js 24 or newer. Lex does not impose an unproven upper bound. Existing users should
+review the [Node 24 migration](docs/releases/node-24-migration.md), including the native SQLite
+rebuild step.
 
 This approved pilot writes one Frame to the local SQLite store under `.smartergpt/lex/`. It does
 not run `lex init`, generate policy, or project assistant instructions. Use a disposable branch,

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,5 +1,5 @@
 # ci.Dockerfile — Local CI replica image (not used by Actions)
-FROM node:22-bookworm
+FROM node:24-bookworm
 
 # Basic OS deps for native modules like better-sqlite3
 # Add ripgrep for script detection in ci.sh

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -9,7 +9,7 @@ This document tracks performance metrics for Lex, particularly focusing on datab
 - **Library:** better-sqlite3-multiple-ciphers v12.4.6
 - **Cipher:** SQLCipher with AES-256
 - **Key Derivation:** PBKDF2-SHA256, 64,000 iterations
-- **Test Environment:** Node.js v20+, Ubuntu Linux
+- **Test Environment:** Node.js v24+, Ubuntu Linux
 - **Database Size:** 2-10K frames (typical development workload)
 
 ### Encryption Overhead

--- a/docs/adr/0001-ts-only-nodenext.md
+++ b/docs/adr/0001-ts-only-nodenext.md
@@ -35,7 +35,7 @@ Prior to this decision, the repository had a mix of `.ts` and `.js` files in `sr
 Lex is a library that needs to:
 - Provide strong type safety guarantees to consumers
 - Emit clean, predictable ESM modules
-- Support modern Node.js (18+) without legacy CommonJS baggage
+- Support the current Node.js 24+ runtime contract without legacy CommonJS baggage
 - Enable deterministic builds via TypeScript project references
 - Allow developers to confidently refactor without runtime surprises
 

--- a/docs/releases/node-24-migration.md
+++ b/docs/releases/node-24-migration.md
@@ -1,0 +1,57 @@
+# Node 24 runtime migration
+
+Lex 3.1 raises the supported runtime floor from Node 20–24 to Node 24 or newer. Node 20 and Node 22
+are no longer tested or supported. Lex does not impose a `<25` ceiling without evidence of an actual
+incompatibility.
+
+## Who must act
+
+Upgrade before installing the Lex 3.1 release if any current environment reports a Node major below
+24:
+
+```bash
+node --version
+npm --version
+```
+
+The supported baseline used by the release gates is Node 24 with its current bundled npm line.
+
+## Clean dependency refresh
+
+Native SQLite modules are compiled for a specific Node ABI. After changing Node majors, refresh the
+checkout's dependencies and rebuild the native module under Node 24:
+
+```bash
+npm ci --ignore-scripts
+npm rebuild better-sqlite3-multiple-ciphers
+npm run check-sqlite
+```
+
+Do not copy `node_modules` between Windows, WSL, Linux, or macOS. Each native execution surface must
+install and rebuild independently.
+
+## Consumer behavior
+
+- npm may warn or fail engine validation when a Lex 3.1 package is installed below Node 24.
+- Existing Lex 3.0.1 artifacts retain their published `>=20 <25` contract; their metadata is
+  immutable.
+- The 3.1 line validates package exports, CLI startup, MCP startup/tool inventory, and native SQLite
+  loading on Node 24.
+- A future Node release is not rejected preemptively. If evidence finds an incompatibility, open a
+  bounded issue and add a reviewed ceiling or workaround then.
+
+## CI and container migration
+
+Replace Node 20/22 matrices and images with Node 24. Current Lex workflows intentionally test one
+supported major rather than spending required CI time proving runtimes the package no longer
+supports.
+
+Run the drift guard locally when editing package, workflow, container, or runtime documentation:
+
+```bash
+npm run check:node-runtime
+```
+
+The guard checks package/lock metadata, `.nvmrc`, the CI image, active workflows, current guidance,
+and the Ecosystem 3.1 manifest. Historical changelog statements remain unchanged because they
+describe earlier immutable releases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@types/express": "^5.0.5",
         "@types/jsonwebtoken": "^9.0.10",
-        "@types/node": ">=20 <25",
+        "@types/node": "^24.0.0",
         "@types/pg": "^8.20.0",
         "axios": "^1.13.2",
         "better-sqlite3-multiple-ciphers": "^12.6.2",
@@ -60,7 +60,7 @@
         "tsx": "^4.20.6"
       },
       "engines": {
-        "node": ">=20 <25"
+        "node": ">=24"
       },
       "optionalDependencies": {
         "pino-pretty": "^13.1.2"

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "check:public-api": "node scripts/verify-public-api.mjs",
     "guard:pack": "node scripts/create-pack-json.js && node scripts/pack-guard.js && rm pack.json *.tgz",
     "check:release-drift": "node scripts/check-release-drift.mjs",
+    "check:node-runtime": "node scripts/check-node-runtime-contract.mjs",
     "check:ecosystem-release": "node scripts/validate-ecosystem-release.mjs",
     "check:mcp-registry-contract": "node scripts/verify-mcp-registry-contract.mjs --version $(node -p \"require('./package.json').version\")",
     "coverage": "c8 -r text -r lcov npm test",
@@ -214,7 +215,7 @@
   },
   "homepage": "https://github.com/Guffawaffle/lex#readme",
   "engines": {
-    "node": ">=20 <25"
+    "node": ">=24"
   },
   "peerDependencies": {
     "pino-pretty": "*"
@@ -231,7 +232,7 @@
   "dependencies": {
     "@types/express": "^5.0.5",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/node": ">=20 <25",
+    "@types/node": "^24.0.0",
     "@types/pg": "^8.20.0",
     "axios": "^1.13.2",
     "better-sqlite3-multiple-ciphers": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "postinstall": "node -e \"if (process.env.npm_config_global === 'true' || !process.cwd().includes('node_modules')) { console.log('\\n📦 Lex installed! Run \\\"npx lex init\\\" to set up your workspace.\\n'); }\"",
     "setup-local": "./scripts/setup-local.sh",
     "build": "tsc -b tsconfig.build.json",
-    "postbuild": "chmod +x dist/shared/cli/lex.js && npm run copy-canon",
+    "postbuild": "node scripts/ensure-cli-executable.mjs && npm run copy-canon",
     "copy-canon": "node scripts/copy-canon.js",
     "clean": "tsc -b tsconfig.build.json --clean && rimraf dist prompts schemas",
     "validate-schemas": "node scripts/validate-schemas.js",

--- a/scripts/check-node-runtime-contract.mjs
+++ b/scripts/check-node-runtime-contract.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/* eslint-disable no-console -- this file is a CLI contract check */
+
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const currentGuidancePaths = [
+  "CONFLICT_RESOLUTION.md",
+  "CONTRIBUTING.md",
+  "QUICK_START.md",
+  "README.md",
+  "README.mcp.md",
+  "docs/PERFORMANCE.md",
+  "docs/adr/0001-ts-only-nodenext.md",
+  "src/memory/renderer/graph.ts",
+  "src/shared/aliases/TESTING.md",
+];
+
+const unsupportedWorkflowPatterns = [
+  /\bNode(?:\.js)?(?:\s+|[-v])(?:18|20|22)(?:\+|\b)/i,
+  /node-version:\s*["']?(?:18|20|22)\b/i,
+  /\bnode:\s*\[[^\]]*["'](?:18|20|22)["']/i,
+  /\bFROM\s+node:(?:18|20|22)\b/i,
+];
+
+const unsupportedRuntimePatterns = [...unsupportedWorkflowPatterns, /(?:>=\s*(?:18|20)|<\s*25)\b/i];
+
+function staleClaims(text, patterns = unsupportedRuntimePatterns) {
+  return patterns.filter((pattern) => pattern.test(text)).map(String);
+}
+
+export function runtimeContractErrors(snapshot) {
+  const errors = [];
+  const rootLock = snapshot.packageLock.packages?.[""];
+  const resolvedNodeTypes = snapshot.packageLock.packages?.["node_modules/@types/node"]?.version;
+
+  if (snapshot.packageJson.engines?.node !== ">=24") {
+    errors.push(
+      `package.json engines.node must be >=24, got ${snapshot.packageJson.engines?.node}`
+    );
+  }
+  if (snapshot.packageJson.dependencies?.["@types/node"] !== "^24.0.0") {
+    errors.push(
+      `package.json @types/node must be ^24.0.0, got ${snapshot.packageJson.dependencies?.["@types/node"]}`
+    );
+  }
+  if (rootLock?.engines?.node !== ">=24") {
+    errors.push(`package-lock root engines.node must be >=24, got ${rootLock?.engines?.node}`);
+  }
+  if (rootLock?.dependencies?.["@types/node"] !== "^24.0.0") {
+    errors.push(
+      `package-lock root @types/node must be ^24.0.0, got ${rootLock?.dependencies?.["@types/node"]}`
+    );
+  }
+  if (!resolvedNodeTypes || Number.parseInt(resolvedNodeTypes.split(".")[0], 10) !== 24) {
+    errors.push(`resolved @types/node must be on major 24, got ${resolvedNodeTypes ?? "missing"}`);
+  }
+  if (snapshot.nvmrc.trim() !== "24") {
+    errors.push(`.nvmrc must select 24, got ${snapshot.nvmrc.trim() || "empty"}`);
+  }
+  if (!/^FROM\s+node:24(?:-|\s|$)/m.test(snapshot.ciDockerfile)) {
+    errors.push("ci.Dockerfile must use a Node 24 base image");
+  }
+
+  for (const [path, text] of Object.entries(snapshot.workflows)) {
+    const claims = staleClaims(text, unsupportedWorkflowPatterns);
+    if (claims.length > 0) errors.push(`${path} contains an unsupported runtime selection`);
+    if (
+      text.includes("actions/setup-node") &&
+      !/node-version:\s*(?:["']24["']|\$\{\{\s*matrix\.node\s*\}\})/.test(text)
+    ) {
+      errors.push(`${path} uses actions/setup-node without an explicit Node 24 selection`);
+    }
+  }
+
+  for (const [path, text] of Object.entries(snapshot.currentGuidance)) {
+    if (staleClaims(text).length > 0) {
+      errors.push(`${path} contains an unsupported current Node 18/20/22 claim or <25 ceiling`);
+    }
+  }
+
+  if (snapshot.ecosystemManifest.runtime?.nodeMinimumMajor !== 24) {
+    errors.push("Ecosystem 3.1 manifest must declare Node minimum major 24");
+  }
+  if (snapshot.ecosystemManifest.runtime?.nodeUpperBoundExclusive !== null) {
+    errors.push("Ecosystem 3.1 manifest must not carry an unproven Node upper bound");
+  }
+
+  return errors;
+}
+
+export async function loadRuntimeSnapshot(baseDir = rootDir) {
+  const workflowDir = join(baseDir, ".github/workflows");
+  const workflowNames = (await readdir(workflowDir)).filter(
+    (name) => name.endsWith(".yml") || name.endsWith(".yaml")
+  );
+  const workflows = Object.fromEntries(
+    await Promise.all(
+      workflowNames.map(async (name) => [
+        `.github/workflows/${name}`,
+        await readFile(join(workflowDir, name), "utf8"),
+      ])
+    )
+  );
+  const currentGuidance = Object.fromEntries(
+    await Promise.all(
+      currentGuidancePaths.map(async (path) => [path, await readFile(join(baseDir, path), "utf8")])
+    )
+  );
+
+  return {
+    packageJson: JSON.parse(await readFile(join(baseDir, "package.json"), "utf8")),
+    packageLock: JSON.parse(await readFile(join(baseDir, "package-lock.json"), "utf8")),
+    nvmrc: await readFile(join(baseDir, ".nvmrc"), "utf8"),
+    ciDockerfile: await readFile(join(baseDir, "ci.Dockerfile"), "utf8"),
+    workflows,
+    currentGuidance,
+    ecosystemManifest: JSON.parse(
+      await readFile(join(baseDir, "releases/ecosystem-3.1.json"), "utf8")
+    ),
+  };
+}
+
+async function main() {
+  const snapshot = await loadRuntimeSnapshot();
+  const errors = runtimeContractErrors(snapshot);
+  if (errors.length > 0) {
+    console.error(`❌ Node runtime contract drifted (${errors.length} issue(s)):`);
+    for (const error of errors) console.error(`- ${error}`);
+    process.exit(1);
+  }
+  console.log(
+    `✅ Node runtime contract is aligned at >=24 (${Object.keys(snapshot.workflows).length} workflows, ${Object.keys(snapshot.currentGuidance).length} guidance files)`
+  );
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().catch((error) => {
+    console.error(`❌ Node runtime contract check failed: ${error.message}`);
+    process.exit(2);
+  });
+}

--- a/scripts/ensure-cli-executable.mjs
+++ b/scripts/ensure-cli-executable.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/* eslint-disable no-console -- this file is a postbuild CLI check */
+
+import { access, chmod } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cliRelativePath = "dist/shared/cli/lex.js";
+
+export async function ensureCliExecutable({
+  baseDir = rootDir,
+  platform = process.platform,
+  operations = { access, chmod },
+} = {}) {
+  const cliPath = resolve(baseDir, cliRelativePath);
+  await operations.access(cliPath);
+
+  if (platform !== "win32") {
+    await operations.chmod(cliPath, 0o755);
+  }
+
+  return { cliPath, chmodApplied: platform !== "win32" };
+}
+
+async function main() {
+  const result = await ensureCliExecutable();
+  const action = result.chmodApplied ? "marked executable" : "verified for Windows packaging";
+  console.log(`✓ CLI artifact ${action}: ${cliRelativePath}`);
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().catch((error) => {
+    console.error(`✗ CLI artifact postbuild check failed: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/src/memory/renderer/graph.ts
+++ b/src/memory/renderer/graph.ts
@@ -422,7 +422,7 @@ export async function exportGraphAsPNG(
   // If you believe you can fix this, you must:
   // 1. Ensure it works with both ESM and CommonJS Node.js configurations
   // 2. Test with sharp installed AND uninstalled (should gracefully fail)
-  // 3. Verify across Node.js versions 18, 20, and 22
+  // 3. Verify against the supported Node.js 24 runtime contract
   // 4. Document the fix in the PR description with test evidence
   //
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment

--- a/src/shared/aliases/TESTING.md
+++ b/src/shared/aliases/TESTING.md
@@ -187,7 +187,7 @@ describe("Feature Name", () => {
 
 The alias tests run automatically on every PR via `.github/workflows/test-aliasing.yml`:
 
-- Runs on Node 20 and 22
+- Runs on the supported Node 24 runtime
 - Checks test passing
 - Verifies 90%+ branch coverage
 - Fails PR if any tests fail

--- a/test/scripts/ensure-cli-executable.test.mjs
+++ b/test/scripts/ensure-cli-executable.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { ensureCliExecutable } from "../../scripts/ensure-cli-executable.mjs";
+
+test("the postbuild check skips the POSIX chmod operation on Windows", async () => {
+  const calls = [];
+  const result = await ensureCliExecutable({
+    baseDir: "C:/lex",
+    platform: "win32",
+    operations: {
+      access: async (path) => calls.push(["access", path]),
+      chmod: async (path, mode) => calls.push(["chmod", path, mode]),
+    },
+  });
+
+  assert.equal(result.chmodApplied, false);
+  assert.deepEqual(calls, [["access", result.cliPath]]);
+});
+
+test("the postbuild check preserves executable permissions on POSIX", async () => {
+  const calls = [];
+  const result = await ensureCliExecutable({
+    baseDir: "/work/lex",
+    platform: "linux",
+    operations: {
+      access: async (path) => calls.push(["access", path]),
+      chmod: async (path, mode) => calls.push(["chmod", path, mode]),
+    },
+  });
+
+  assert.equal(result.chmodApplied, true);
+  assert.deepEqual(calls, [
+    ["access", result.cliPath],
+    ["chmod", result.cliPath, 0o755],
+  ]);
+});
+
+test("the postbuild check fails when the built CLI artifact is missing", async () => {
+  await assert.rejects(
+    ensureCliExecutable({
+      operations: {
+        access: async () => {
+          throw new Error("missing CLI artifact");
+        },
+        chmod: async () => {},
+      },
+    }),
+    /missing CLI artifact/
+  );
+});

--- a/test/scripts/node-runtime-contract.test.mjs
+++ b/test/scripts/node-runtime-contract.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  loadRuntimeSnapshot,
+  runtimeContractErrors,
+} from "../../scripts/check-node-runtime-contract.mjs";
+
+test("the checked-in repository satisfies the Node 24 runtime contract", async () => {
+  assert.deepEqual(runtimeContractErrors(await loadRuntimeSnapshot()), []);
+});
+
+test("the contract rejects a legacy package range and upper bound", async () => {
+  const snapshot = await loadRuntimeSnapshot();
+  snapshot.packageJson.engines.node = ">=20 <25";
+  assert.match(runtimeContractErrors(snapshot).join("\n"), /engines\.node must be >=24/);
+});
+
+test("the contract rejects an active Node 20 workflow", async () => {
+  const snapshot = await loadRuntimeSnapshot();
+  snapshot.workflows[".github/workflows/example.yml"] = `
+steps:
+  - uses: actions/setup-node@v6
+    with:
+      node-version: "20"
+`;
+  assert.match(runtimeContractErrors(snapshot).join("\n"), /unsupported runtime selection/);
+});
+
+test("the contract rejects stale current guidance", async () => {
+  const snapshot = await loadRuntimeSnapshot();
+  snapshot.currentGuidance["README.md"] += "\nSupports Node.js 20 through 24.\n";
+  assert.match(runtimeContractErrors(snapshot).join("\n"), /unsupported current Node/);
+});
+
+test("the contract rejects a mismatched ecosystem release policy", async () => {
+  const snapshot = await loadRuntimeSnapshot();
+  snapshot.ecosystemManifest.runtime.nodeUpperBoundExclusive = 25;
+  assert.match(
+    runtimeContractErrors(snapshot).join("\n"),
+    /must not carry an unproven Node upper bound/
+  );
+});


### PR DESCRIPTION
## Summary

- raise Lex package, lock, Docker, workflow, and current documentation runtime contract to Node 24+
- remove the unproven `<25` ceiling and add a migration guide
- add a CI drift guard with bounded negative-path tests across package metadata, workflows, docs, and the Ecosystem 3.1 manifest
- replace the POSIX-only postbuild `chmod` command with a tested cross-platform Node check
- queue a minor changeset for the 3.1 line

## Validation

Linux, Node `v24.18.0`, npm `11.16.0`:

- runtime drift guard and 5 negative-path tests
- cross-platform postbuild tests for Windows, POSIX, and missing artifacts
- lint, type-check, build, documentation, schemas, and ecosystem manifest
- public API, SQLite native binding, release drift, pack guard, and clean packed-consumer smoke
- signed commits verified locally

Native Windows x64, Node `v24.14.1`, npm `11.11.0`:

- exact `>=24` engine contract with no upper bound
- all 29 ESM exports
- CommonJS-host dynamic `import()` without a synchronous `require()` claim
- CLI version/help
- MCP handshake with all 14 expected tools
- native SQLite disk create/write/read
- packed artifact SHA-256 `120d064783ee1f7a519ba817447e7da663b67366ee5ecac280429c195e3416c7`

Windows evidence: [issue comment](https://github.com/Guffawaffle/lex/issues/781#issuecomment-5040255762), [PR comment](https://github.com/Guffawaffle/lex/pull/786#issuecomment-5040255856).

## Security note

The clean install surfaced two high advisories published/updated on 2026-07-21. Their remediation is isolated in release blocker #785 because the direct `sharp` 0.34→0.35 transition needs renderer/native compatibility evidence.

Closes #781
