### PR TITLE
fix(mcp): align Frame fallback and scope health

### DIFF
--- a/README.mcp.md
+++ b/README.mcp.md
@@ -57,6 +57,11 @@ After restarting the MCP client, ask it to call `system_introspect`, then `frame
 limit. Introspection should identify the selected workspace and store. Listing an empty store is a
 valid result.
 
+Introspection also reports the shared Frame write contract and scope health. If policy is
+unavailable or no policy-backed module applies, use the explicit fallback
+`{"module_scope":["workspace/unscoped"]}`. Empty scope is still invalid; `frame_validate` returns
+that exact payload as structured remediation.
+
 ## Tools
 
 | Tool | Purpose |

--- a/src/memory/mcp_server/README.md
+++ b/src/memory/mcp_server/README.md
@@ -53,6 +53,21 @@ exactly fourteen canonical `resource_action` names:
 | `turncost_calculate` | Calculate bounded turn-cost estimates |
 | `contradictions_scan` | Find conflicting Frame claims |
 
+## Frame write fallback and scope health
+
+`frame_create` and `frame_validate` require a non-empty `module_scope`. When no policy-backed
+module applies, callers must send the canonical fallback explicitly:
+
+```json
+{ "module_scope": ["workspace/unscoped"] }
+```
+
+Fallback Frames retain `module_attribution.mode = "fallback"` when stored and retrieved.
+`system_introspect` exposes the same structured write contract plus scope health: policy
+availability and source, policy module count, unscoped Frame count, and a bounded summary of
+Frame module IDs absent from the loaded policy. An empty scope remains invalid and returns the
+exact fallback payload as structured remediation; it is never silently rewritten.
+
 Accepted legacy aliases are compatibility inputs only. They are not advertised tools and must not
 appear as the preferred name in current consumer documentation. Alias mappings and capability
 coverage live in [`../../shared/runtime-scope/capabilities.ts`](../../shared/runtime-scope/capabilities.ts).

--- a/src/memory/mcp_server/server.ts
+++ b/src/memory/mcp_server/server.ts
@@ -79,6 +79,13 @@ import {
   type TrustedRuntimeScopeBootstrapResultV1,
   type TrustedRuntimeScopeEntrypointGuardV1,
 } from "../../shared/runtime-scope/index.js";
+import {
+  buildFrameWriteContract,
+  createFallbackModuleAttribution,
+  UNSCOPED_MODULE_ID,
+  type FrameWriteContract,
+  type ModuleAttribution,
+} from "../../shared/cli/frame-write-contract.js";
 
 const logger = getLogger("memory:mcp_server:server");
 
@@ -101,6 +108,92 @@ function getPackageVersion(): string {
  * Increase this value if you have very large frame stores.
  */
 const MAX_FILTER_FETCH_LIMIT = 1000;
+const SCOPE_HEALTH_PAGE_SIZE = 500;
+const SCOPE_HEALTH_SUMMARY_LIMIT = 10;
+const MCP_FRAME_REQUIRED_FIELDS = [
+  "reference_point",
+  "summary_caption",
+  "status_snapshot",
+  "module_scope",
+] as const;
+const MCP_FRAME_RECOMMENDED_FIELDS = ["branch", "jira", "keywords"] as const;
+
+interface MCPFrameWriteContract {
+  requiredFields: readonly string[];
+  recommendedFields: readonly string[];
+  policy: FrameWriteContract["policy"];
+  inference: {
+    available: boolean;
+    mode: "suggestions-only";
+  };
+  fallback: {
+    available: true;
+    moduleId: typeof UNSCOPED_MODULE_ID;
+    input: {
+      module_scope: [typeof UNSCOPED_MODULE_ID];
+    };
+  };
+  suggestions: FrameWriteContract["suggestions"];
+}
+
+interface ScopeHealth {
+  policy: {
+    state: "loaded" | "unavailable";
+    source: string;
+    path: string | null;
+    moduleCount: number;
+  };
+  frames: {
+    state: "available" | "unavailable";
+    unscopedCount: number;
+    drift: {
+      state: "evaluated" | "not-evaluated";
+      frameCount: number;
+      moduleIdCount: number;
+      modules: Array<{ moduleId: string; frameCount: number }>;
+      summaryLimit: number;
+      truncated: boolean;
+    };
+  };
+}
+
+function toMCPFrameWriteContract(contract: FrameWriteContract): MCPFrameWriteContract {
+  return {
+    requiredFields: MCP_FRAME_REQUIRED_FIELDS,
+    recommendedFields: MCP_FRAME_RECOMMENDED_FIELDS,
+    policy: contract.policy,
+    inference: {
+      available: contract.inference.available,
+      mode: "suggestions-only",
+    },
+    fallback: {
+      available: true,
+      moduleId: contract.fallback.moduleId,
+      input: {
+        module_scope: [contract.fallback.moduleId],
+      },
+    },
+    suggestions: contract.suggestions,
+  };
+}
+
+function isCanonicalUnscopedScope(moduleScope: unknown): moduleScope is string[] {
+  return (
+    Array.isArray(moduleScope) && moduleScope.length === 1 && moduleScope[0] === UNSCOPED_MODULE_ID
+  );
+}
+
+function fallbackRemediation(): {
+  message: string;
+  input: { module_scope: [typeof UNSCOPED_MODULE_ID] };
+} {
+  return {
+    message: `Use the canonical fallback exactly as shown when no policy-backed module applies: {"module_scope":["${UNSCOPED_MODULE_ID}"]}`,
+    input: {
+      module_scope: [UNSCOPED_MODULE_ID],
+    },
+  };
+}
 
 interface RememberArgs {
   reference_point: string;
@@ -877,14 +970,18 @@ export class MCPServer {
       throw new MCPError(
         MCPErrorCode.VALIDATION_REQUIRED_FIELD,
         `Missing required fields: ${missing.join(", ")}`,
-        { missingFields: missing }
+        {
+          missingFields: missing,
+          ...(missing.includes("module_scope") ? { remediation: fallbackRemediation() } : {}),
+        }
       );
     }
 
     if (!Array.isArray(module_scope) || module_scope.length === 0) {
       throw new MCPError(
         MCPErrorCode.VALIDATION_EMPTY_MODULE_SCOPE,
-        "module_scope must be a non-empty array of module IDs"
+        "module_scope must be a non-empty array of module IDs",
+        { remediation: fallbackRemediation() }
       );
     }
 
@@ -898,7 +995,15 @@ export class MCPServer {
 
     // THE CRITICAL RULE: Resolve aliases and validate module IDs against policy (if available)
     let canonicalModuleScope = module_scope;
-    if (context.policy) {
+    const fallbackScope = isCanonicalUnscopedScope(module_scope);
+    const moduleAttribution: ModuleAttribution = fallbackScope
+      ? createFallbackModuleAttribution("mcp:module_scope")
+      : {
+          mode: "explicit",
+          confidence: "high",
+          evidence: ["mcp:module_scope"],
+        };
+    if (context.policy && !fallbackScope) {
       const validationResult = await validateModuleIds(module_scope, context.policy);
 
       if (!validationResult.valid && validationResult.errors) {
@@ -953,6 +1058,7 @@ export class MCPServer {
       keywords: keywords || undefined,
       atlas_frame_id: atlas_frame_id || undefined,
       image_ids: [] as string[],
+      module_attribution: moduleAttribution,
     };
 
     // Process image attachments if provided
@@ -1016,6 +1122,8 @@ export class MCPServer {
       success: true,
       frame_id: frameId,
       created_at: timestamp,
+      module_scope: canonicalModuleScope,
+      module_attribution: moduleAttribution,
     };
 
     // Include atlas_frame_id if one was provided or stored
@@ -1065,15 +1173,27 @@ export class MCPServer {
       summary_caption,
       status_snapshot,
       module_scope,
-      branch: _branch,
+      branch,
       jira,
       keywords: _keywords,
       atlas_frame_id: _atlas_frame_id,
       images,
     } = args as unknown as RememberArgs;
 
-    const errors: Array<{ field: string; code: string; message: string; suggestions?: string[] }> =
-      [];
+    const frameWriteContract = this.buildMCPFrameWriteContract(
+      context,
+      [],
+      [reference_point, summary_caption, status_snapshot?.next_action].filter(Boolean).join(" "),
+      branch
+    );
+    const remediation = fallbackRemediation();
+    const errors: Array<{
+      field: string;
+      code: string;
+      message: string;
+      suggestions?: string[];
+      remediation?: ReturnType<typeof fallbackRemediation>;
+    }> = [];
     const warnings: Array<{ field: string; message: string }> = [];
 
     // Validate required fields
@@ -1109,12 +1229,14 @@ export class MCPServer {
         field: "module_scope",
         code: MCPErrorCode.VALIDATION_REQUIRED_FIELD,
         message: "module_scope is required",
+        remediation,
       });
     } else if (!Array.isArray(module_scope) || module_scope.length === 0) {
       errors.push({
         field: "module_scope",
         code: MCPErrorCode.VALIDATION_EMPTY_MODULE_SCOPE,
         message: "module_scope must be a non-empty array of module IDs",
+        remediation,
       });
     }
 
@@ -1130,7 +1252,13 @@ export class MCPServer {
     }
 
     // Validate module IDs against policy (if available and module_scope is valid)
-    if (context.policy && module_scope && Array.isArray(module_scope) && module_scope.length > 0) {
+    if (
+      context.policy &&
+      module_scope &&
+      Array.isArray(module_scope) &&
+      module_scope.length > 0 &&
+      !isCanonicalUnscopedScope(module_scope)
+    ) {
       try {
         const validationResult = await validateModuleIds(module_scope, context.policy);
 
@@ -1154,7 +1282,12 @@ export class MCPServer {
           message: `Module validation failed: ${errorMessage}`,
         });
       }
-    } else if (!context.policy && module_scope && Array.isArray(module_scope)) {
+    } else if (
+      !context.policy &&
+      module_scope &&
+      Array.isArray(module_scope) &&
+      module_scope.length > 0
+    ) {
       // No policy loaded - add a warning
       warnings.push({
         field: "module_scope",
@@ -1194,6 +1327,23 @@ export class MCPServer {
 
     // Build response
     const valid = errors.length === 0;
+    const moduleAttribution: ModuleAttribution | null =
+      Array.isArray(module_scope) && module_scope.length > 0
+        ? isCanonicalUnscopedScope(module_scope)
+          ? createFallbackModuleAttribution("mcp:module_scope")
+          : {
+              mode: "explicit",
+              confidence: "high",
+              evidence: ["mcp:module_scope"],
+            }
+        : null;
+    const responseData = {
+      valid,
+      errors,
+      warnings,
+      frameWriteContract,
+      moduleAttribution,
+    };
 
     if (valid) {
       // Success response with warnings if any
@@ -1212,6 +1362,7 @@ export class MCPServer {
             text,
           },
         ],
+        data: responseData,
       };
     } else {
       // Error response with structured errors
@@ -1221,6 +1372,9 @@ export class MCPServer {
         text += `  - ${error.field}: ${error.message}\n`;
         if (error.suggestions && error.suggestions.length > 0) {
           text += `    Suggestions: ${error.suggestions.join(", ")}\n`;
+        }
+        if (error.remediation) {
+          text += `    Remediation: ${error.remediation.message}\n`;
         }
       }
 
@@ -1238,6 +1392,7 @@ export class MCPServer {
             text,
           },
         ],
+        data: responseData,
       };
     }
   }
@@ -1502,6 +1657,8 @@ export class MCPServer {
       data: {
         frame_id: frame.id,
         timestamp: frame.timestamp,
+        module_scope: frame.module_scope,
+        module_attribution: frame.module_attribution ?? null,
       },
     };
   }
@@ -2074,6 +2231,127 @@ export class MCPServer {
     }
   }
 
+  private buildMCPFrameWriteContract(
+    context: MCPDispatchWorkspaceContext,
+    recentFrames: Frame[] = [],
+    query?: string,
+    branch: string | undefined = context.sourceRevision?.branch
+  ): MCPFrameWriteContract {
+    const contract = buildFrameWriteContract({
+      policy: context.policy,
+      projectRoot: context.projectRoot ?? context.configResolution.workspaceRoot.path,
+      branch,
+      query,
+      recentFrames,
+    });
+    return toMCPFrameWriteContract(contract);
+  }
+
+  private async inspectScopeHealth(
+    frameStore: FrameStore,
+    context: MCPDispatchWorkspaceContext,
+    storeHealthy: boolean
+  ): Promise<{ scopeHealth: ScopeHealth; recentFrames: Frame[] }> {
+    const policyModules = new Set(Object.keys(context.policy?.modules ?? {}));
+    const policyHealth: ScopeHealth["policy"] = {
+      state: context.policy ? "loaded" : "unavailable",
+      source: context.policyResolution?.source ?? "not-found",
+      path: context.policyResolution?.path ?? null,
+      moduleCount: policyModules.size,
+    };
+
+    if (!storeHealthy) {
+      return {
+        scopeHealth: {
+          policy: policyHealth,
+          frames: {
+            state: "unavailable",
+            unscopedCount: 0,
+            drift: {
+              state: "not-evaluated",
+              frameCount: 0,
+              moduleIdCount: 0,
+              modules: [],
+              summaryLimit: SCOPE_HEALTH_SUMMARY_LIMIT,
+              truncated: false,
+            },
+          },
+        },
+        recentFrames: [],
+      };
+    }
+
+    let cursor: string | undefined;
+    let unscopedCount = 0;
+    let driftedFrameCount = 0;
+    const unknownModules = new Map<string, number>();
+    const seenCursors = new Set<string>();
+    const recentFrames: Frame[] = [];
+
+    do {
+      const result = await frameStore.listFrames({
+        limit: SCOPE_HEALTH_PAGE_SIZE,
+        cursor,
+      });
+      recentFrames.push(...result.frames.slice(0, Math.max(0, 10 - recentFrames.length)));
+
+      for (const frame of result.frames) {
+        const moduleIds = new Set(frame.module_scope);
+        if (moduleIds.has(UNSCOPED_MODULE_ID)) {
+          unscopedCount += 1;
+        }
+        if (!context.policy) continue;
+
+        const unknownForFrame = [...moduleIds].filter(
+          (moduleId) => moduleId !== UNSCOPED_MODULE_ID && !policyModules.has(moduleId)
+        );
+        if (unknownForFrame.length > 0) {
+          driftedFrameCount += 1;
+        }
+        for (const moduleId of unknownForFrame) {
+          unknownModules.set(moduleId, (unknownModules.get(moduleId) ?? 0) + 1);
+        }
+      }
+
+      const nextCursor = result.page.nextCursor ?? undefined;
+      if (!nextCursor) break;
+      if (seenCursors.has(nextCursor)) {
+        throw new Error("FrameStore pagination repeated a cursor during scope-health inspection.");
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    } while (cursor);
+
+    const sortedUnknownModules = [...unknownModules.entries()]
+      .sort(([leftId, leftCount], [rightId, rightCount]) => {
+        return rightCount - leftCount || leftId.localeCompare(rightId);
+      })
+      .map(([moduleId, frameCount]) => ({ moduleId, frameCount }));
+
+    return {
+      scopeHealth: {
+        policy: policyHealth,
+        frames: {
+          state: "available",
+          unscopedCount,
+          drift: {
+            state: context.policy ? "evaluated" : "not-evaluated",
+            frameCount: context.policy ? driftedFrameCount : 0,
+            moduleIdCount: context.policy ? sortedUnknownModules.length : 0,
+            modules: context.policy
+              ? sortedUnknownModules.slice(0, SCOPE_HEALTH_SUMMARY_LIMIT)
+              : [],
+            summaryLimit: SCOPE_HEALTH_SUMMARY_LIMIT,
+            truncated: context.policy
+              ? sortedUnknownModules.length > SCOPE_HEALTH_SUMMARY_LIMIT
+              : false,
+          },
+        },
+      },
+      recentFrames,
+    };
+  }
+
   /**
    * Handle introspect tool - discover current Lex state
    */
@@ -2098,11 +2376,13 @@ export class MCPServer {
 
       // Get state information through a backend-neutral health probe.
       const storeHealth = await frameStore.getHealth();
-      const result = storeHealth.healthy
-        ? await frameStore.listFrames({ limit: 1 })
-        : { frames: [] };
       const frameCount = storeHealth.healthy ? await this.getFrameCount(frameStore) : 0;
-      const latestFrame = result.frames.length > 0 ? result.frames[0].timestamp : null;
+      const { scopeHealth, recentFrames } = await this.inspectScopeHealth(
+        frameStore,
+        context,
+        storeHealth.healthy
+      );
+      const latestFrame = recentFrames.length > 0 ? recentFrames[0].timestamp : null;
 
       // Get current branch (if available)
       let currentBranch = "unknown";
@@ -2125,6 +2405,12 @@ export class MCPServer {
           // If we can't get branch, keep "unknown"
         }
       }
+      const frameWriteContract = this.buildMCPFrameWriteContract(
+        context,
+        recentFrames,
+        undefined,
+        currentBranch
+      );
 
       const workspaceResolution = {
         path: context.configResolution.workspaceRoot.path,
@@ -2198,7 +2484,7 @@ export class MCPServer {
       }
 
       // Schema version for contract stability
-      const schemaVersion = "1.0.0";
+      const schemaVersion = "1.1.0";
 
       if (format === "compact") {
         // Compact format for small-context agents
@@ -2212,6 +2498,8 @@ export class MCPServer {
           },
           ctx: runtimeResolution,
           mods: policyData ? policyData.moduleCount : 0,
+          frameWriteContract,
+          scopeHealth,
           // Abbreviate error codes and re-sort (abbreviation changes alphabetical order)
           errs: errorCodes.map((code) => this.abbreviateErrorCode(code)).sort(),
           warnings,
@@ -2242,6 +2530,8 @@ export class MCPServer {
                 moduleCount: policyData.moduleCount,
               }
             : null,
+          frameWriteContract,
+          scopeHealth,
           state: {
             frameCount,
             latestFrame,
@@ -2266,6 +2556,23 @@ export class MCPServer {
         } else {
           text += `📋 Policy: Not loaded\n\n`;
         }
+
+        text += `✍️  Frame Write Contract:\n`;
+        text += `  Required MCP fields: ${frameWriteContract.requiredFields.join(", ")}\n`;
+        text += `  Fallback module: ${frameWriteContract.fallback.moduleId}\n`;
+        text += `  Fallback input: ${JSON.stringify(frameWriteContract.fallback.input)}\n\n`;
+
+        text += `🩺 Scope Health:\n`;
+        text += `  Policy: ${scopeHealth.policy.state} (${scopeHealth.policy.source})\n`;
+        text += `  Unscoped Frames: ${scopeHealth.frames.unscopedCount}\n`;
+        text += `  Policy-drift Frames: ${scopeHealth.frames.drift.frameCount}\n`;
+        text += `  Unknown Module IDs: ${scopeHealth.frames.drift.moduleIdCount}\n`;
+        if (scopeHealth.frames.drift.modules.length > 0) {
+          text += `  Drift Summary: ${scopeHealth.frames.drift.modules
+            .map((item) => `${item.moduleId} (${item.frameCount})`)
+            .join(", ")}\n`;
+        }
+        text += "\n";
 
         text += `📊 State:\n`;
         text += `  Frames: ${frameCount}\n`;
@@ -2841,6 +3148,17 @@ export class MCPServer {
           description: workflows[w]?.description || w,
         })),
       };
+      const hasFrameWriteContract = tool === "frame_create" || tool === "frame_validate";
+      if (hasFrameWriteContract) {
+        response.frameWriteContract = {
+          requiredFields: MCP_FRAME_REQUIRED_FIELDS,
+          policyState: "discover-via-system_introspect",
+          fallback: {
+            moduleId: UNSCOPED_MODULE_ID,
+            input: fallbackRemediation().input,
+          },
+        };
+      }
 
       if (examples) {
         if (format === "micro" && helpData.microExamples) {
@@ -2881,6 +3199,16 @@ export class MCPServer {
         "## Workflows",
         helpData.workflows.map((w) => `  - ${w}: ${workflows[w]?.description || ""}`).join("\n")
       );
+
+      if (hasFrameWriteContract) {
+        textOutput.push(
+          "",
+          "## Frame Write Fallback",
+          `  Module: ${UNSCOPED_MODULE_ID}`,
+          `  Exact input: ${JSON.stringify(fallbackRemediation().input)}`,
+          "  Use this explicit fallback only when no policy-backed module applies."
+        );
+      }
 
       if (examples) {
         if (format === "micro" && helpData.microExamples) {
@@ -2930,6 +3258,14 @@ export class MCPServer {
               requiredFields: data.requiredFields,
               relatedTools: data.relatedTools,
             };
+            if (name === "frame_create" || name === "frame_validate") {
+              toolData.frameWriteContract = {
+                fallback: {
+                  moduleId: UNSCOPED_MODULE_ID,
+                  input: fallbackRemediation().input,
+                },
+              };
+            }
             if (examples && data.examples.length > 0) {
               toolData.examples = data.examples;
             }

--- a/src/memory/mcp_server/tools.ts
+++ b/src/memory/mcp_server/tools.ts
@@ -53,7 +53,8 @@ export const MCP_TOOLS: MCPTool[] = [
         module_scope: {
           type: "array",
           items: { type: "string" },
-          description: 'Module IDs from lexmap.policy.json (e.g., ["auth/core", "auth/password"])',
+          description:
+            'Module IDs from lexmap.policy.json. If no policy-backed module applies, use the exact fallback ["workspace/unscoped"].',
         },
         branch: {
           type: "string",
@@ -130,7 +131,8 @@ export const MCP_TOOLS: MCPTool[] = [
         module_scope: {
           type: "array",
           items: { type: "string" },
-          description: 'Module IDs from lexmap.policy.json (e.g., ["auth/core", "auth/password"])',
+          description:
+            'Module IDs from lexmap.policy.json. If no policy-backed module applies, use the exact fallback ["workspace/unscoped"].',
         },
         branch: {
           type: "string",

--- a/src/shared/cli/frame-write-contract.ts
+++ b/src/shared/cli/frame-write-contract.ts
@@ -37,6 +37,9 @@ export interface FrameWriteContract {
     available: true;
     moduleId: typeof UNSCOPED_MODULE_ID;
     argument: "--modules unscoped";
+    mcpInput: {
+      module_scope: [typeof UNSCOPED_MODULE_ID];
+    };
   };
   suggestions: ModuleSuggestion[];
   compact: string;
@@ -170,11 +173,22 @@ export function buildFrameWriteContract(options: ContractOptions): FrameWriteCon
       available: true,
       moduleId: UNSCOPED_MODULE_ID,
       argument: "--modules unscoped",
+      mcpInput: {
+        module_scope: [UNSCOPED_MODULE_ID],
+      },
     },
     suggestions,
     compact: policyLoaded
       ? "Frame write contract: summary + modules required; use --modules auto or explicit policy IDs; next/reference-point recommended."
       : `Frame write contract: summary + modules required; policy unavailable; use --modules auto or --modules unscoped (${UNSCOPED_MODULE_ID}); next/reference-point recommended.`,
+  };
+}
+
+export function createFallbackModuleAttribution(source?: string): ModuleAttribution {
+  return {
+    mode: "fallback",
+    confidence: "low",
+    evidence: ["explicit-unscoped-fallback", ...(source ? [source] : [])].slice(0, MAX_EVIDENCE),
   };
 }
 
@@ -191,11 +205,13 @@ export function resolveModuleAttribution(
   if (requestsFallback || (requestsAuto && contract.policy.state === "unavailable")) {
     return {
       modules: [UNSCOPED_MODULE_ID],
-      attribution: {
-        mode: "fallback",
-        confidence: "low",
-        evidence: [requestsFallback ? "explicit-unscoped-fallback" : "policy-unavailable"],
-      },
+      attribution: requestsFallback
+        ? createFallbackModuleAttribution()
+        : {
+            mode: "fallback",
+            confidence: "low",
+            evidence: ["policy-unavailable"],
+          },
     };
   }
 

--- a/test/memory/mcp_server/help-tool.test.ts
+++ b/test/memory/mcp_server/help-tool.test.ts
@@ -152,6 +152,17 @@ describe("Help MCP Tool (AX #577)", () => {
         assert.ok(requiredFields.includes("summary_caption"));
         assert.ok(requiredFields.includes("status_snapshot"));
         assert.ok(requiredFields.includes("module_scope"));
+
+        const writeContract = data.frameWriteContract as Record<string, unknown>;
+        const fallback = writeContract.fallback as Record<string, unknown>;
+        assert.strictEqual(fallback.moduleId, "workspace/unscoped");
+        assert.deepStrictEqual(fallback.input, {
+          module_scope: ["workspace/unscoped"],
+        });
+        assert.ok(
+          response.content[0].text.includes('{"module_scope":["workspace/unscoped"]}'),
+          "Help should render the exact fallback payload"
+        );
       } finally {
         await teardown();
       }

--- a/test/memory/mcp_server/introspect.test.ts
+++ b/test/memory/mcp_server/introspect.test.ts
@@ -8,6 +8,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
 import { MCPServer } from "@app/memory/mcp_server/server.js";
+import { createFrameStore } from "@app/memory/store/index.js";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -494,6 +495,155 @@ describe("MCP Server - Introspect Tool", () => {
       assert.match(database.identity as string, /^path-v1:[a-f0-9]{16}$/);
     } finally {
       await configuredServer.close();
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("introspect exposes the exact fallback contract when policy is unavailable", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "lex-introspect-no-policy-"));
+    const noPolicyServer = new MCPServer({
+      dbPath: join(workspaceRoot, "frames.db"),
+      repoRoot: workspaceRoot,
+    });
+    try {
+      const response = await noPolicyServer.handleRequest({
+        method: "tools/call",
+        params: {
+          name: "system_introspect",
+          arguments: {},
+        },
+      });
+      const data = response.data as Record<string, unknown>;
+      const writeContract = data.frameWriteContract as Record<string, unknown>;
+      const contractPolicy = writeContract.policy as Record<string, unknown>;
+      const fallback = writeContract.fallback as Record<string, unknown>;
+      const scopeHealth = data.scopeHealth as Record<string, unknown>;
+      const policyHealth = scopeHealth.policy as Record<string, unknown>;
+
+      assert.strictEqual(contractPolicy.state, "unavailable");
+      assert.strictEqual(contractPolicy.moduleCount, 0);
+      assert.strictEqual(fallback.moduleId, "workspace/unscoped");
+      assert.deepStrictEqual(fallback.input, {
+        module_scope: ["workspace/unscoped"],
+      });
+      assert.strictEqual(policyHealth.state, "unavailable");
+      assert.strictEqual(policyHealth.moduleCount, 0);
+    } finally {
+      await noPolicyServer.close();
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("introspect exposes the shared write contract and bounded scope health", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "lex-introspect-scope-health-"));
+    const dbPath = join(workspaceRoot, "frames.db");
+    const seedStore = createFrameStore(dbPath);
+    const paginationFrames = Array.from({ length: 501 }, (_, index) => ({
+      id: `frame-current-${index}`,
+      timestamp: new Date(Date.parse("2026-07-28T00:00:00.000Z") + index * 1000).toISOString(),
+      branch: "main",
+      module_scope: ["current/module"],
+      summary_caption: "Current policy module",
+      reference_point: `scope health pagination ${index}`,
+      status_snapshot: { next_action: "Continue" },
+    }));
+    await seedStore.saveFrames([
+      ...paginationFrames,
+      {
+        id: "frame-unscoped",
+        timestamp: "2026-07-27T00:00:00.000Z",
+        branch: "main",
+        module_scope: ["workspace/unscoped"],
+        summary_caption: "Explicit fallback",
+        reference_point: "scope health fallback",
+        status_snapshot: { next_action: "Define a policy module when warranted" },
+      },
+      {
+        id: "frame-drift",
+        timestamp: "2026-07-27T00:01:00.000Z",
+        branch: "main",
+        module_scope: ["retired/module"],
+        summary_caption: "Historical policy drift",
+        reference_point: "scope health drift",
+        status_snapshot: { next_action: "Map the retired module" },
+      },
+      {
+        id: "frame-many-drift",
+        timestamp: "2026-07-27T00:01:30.000Z",
+        branch: "main",
+        module_scope: Array.from(
+          { length: 12 },
+          (_, index) => `drift/module-${String(index).padStart(2, "0")}`
+        ),
+        summary_caption: "Bounded policy drift",
+        reference_point: "scope health bounded drift",
+        status_snapshot: { next_action: "Keep the summary bounded" },
+      },
+      {
+        id: "frame-current",
+        timestamp: "2026-07-27T00:02:00.000Z",
+        branch: "main",
+        module_scope: ["current/module"],
+        summary_caption: "Current policy module",
+        reference_point: "scope health current",
+        status_snapshot: { next_action: "Continue" },
+      },
+    ]);
+    await seedStore.close();
+
+    const policyDir = join(workspaceRoot, ".smartergpt", "lex");
+    mkdirSync(policyDir, { recursive: true });
+    writeFileSync(
+      join(policyDir, "lexmap.policy.json"),
+      JSON.stringify({
+        modules: {
+          "current/module": {
+            owns_paths: ["src/current/**"],
+          },
+        },
+      })
+    );
+
+    const scopedServer = new MCPServer({ dbPath, repoRoot: workspaceRoot });
+    try {
+      const response = await scopedServer.handleRequest({
+        method: "tools/call",
+        params: {
+          name: "system_introspect",
+          arguments: {},
+        },
+      });
+      const data = response.data as Record<string, unknown>;
+      assert.strictEqual(data.schemaVersion, "1.1.0");
+
+      const writeContract = data.frameWriteContract as Record<string, unknown>;
+      const contractPolicy = writeContract.policy as Record<string, unknown>;
+      const fallback = writeContract.fallback as Record<string, unknown>;
+      assert.strictEqual(contractPolicy.state, "loaded");
+      assert.strictEqual(contractPolicy.moduleCount, 1);
+      assert.strictEqual(fallback.moduleId, "workspace/unscoped");
+      assert.deepStrictEqual(fallback.input, {
+        module_scope: ["workspace/unscoped"],
+      });
+
+      const scopeHealth = data.scopeHealth as Record<string, unknown>;
+      const policy = scopeHealth.policy as Record<string, unknown>;
+      const frames = scopeHealth.frames as Record<string, unknown>;
+      const drift = frames.drift as Record<string, unknown>;
+      assert.strictEqual(policy.state, "loaded");
+      assert.strictEqual(policy.moduleCount, 1);
+      assert.strictEqual(frames.unscopedCount, 1);
+      assert.strictEqual(drift.state, "evaluated");
+      assert.strictEqual(drift.frameCount, 2);
+      assert.strictEqual(drift.moduleIdCount, 13);
+      assert.strictEqual((drift.modules as unknown[]).length, 10);
+      assert.strictEqual(drift.truncated, true);
+      assert.deepStrictEqual((drift.modules as unknown[])[0], {
+        moduleId: "drift/module-00",
+        frameCount: 1,
+      });
+    } finally {
+      await scopedServer.close();
       rmSync(workspaceRoot, { recursive: true, force: true });
     }
   });

--- a/test/memory/mcp_server/validate-remember.test.ts
+++ b/test/memory/mcp_server/validate-remember.test.ts
@@ -120,6 +120,10 @@ describe("MCP Server - validate_remember", () => {
         response.content[0].text.includes("module_scope"),
         "Should mention missing module_scope"
       );
+      assert.ok(
+        response.content[0].text.includes('{"module_scope":["workspace/unscoped"]}'),
+        "Should provide the exact fallback payload for missing scope"
+      );
     } finally {
       await teardown();
     }
@@ -150,6 +154,20 @@ describe("MCP Server - validate_remember", () => {
         response.content[0].text.includes("module_scope must be a non-empty array"),
         "Should mention empty module_scope"
       );
+      assert.ok(
+        response.content[0].text.includes('{"module_scope":["workspace/unscoped"]}'),
+        "Should name the exact fallback payload"
+      );
+      const data = response.data as Record<string, unknown>;
+      const errors = data.errors as Array<Record<string, unknown>>;
+      const scopeError = errors.find((error) => error.field === "module_scope");
+      const remediation = scopeError?.remediation as Record<string, unknown>;
+      assert.deepStrictEqual(remediation.input, {
+        module_scope: ["workspace/unscoped"],
+      });
+      const contract = data.frameWriteContract as Record<string, unknown>;
+      const fallback = contract.fallback as Record<string, unknown>;
+      assert.strictEqual(fallback.moduleId, "workspace/unscoped");
     } finally {
       await teardown();
     }
@@ -245,6 +263,65 @@ describe("MCP Server - validate_remember", () => {
         response.content[0].text.includes("✅ Validation passed"),
         "Should confirm validation passed"
       );
+    } finally {
+      await teardown();
+    }
+  });
+
+  test("canonical unscoped fallback validates and round-trips fallback attribution", async () => {
+    const srv = setup(true);
+    try {
+      const args = {
+        reference_point: "policy fallback",
+        summary_caption: "No policy-backed module applies",
+        status_snapshot: { next_action: "Refine the policy later" },
+        module_scope: ["workspace/unscoped"],
+      };
+
+      const validation = await srv.handleRequest({
+        method: "tools/call",
+        params: {
+          name: "frame_validate",
+          arguments: args,
+        },
+      });
+      assert.ok(validation.content[0].text.includes("✅ Validation passed"));
+      assert.deepStrictEqual(validation.data?.moduleAttribution, {
+        mode: "fallback",
+        confidence: "low",
+        evidence: ["explicit-unscoped-fallback", "mcp:module_scope"],
+      });
+
+      const created = await srv.handleRequest({
+        method: "tools/call",
+        params: {
+          name: "frame_create",
+          arguments: args,
+        },
+      });
+      assert.ok(created.data?.frame_id);
+      assert.deepStrictEqual(created.data?.module_attribution, {
+        mode: "fallback",
+        confidence: "low",
+        evidence: ["explicit-unscoped-fallback", "mcp:module_scope"],
+      });
+
+      const retrieved = await srv.handleRequest({
+        method: "tools/call",
+        params: {
+          name: "frame_get",
+          arguments: {
+            frame_id: created.data?.frame_id,
+            include_atlas: false,
+          },
+        },
+      });
+      assert.deepStrictEqual(retrieved.data?.module_scope, ["workspace/unscoped"]);
+      assert.deepStrictEqual(retrieved.data?.module_attribution, {
+        mode: "fallback",
+        confidence: "low",
+        evidence: ["explicit-unscoped-fallback", "mcp:module_scope"],
+      });
     } finally {
       await teardown();
     }

--- a/test/shared/cli/frame-write-contract.test.ts
+++ b/test/shared/cli/frame-write-contract.test.ts
@@ -17,6 +17,9 @@ test("policy-less module auto uses the canonical unscoped fallback", () => {
     assert.deepStrictEqual(result.modules, ["workspace/unscoped"]);
     assert.strictEqual(result.attribution.mode, "fallback");
     assert.strictEqual(contract.policy.state, "unavailable");
+    assert.deepStrictEqual(contract.fallback.mcpInput, {
+      module_scope: ["workspace/unscoped"],
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #803

## What changed

- Reused the shared Frame write contract and canonical `workspace/unscoped` ID in MCP validation, help, and introspection.
- Returned the exact fallback input as structured remediation for missing or empty `module_scope`.
- Stored and round-tripped fallback `module_attribution` receipts.
- Added policy source/module-count health, exact unscoped Frame counts, and paginated policy-drift counts with a bounded deterministic summary.
- Preserved explicit validation for policy-backed and unknown module IDs and kept recall independent of Policy Neighborhood availability.

## Why

The CLI already exposed an actionable Frame write contract, while MCP callers had to guess the fallback and lost attribution when they found it. MCP introspection also reported policy availability without showing whether stored Frames were unscoped or had drifted from the current policy.

## Impact

Agents get a single explicit recovery payload, truthful fallback provenance, and actionable policy health without silent scope inference. The introspection response advances additively to schema `1.1.0`.

## Validation

- `npm test` — 2,414 TypeScript tests and 149 JavaScript tests passed
- focused MCP/help/introspection/runtime-scope suite — 103 tests passed
- scope-health coverage crosses the 500-Frame pagination boundary and bounds a 13-ID drift set to 10 entries
- `npm run lint`
- `npm run type-check`
- `npm run validate-docs`
- `npm run check:public-api`
- signed commit verified locally

## Dogfood evidence

The currently deployed STFC-scoped MCP rejected both Lex-specific modules and the canonical fallback, reproducing the pre-fix behavior. No inaccurate STFC module was used to force the handoff write.