### PR TITLE
docs: split legacy Atlas terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ lex/
 │   └── shared/               # Shared utilities
 │       ├── types/            # Core TypeScript types
 │       ├── policy/           # Policy loading
-│       ├── atlas/            # Atlas frame generation
+│       ├── atlas/            # Policy Neighborhood + Frame Graph compatibility code
 │       ├── aliases/          # Module ID alias resolution
 │       ├── module_ids/       # Module ID validation
 │       └── cli/              # CLI commands and entry point

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -3,7 +3,7 @@
 This guide proves one thing: whether a durable checkpoint helps a later agent session continue
 without making you reconstruct the work.
 
-The pilot uses local SQLite. It does not require MCP, policy, Atlas, PostgreSQL, instruction
+The pilot uses local SQLite. It does not require MCP, policy, Policy Neighborhoods, PostgreSQL, instruction
 projection, AXF, LexRunner, or LexSona.
 
 ## Before you begin
@@ -137,7 +137,7 @@ Once the local handoff is useful, add one capability at a time:
 | Agent session bootstrap | [Agent Continuity](./docs/AGENT_CONTINUITY.md) |
 | MCP client access | [MCP Server](./README.mcp.md) |
 | Repository module boundaries | [Policy usage](./docs/API_USAGE.md) |
-| Nearby module context | [Atlas](./docs/atlas/README.md) |
+| Nearby module context | [Policy Neighborhood](./docs/atlas/README.md) |
 | Canonical assistant instructions | [Instructions](./docs/INSTRUCTIONS.md) |
 | Shared cross-host storage | [Store Contracts](./docs/STORE_CONTRACTS.md) and [PostgreSQL Scope Security](./docs/POSTGRES_SCOPE_SECURITY.md) |
 | Trusted tenant/workspace scope | [Runtime Scope](./docs/RUNTIME_SCOPE_CONTRACT.md) |

--- a/README.mcp.md
+++ b/README.mcp.md
@@ -2,7 +2,7 @@
 
 Use Lex from an MCP-capable agent without teaching the agent shell commands. The server exposes
 the same deliberate Frame workflow as the CLI: remember what mattered, find it later, and keep
-repository policy and Atlas context available when they are useful.
+repository policy and Policy Neighborhood context available when they are useful.
 
 Lex MCP is optional. Use the CLI if your agent already has a reliable shell; add MCP when your
 client benefits from typed tools and discoverable schemas.
@@ -73,7 +73,7 @@ that exact payload as structured remediation.
 | `frame_validate` | Validate Frame input without storing it |
 | `policy_check` | Check scanned code facts against repository policy |
 | `timeline_show` | Show Frame evolution for a ticket or branch |
-| `atlas_analyze` | Analyze code structure and dependencies |
+| `atlas_analyze` | Build the experimental Code Index (legacy tool name) |
 | `system_introspect` | Report active capabilities, workspace, and store state |
 | `help` | Return tool usage and examples |
 | `hints_get` | Retrieve stable recovery hints |
@@ -84,6 +84,9 @@ that exact payload as structured remediation.
 Old tool names such as `remember` and `recall` remain compatibility aliases. New integrations
 should use the names above. See
 [ADR-0009](./docs/adr/0009-mcp-tool-naming-convention.md).
+
+`atlas_analyze` is a legacy-named Code Index surface; it is not Policy Neighborhood enrichment or
+the historical Frame Graph. See the [terminology map](./docs/ATLAS_TERMINOLOGY.md).
 
 ## Storage and trust models
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ lex --json context --branch main --limit 5
 | Small session-start context | Read-only `lex context` | [Agent Continuity](./docs/AGENT_CONTINUITY.md) |
 | MCP access from an assistant | `@smartergpt/lex-mcp` | [MCP setup](./README.mcp.md) |
 | Repository boundaries | Policy checks | [Policy usage](./docs/API_USAGE.md) |
-| Nearby module context | Atlas | [Atlas guide](./docs/atlas/README.md) |
+| Nearby module context | Policy Neighborhood | [Context guide](./docs/atlas/README.md) |
 | Canonical assistant instructions | Instructions projection | [Instructions](./docs/INSTRUCTIONS.md) |
 | Typed Markdown project knowledge | Derived KnowledgeFrame snapshots | [KnowledgeFrames](./docs/KNOWLEDGE_FRAMES.md) |
 | Shared cross-host storage | PostgreSQL | [Store contracts](./docs/STORE_CONTRACTS.md) and [scope security](./docs/POSTGRES_SCOPE_SECURITY.md) |
@@ -239,7 +239,7 @@ their explicit package relationships:
 
 | Project | Responsibility | Relationship |
 |---|---|---|
-| **Lex** | Durable work context, repository policy, Atlas, instructions, and scoped Frame storage | Core library and CLI |
+| **Lex** | Durable work context, repository policy, optional neighborhood context, instructions, and scoped Frame storage | Core library and CLI |
 | [**AXF**](https://github.com/Guffawaffle/axf) | Inspectable workspace capabilities and their execution boundaries | Independently usable; composes with Lex |
 | [**LexRunner**](https://github.com/Guffawaffle/lexrunner) | Fanout, attempts, worker/workspace coordination, verification, and merge-weave | Consumes Lex for continuity |
 | [**Lex-MCP**](https://github.com/Guffawaffle/lex-mcp) | Thin MCP transport for Lex capabilities | Pins the matching Lex release |

--- a/RECEIPTS.md
+++ b/RECEIPTS.md
@@ -353,4 +353,4 @@ But the **default is local-only**.
 
 - [FAQ.md](./docs/FAQ.md) - Common questions about Frames and receipts
 - [ARCHITECTURE_LOOP.md](./docs/ARCHITECTURE_LOOP.md) - How LexBrain + LexMap enable policy-aware reasoning
-- [MIND_PALACE.md](./docs/MIND_PALACE.md) - Advanced recall with reference points and Atlas Frames
+- [MIND_PALACE.md](./docs/MIND_PALACE.md) - Advanced recall with reference points and Policy Neighborhoods

--- a/canon/instructions/lex.example.md
+++ b/canon/instructions/lex.example.md
@@ -14,7 +14,7 @@ Lex provides memory and policy management for AI-assisted development:
 
 - **Memory:** Stores and retrieves episodic context about work sessions
 - **Policy:** Enforces module ownership and dependency rules
-- **Atlas:** Maps code structure for navigation and understanding
+- **Policy Neighborhood:** Adds bounded, policy-backed nearby-module context during recall
 
 ## Key Files
 

--- a/canon/policy/lexmap.policy.json
+++ b/canon/policy/lexmap.policy.json
@@ -79,7 +79,7 @@
       "exposes": ["computeFoldRadius", "generateAtlasFrame"],
       "allowed_callers": ["memory/mcp", "cli"],
       "forbidden_callers": ["policy/scanners"],
-      "notes": "Atlas Frame generation - fold-radius spatial neighborhood extraction"
+      "notes": "Policy Neighborhood generation through legacy AtlasFrame APIs"
     },
     "shared/module_ids": {
       "coords": [1, 3],

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -342,7 +342,7 @@ The rule: **If it's not worth explaining to a teammate, don't capture it.**
 | **Phase 3** | Make Frames searchable | Always tag with ticket ID, summary, and next action |
 | **Phase 4** | Add policy-aware reasoning | Wire LexMap so `module_scope` is populated |
 | **Phase 5** | Automate recall | Teach your assistant to call `/recall <ticket>` |
-| **Phase 6** | Enable Mind Palace (optional) | Add reference points and Atlas Frames for natural recall |
+| **Phase 6** | Enable Mind Palace (optional) | Add reference points and Policy Neighborhoods for natural recall |
 
 By Phase 5, you should be able to:
 
@@ -353,7 +353,7 @@ By Phase 5, you should be able to:
 By Phase 6 (Mind Palace), you can also:
 
 - Recall by natural phrasing: "Where did I leave off with the payment webhook?"
-- Get structural context via Atlas Frames (module neighborhoods + policy boundaries)
+- Get structural context via Policy Neighborhoods (module neighborhoods + policy boundaries)
 - Use fold radius to control context expansion
 
 That's the value of Lex.
@@ -364,13 +364,14 @@ That's the value of Lex.
 
 ### Goal
 
-Upgrade to reference point-based recall with Atlas Frames for even faster, more intuitive context retrieval.
+Upgrade to reference point-based recall with Policy Neighborhoods for even faster, more intuitive
+context retrieval.
 
 ### What is Mind Palace?
 
 Mind Palace extends Lex with:
 - **Reference points** - human-memorable anchor phrases ("Add User button still disabled")
-- **Atlas Frames** - structural snapshots of relevant module neighborhoods
+- **Policy Neighborhoods** - bounded views of relevant policy modules
 - **Fold radius** - controlled context expansion to prevent token bloat
 
 This enables questions like:
@@ -422,7 +423,7 @@ Edit your `lexmap.policy.json` to include coordinates for each module:
 
 ### Step 2: Verify LexMap Adjacency Export
 
-Test that LexMap can generate Atlas Frames:
+Test that policy can generate Policy Neighborhoods:
 
 ```bash
 lexmap export-adjacency \
@@ -491,11 +492,12 @@ Or ask your assistant:
 
 You should get back:
 - The Frame (summary, next_action, timestamp)
-- The Atlas Frame (module neighborhood, policy boundaries)
+- The Policy Neighborhood (module neighborhood, policy boundaries)
 
-### Step 6: Verify Atlas Frame Was Generated
+### Step 6: Verify the Policy Neighborhood was generated
 
-Check the response includes an Atlas Frame:
+Check the response includes a Policy Neighborhood. Current CLI text may still label the
+compatibility shape `Atlas Frame`:
 
 ```json
 {
@@ -568,7 +570,7 @@ lex recall TICKET-456
 lex recall "timeout"
 ```
 
-All should return the same Frame + Atlas Frame.
+All should return the same Frame plus equivalent Policy Neighborhood context.
 
 ### Adjusting Fold Radius
 
@@ -608,7 +610,7 @@ Start with radius 1 (default). Only increase if needed.
 - Check that the assistant has access to the `lex` MCP server
 - Try calling it manually via MCP to verify it works: `mcp call lex frame_search TICKET-123` (or use deprecated alias `recall`)
 
-### "Atlas Frames aren't being generated"
+### “Policy Neighborhoods are not being generated”
 
 - Verify LexMap is configured and accessible: `lexmap version`
 - Check that your `lexmap.policy.json` includes coordinates for modules
@@ -622,17 +624,17 @@ Start with radius 1 (default). Only increase if needed.
 - Verify normalization: `lex debug-normalize "payment webhook"`
 - Fall back to ticket ID if fuzzy matching fails: `/recall TICKET-456`
 
-### "Atlas Frame shows stale modules"
+### “Policy Neighborhood shows stale modules”
 
 - Your policy may have changed since the Frame was captured
-- Atlas Frames snapshot policy **at capture time**
-- Re-capture the Frame to get updated Atlas Frame: `lex remember --jira TICKET-456 --reference-point "..." --summary "..."`
+- Policy Neighborhoods use the policy resolved for the recall operation
+- Fix or select the intended policy, then recall the Frame again
 
 ---
 
 ## Next Steps
 
-- Read [Mind Palace Guide](./MIND_PALACE.md) to learn about reference points and Atlas Frames
+- Read [Mind Palace Guide](./MIND_PALACE.md) to learn about reference points and Policy Neighborhoods
 - Read [Mind Palace Architecture](./MIND_PALACE_ARCHITECTURE.md) for implementation details
 - Read [Architecture Loop](./ARCHITECTURE_LOOP.md) to understand the full explainability story
 - Read [FAQ](./FAQ.md) for privacy, security, and compliance questions

--- a/docs/AGENT_CONTINUITY.md
+++ b/docs/AGENT_CONTINUITY.md
@@ -54,7 +54,7 @@ Every non-interactive Frame write needs a summary and one module strategy:
 
 Inference considers changed paths, intent terms, the current branch, and recent Frames. The stored
 `module_attribution` receipt records `explicit`, `inferred`, or `fallback`, its confidence, and
-bounded evidence. The fallback uses the canonical `workspace/unscoped` Atlas anchor.
+bounded evidence. The fallback uses the canonical `workspace/unscoped` policy-context anchor.
 
 `--skip-policy` skips ontology validation only; it does not make required fields optional.
 

--- a/docs/API_USAGE.md
+++ b/docs/API_USAGE.md
@@ -117,7 +117,7 @@ publish its internal HTTP ingestion server as a supported package entry point.
 ## Where policy fits
 
 ```text
-repository paths ──→ module IDs ──→ Frame attribution and Atlas neighborhoods
+repository paths ──→ module IDs ──→ Frame attribution and Policy Neighborhoods
                               └──→ scanner facts checked against boundaries
 ```
 
@@ -126,7 +126,8 @@ workspace. Keep those decisions separate.
 
 ## See also
 
-- [Atlas guide](./atlas/README.md)
+- [Policy Neighborhood and Code Index guide](./atlas/README.md)
+- [Atlas terminology map](./ATLAS_TERMINOLOGY.md)
 - [Runtime scope contract](./RUNTIME_SCOPE_CONTRACT.md)
 - [Public package API](./PUBLIC_API.md)
 - [Contract surface](./CONTRACT_SURFACE.md)

--- a/docs/ARCHITECTURE_LOOP.md
+++ b/docs/ARCHITECTURE_LOOP.md
@@ -292,6 +292,6 @@ Just: "Here's what you were doing, why it mattered, and what you said you'd do n
 ## Next Steps
 
 - Read the [Adoption Guide](./ADOPTION_GUIDE.md) to roll out LexBrain in phases
-- Read the [Mind Palace Guide](./MIND_PALACE.md) to learn about reference points and Atlas Frames
+- Read the [Mind Palace Guide](./MIND_PALACE.md) to learn about reference points and Policy Neighborhoods
 - Read the [FAQ](./FAQ.md) for privacy, security, and compliance questions
 - Read [Contributing](../CONTRIBUTING.md) to extend LexBrain safely

--- a/docs/ATLAS_TERMINOLOGY.md
+++ b/docs/ATLAS_TERMINOLOGY.md
@@ -1,0 +1,163 @@
+# Atlas terminology and compatibility map
+
+**Status:** Adopted vocabulary for new work
+
+**Inventory date:** 2026-07-27
+**Tracking issue:** [#805](https://github.com/Guffawaffle/lex/issues/805)
+
+“Atlas” is a legacy umbrella over three independent systems. New prose and new APIs must use
+**Policy Neighborhood**, **Code Index**, or **Frame Graph** when one of those concepts is intended.
+Existing names containing `Atlas` remain compatibility surfaces until an additive, tested
+migration is available.
+
+This inventory groups repeated implementations by symbol family or path family. Every current
+Atlas-named source, declaration, command, tool, route, persistence field, and active documentation
+surface belongs to one of the rows below. Checked-in historical records keep their original
+wording and are classified as historical compatibility references rather than current vocabulary.
+
+## Concept contracts
+
+### Policy Neighborhood
+
+A **Policy Neighborhood** is bounded nearby-module context expanded from a Frame’s
+`module_scope` through the active repository policy. The policy/context layer owns it; CLI recall,
+MCP Frame reads, policy reports, renderers, and the LexRunner packet experiment consume it. The
+feature is supported but its current `AtlasFrame` names and output labels are legacy compatibility
+surfaces. If policy is absent, unreadable, or does not contain the requested IDs, neighborhood
+enrichment fails closed while core Frame capture and recall remain available; it never invents
+module IDs or grants authority.
+
+### Code Index
+
+The **Code Index** is experimental source and symbol extraction for TypeScript, JavaScript, and
+Python, with `CodeUnit`, run-provenance, optional persistence, and policy-seed evidence. The
+source-extraction and experimental Code Index store layers own it; the `code-atlas` CLI,
+`atlas_analyze` MCP tool, and `/api/atlas/*` HTTP routes are its current consumers. It has no
+identified LexRunner production consumer, and it is not the canonical mixed-language policy
+builder. Extraction failure or truncation is reported explicitly, stored output remains evidence
+rather than authority, and Frame capture/recall does not depend on it.
+
+### Frame Graph
+
+The **Frame Graph** is an in-memory derived graph over historical Frames, connecting them by module
+overlap, branch, and temporal proximity. The historical graph/rebuild layer owns it; only the
+public rebuild, validation, queue, and manager APIs plus examples and tests currently consume it.
+No first-party production caller was found in the source inventory. Rebuild or validation failure
+must leave durable Frames unchanged and must not block Frame capture or recall; stabilization
+depends on an explicit consumer decision.
+
+None of these three systems establishes tenant, workspace, repository, or filesystem authority.
+Trusted hosts resolve and attenuate `AuthorizedScope` before invoking any of them.
+
+## Public package API
+
+The paths and symbols in this table are already semver-governed. Classification does not rename or
+remove them.
+
+| Existing surface | Classification | Compatibility treatment |
+|---|---|---|
+| Root `@smartergpt/lex`: `AtlasFrame`, `AtlasModuleData`, `AtlasEdge`, `generateAtlasFrame`, `autoTuneRadius`, `estimateTokens` | Policy Neighborhood | Preserve; add the aliases tracked by [#806](https://github.com/Guffawaffle/lex/issues/806). |
+| Root `@smartergpt/lex`: `AtlasRebuildManager`, `triggerAtlasRebuild`, manager callbacks/configuration | Frame Graph | Preserve; add the aliases tracked by [#808](https://github.com/Guffawaffle/lex/issues/808). |
+| `@smartergpt/lex/atlas`: policy types, `Graph`, `AtlasFrame`, policy `AtlasEdge`, graph traversal, fold-radius, generation, cache, and auto-tuning exports | Policy Neighborhood | The package path stays; new docs identify this symbol family as Policy Neighborhood. |
+| `@smartergpt/lex/atlas`: `Atlas`, `AtlasNode`, `rebuildAtlas`, `validateAtlas`, `checkReachability`, `AtlasRebuildQueue`, `AtlasRebuildManager`, triggers, callbacks, and configuration | Frame Graph | The package path stays; new docs identify this symbol family as Frame Graph. |
+| `@smartergpt/lex/atlas`: `CodeUnit` schema, parser, validator, kinds, and spans | Code Index | The mixed barrel stays for compatibility; prefer a future additive Code Index name. |
+| `@smartergpt/lex/atlas/code-unit` | Code Index | Public compatibility path; do not remove or repurpose. |
+| `@smartergpt/lex/atlas/schemas`: `CodeAtlasRun`, `PolicySeed`, schemas, parsers, validators, and policy-seed generator | Code Index | Public compatibility path and serialized literals remain unchanged. |
+| `@smartergpt/lex/store`: `CodeAtlasStore`, `SqliteCodeAtlasStore`, CodeUnit queries, and CodeAtlasRun queries | Code Index | Experimental behavior on a public package path; migration is additive. |
+| Package keyword `atlas`, `shared/atlas` policy module ID, and `src/shared/atlas/` directory | Shared compatibility | These locate the legacy umbrella and do not define one subsystem. |
+
+The two source-level `AtlasEdge` types are not the same concept:
+`src/shared/atlas/types.ts` describes policy edges in a Policy Neighborhood, while
+`src/shared/atlas/rebuild.ts` describes weighted relationships in a Frame Graph.
+
+## CLI surfaces
+
+| Existing surface | Classification | Notes |
+|---|---|---|
+| `lex recall --fold-radius`, `--auto-radius`, `--max-tokens`, and `--cache-stats` | Policy Neighborhood | Existing flags remain; help should prefer Policy Neighborhood wording. |
+| Recall JSON `atlasFrame` and text label `Atlas Frame` | Policy Neighborhood | Output compatibility surface; rename only through an additive/versioned decision. |
+| `lex code-atlas`, `CodeAtlasOptions`, `CodeAtlasResult`, and `codeAtlas()` | Code Index | Existing command remains; additive `code-index` work is tracked by [#807](https://github.com/Guffawaffle/lex/issues/807). |
+| CLI Frame input/output `atlas_frame_id` | Policy Neighborhood compatibility | The stored value is opaque; do not silently reinterpret it as a Code Index or Frame Graph ID. |
+
+There is no first-party CLI command for the Frame Graph.
+
+## MCP and HTTP surfaces
+
+| Existing surface | Classification | Notes |
+|---|---|---|
+| Policy enrichment on `frame_create`, `frame_search`, `frame_get`, and `frame_list` | Policy Neighborhood | Optional enrichment; core Frame operations remain available without policy. |
+| `include_atlas`, `atlasFrame`, `atlas_frame_id`, and `Atlas Frame` response labels | Policy Neighborhood compatibility | Preserve wire and stored compatibility while additive aliases are designed. |
+| `atlas_analyze`, deprecated aliases `code_atlas`/`lex_code_atlas`, and the `code-atlas` runtime capability | Code Index | The current implementation extracts source units; it is not Policy Neighborhood generation. |
+| `POST /api/atlas/ingest` | Code Index | Ingests `CodeAtlasRun` plus `CodeUnit[]`. |
+| `GET /api/atlas/units`, `/units/:id`, `/runs`, and `/runs/:runId` | Code Index | Queries experimental Code Index persistence. |
+| `AtlasIngestRequest`, `AtlasIngestResponse`, and `AtlasApiErrorResponse` | Code Index | HTTP compatibility type names. |
+| Logger/category names under `memory:mcp_server:routes:atlas` | Code Index compatibility | Internal diagnostic name; migrate only with its route family. |
+
+There is no first-party MCP or HTTP surface for the Frame Graph. In particular,
+`atlas_analyze` is Code Index despite its name.
+
+## Types, schemas, and persistence
+
+| Existing surface | Classification | Compatibility treatment |
+|---|---|---|
+| `AtlasFrame`, `AtlasModuleData`/`AtlasModule`, policy `AtlasEdge`, `atlas_timestamp`, `seed_modules`, `fold_radius`, modules, edges, and critical rule | Policy Neighborhood | Existing in-memory/output shape remains readable. |
+| Frame field `atlas_frame_id` in TypeScript/Zod types, validators, SQLite/PostgreSQL rows, migrations, indexes, recovery, HTTP, MCP, and renderers | Policy Neighborhood compatibility | Preserve the field and its opaque values until a versioned data migration exists. |
+| `CodeUnit`, `CodeUnitKind`, `CodeUnitSpan`, and `code-unit-v0` | Code Index | Preserve serialized schema literals. |
+| `CodeAtlasRun`, limits, and `code-atlas-run-v0` | Code Index | Preserve serialized schema literals and stored rows. |
+| `PolicySeed`, `PolicySeedModule`, and `generatedBy: "code-atlas-v0"` | Code Index | Experimental seed evidence; not canonical policy authority. |
+| `code_units` and `code_atlas_runs` tables, queries, and `CodeAtlasStore` implementations | Code Index | Experimental persistence; no table rename without a migration. |
+| `Atlas`, `AtlasNode`, weighted Frame-graph `AtlasEdge`, `RebuildResult`, and validation result | Frame Graph | Current values are derived in memory; no durable Frame Graph format was found. |
+
+Checked-in `.d.ts` compatibility declarations mirror their corresponding source classification.
+Test fixtures containing names such as `atlas-001` inherit the classification of the field or API
+they exercise and do not define a fourth concept.
+
+## Internal source ownership
+
+| Source family | Classification |
+|---|---|
+| `src/shared/atlas/atlas-frame.ts`, `fold-radius.ts`, policy traversal portions of `graph.ts`, `cache.ts`, `auto-tune.ts`, and policy-neighborhood types | Policy Neighborhood |
+| Policy enrichment in `src/shared/cli/recall.ts`, `src/policy/check/reporter.ts`, `src/memory/mcp_server/server.ts`, and `src/memory/renderer/` | Policy Neighborhood |
+| `src/atlas/**`, `src/shared/cli/code-atlas.ts`, Code Index store/query files, and `src/memory/mcp_server/routes/atlas.ts` | Code Index |
+| `src/shared/atlas/rebuild.ts`, `validate.ts`, `queue.ts`, and `trigger.ts` | Frame Graph |
+| `src/shared/atlas/index.ts` | Shared compatibility barrel containing all three concepts |
+
+The policy traversal file `src/shared/atlas/graph.ts` belongs to Policy Neighborhood. The word
+“graph” there describes the repository policy graph, not the historical Frame Graph.
+
+## Documentation inventory
+
+| Documentation family | Classification |
+|---|---|
+| Recall, Mind Palace, adoption, recall-quality, policy, module-ID, CLI, memory, and renderer guidance that discusses `Atlas Frame` or fold radius | Policy Neighborhood |
+| `docs/atlas/api-reference.md`, `docs/atlas/code-atlas-v0.md`, `docs/atlas/examples.md`, CodeAtlasStore guidance, and Code Atlas limitations | Code Index, except their explicitly labeled recall/`AtlasFrame` sections, which are Policy Neighborhood |
+| Batch-ingestion “Atlas rebuild” guidance and rebuild/queue/validation sections in `src/shared/atlas/README.md` | Frame Graph |
+| `docs/atlas/README.md`, public API inventories, contract maps, and architecture overviews | Mixed compatibility landing surfaces; they must cross-link this map and name the intended concept |
+| `CHANGELOG.md`, historical work logs, old PR descriptions, archived examples/fixtures, ADR history, and research artifacts | Historical compatibility references; retained as records rather than rewritten as current terminology |
+
+## Migration order
+
+1. Use the three conceptual names in new issues, active documentation, comments, and help text.
+2. Add aliases without removing old package exports, CLI commands, MCP inputs, HTTP routes, types,
+   or serialized values.
+3. Move first-party consumers to the additive names and collect compatibility telemetry.
+4. Decide deprecation separately for each concept. A deprecation notice is not permission to
+   remove a public surface.
+5. Remove package paths, commands, wire fields, or serialized names only through the appropriate
+   major release or versioned data migration.
+
+The implementation follow-ups are:
+
+- [#806 — Policy Neighborhood aliases](https://github.com/Guffawaffle/lex/issues/806)
+- [#807 — Code Index aliases](https://github.com/Guffawaffle/lex/issues/807)
+- [#808 — Frame Graph aliases](https://github.com/Guffawaffle/lex/issues/808)
+
+## Related ownership decisions
+
+- [#733](https://github.com/Guffawaffle/lex/issues/733) is **Frame Graph** performance work.
+- [#804](https://github.com/Guffawaffle/lex/issues/804) is deferred **Code Index** research for
+  C++.
+- [Guffawaffle/lexrunner#858](https://github.com/Guffawaffle/lexrunner/issues/858) is a
+  **Policy Neighborhood** consumer experiment for task-packet construction.
+- [#801](https://github.com/Guffawaffle/lex/issues/801) is deterministic mixed-language policy
+  generation, not Code Index extraction.

--- a/docs/BATCH_INGESTION.md
+++ b/docs/BATCH_INGESTION.md
@@ -89,7 +89,7 @@ interface BatchOptions {
 
   /**
    * Optional callback to trigger after successful batch ingestion.
-   * This is commonly used to schedule Atlas rebuilds after external writes.
+   * This is commonly used to schedule Frame Graph rebuilds after external writes.
    * The callback receives the batch result and is only called on success.
    */
   onSuccess?: (result: BatchIngestionResult) => void | Promise<void>;
@@ -334,9 +334,10 @@ const result = await insertFramesBatch(store, validatedFrames, {
 });
 ```
 
-### 5. Trigger Atlas Rebuild After Batch Ingestion (L-EXE-004)
+### 5. Trigger a Frame Graph rebuild after batch ingestion (L-EXE-004)
 
-Use the `onSuccess` callback to schedule Atlas rebuilds after successful batch writes:
+Use the `onSuccess` callback to schedule Frame Graph rebuilds after successful batch writes. The
+current public function retains its legacy `triggerAtlasRebuild` name:
 
 ```typescript
 import { insertFramesBatch } from '@smartergpt/lex/memory';
@@ -344,9 +345,9 @@ import { triggerAtlasRebuild } from '@smartergpt/lex/atlas';
 
 const result = await insertFramesBatch(store, frames, {
   onSuccess: async (batchResult) => {
-    console.log(`Batch ingested ${batchResult.count} frames, triggering Atlas rebuild...`);
+    console.log(`Batch ingested ${batchResult.count} frames, triggering Frame Graph rebuild...`);
     
-    // Schedule Atlas rebuild (non-blocking, debounced)
+    // Schedule Frame Graph rebuild (non-blocking, debounced)
     await triggerAtlasRebuild();
   }
 });
@@ -361,11 +362,11 @@ const result = await insertFramesBatch(store, frames, {
 **When to use:**
 - After bulk Frame imports that should update derived views
 - When external orchestrators need to trigger downstream processing
-- For high-volume data ingestion that requires periodic Atlas updates
+- For high-volume data ingestion that requires periodic Frame Graph updates
 
 **When NOT to use:**
 - For individual Frame writes (use `notifyFrameIngested()` instead)
-- When Atlas rebuild should happen independently of Frame writes
+- When Frame Graph rebuild should happen independently of Frame writes
 
 ### 6. Always Close the Store
 
@@ -396,12 +397,14 @@ try {
 - `validateFramePayload()`: Standalone validation (no persistence)
 - `insertFramesBatch()`: Combines validation + persistence in one call
 
-### vs. Atlas Rebuild APIs
+### vs. Frame Graph rebuild APIs
 
-Batch ingestion writes Frames to storage. Atlas rebuilding creates derived views from those Frames:
+Batch ingestion writes Frames to storage. Frame Graph rebuilding creates a derived view from those
+Frames:
 
 - **Writing Frames**: Use `insertFramesBatch()` to persist Frame data
-- **Rebuilding Atlas**: Use `triggerAtlasRebuild()` to update derived views from Frames
+- **Rebuilding the Frame Graph**: Use legacy-named `triggerAtlasRebuild()` to update the derived
+  relationships
 - **Integration**: Use `onSuccess` callback to automatically trigger rebuilds after batch writes
 
 **Key distinction:**
@@ -409,7 +412,7 @@ Batch ingestion writes Frames to storage. Atlas rebuilding creates derived views
 // Writing Frames (primary data)
 const result = await insertFramesBatch(store, frames);
 
-// Rebuilding Atlas (derived views from all Frames in store)
+// Rebuilding the Frame Graph (derived view from all Frames in store)
 await triggerAtlasRebuild();
 
 // Combined: Write Frames + trigger rebuild
@@ -420,7 +423,8 @@ const result = await insertFramesBatch(store, frames, {
 });
 ```
 
-See the [Atlas Rebuild documentation](./ATLAS_REBUILD.md) for details on rebuild scheduling and debouncing.
+See the [terminology map](./ATLAS_TERMINOLOGY.md) for the Frame Graph ownership and compatibility
+boundary.
 
 ## Migration Guide
 

--- a/docs/CONTRACT_SURFACE.md
+++ b/docs/CONTRACT_SURFACE.md
@@ -17,10 +17,15 @@ paths, and historical `lex/...` imports are internal. See the exact
 | Frames | `@smartergpt/lex/types` | Frame Schema v7 |
 | Frame stores | `@smartergpt/lex/store` | Compatibility and scope-bound adapters |
 | Repository policy | `@smartergpt/lex/policy` | Zod-validated module/path relationships |
-| Atlas | `@smartergpt/lex/atlas` | Policy neighborhoods and experimental extraction surfaces |
+| Policy Neighborhood | `@smartergpt/lex/atlas` (compatibility path) | Optional bounded policy context |
+| Code Index | `code-atlas`, `atlas_analyze`, and `@smartergpt/lex/atlas/*` compatibility surfaces | Experimental source/symbol extraction |
+| Frame Graph | `@smartergpt/lex/atlas` (compatibility path) | Derived historical Frame relationships; no production caller identified |
 | CLI events | `@smartergpt/lex/cli-output` plus published schema | `CliEvent` v1 |
 | MCP | `@smartergpt/lex/mcp-server` | Embeddable server and deterministic tool schemas |
 | Instructions | CLI plus `lex.yaml`/marker contracts | Canonical source projected into host files |
+
+The three legacy Atlas-named families are inventoried separately in the
+[terminology and compatibility map](./ATLAS_TERMINOLOGY.md).
 
 ## Trusted runtime scope
 
@@ -119,7 +124,7 @@ tenant authority. See [Lex MCP](../README.mcp.md).
 
 ## Experimental surfaces
 
-Code Atlas persistence and `@smartergpt/lex/lexsona` expose useful integration points but retain
+Code Index persistence and `@smartergpt/lex/lexsona` expose useful integration points but retain
 explicit experimental status in their source contracts. Their declared package entry points are
 real and supported as import paths; experimental behavior inside them may require an explicit
 stabilization decision before external consumers should rely on it broadly.
@@ -157,7 +162,7 @@ A Lex-aware runner or tool should:
 [LexRunner](https://github.com/Guffawaffle/lexrunner) is the source-available orchestration engine
 used alongside Lex for fanout, attempts, verification, workspace coordination, and merge-weave.
 It consumes Lex contracts but does not define them, and it is not required for the Lex CLI,
-SQLite, policy, Atlas, instruction, or MCP workflows.
+SQLite, policy, Policy Neighborhood, Code Index, Frame Graph, instruction, or MCP workflows.
 
 If a published contract is ambiguous, file an issue with the package version, public entry point,
 expected invariant, and a minimal consumer example.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -64,7 +64,7 @@ Never store credentials, tokens, private keys, or other secrets in Frames.
 ## What is the difference between `recall` and `context`?
 
 `lex recall` retrieves Frames for a person or program to inspect. It supports compact summaries,
-listing, and Atlas-related controls.
+listing, and optional Policy Neighborhood controls.
 
 `lex context` is the bounded session-bootstrap surface. It selects a small set of relevant Frames,
 reports provenance and warnings, and enforces an approximate output budget. It uses hard read-only
@@ -89,18 +89,22 @@ describes. Choose one strategy:
 ## What does repository policy add?
 
 Policy maps stable module IDs to owned paths and allowed or forbidden relationships. Lex can use
-that vocabulary for Frame attribution, Atlas neighborhoods, and static boundary checks.
+that vocabulary for Frame attribution, Policy Neighborhoods, and static boundary checks.
 
 Policy is optional and is not an access-control system. See the [Repository Policy Guide](./API_USAGE.md).
 
-## What is Atlas?
+## What does the legacy “Atlas” name cover?
 
-Atlas turns policy relationships into a bounded neighborhood around the modules relevant to a
-Frame. It helps an agent see nearby architectural context without loading an entire repository
-graph. If no readable policy exists, core Frame recall still works without Atlas enrichment.
+Lex now distinguishes three systems that historically shared the Atlas name:
 
-Code Atlas extraction is a separate, experimental source-indexing surface. See the
-[Atlas guide](./atlas/README.md).
+- **Policy Neighborhood** turns policy relationships into bounded nearby-module context for a
+  recalled Frame. Core recall still works when policy is unavailable.
+- **Code Index** is experimental source/symbol extraction and provenance.
+- **Frame Graph** derives relationships among historical Frames and has no first-party production
+  caller today.
+
+See the [terminology and compatibility map](./ATLAS_TERMINOLOGY.md) and the
+[Policy Neighborhood and Code Index guide](./atlas/README.md).
 
 ## Do I need MCP?
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -14,7 +14,7 @@ recalled.
 
 ## Context budgets are approximate
 
-`lex context --max-tokens` and Atlas auto-tuning use deterministic estimates, not a target model's
+`lex context --max-tokens` and Policy Neighborhood auto-tuning use deterministic estimates, not a target model's
 exact tokenizer. The budget is a practical bound for selecting and formatting context, not a
 guarantee that every model will count the result identically.
 
@@ -66,17 +66,19 @@ policy maintenance.
 
 ## Scanner coverage is partial
 
-The built-in Code Atlas extractor focuses on TypeScript/JavaScript and Python source. Policy
+The built-in Code Index extractor (legacy `code-atlas` command) focuses on TypeScript/JavaScript
+and Python source. Policy
 scanner support is language-specific; Python and PHP examples exist, while Java, C#, Go, Rust, and
 other ecosystems require additional scanner work or external fact generation.
 
 Static scanners emit structural evidence. They cannot fully model runtime dispatch, generated
 code, reflection, or every framework convention.
 
-## Code Atlas persistence remains experimental
+## Code Index persistence remains experimental
 
-The `CodeAtlasStore` extension surface is experimental. Its API may change before it receives the
-same stability guarantees as the Frame and scoped-store contracts.
+The legacy-named `CodeAtlasStore` extension surface is experimental. Its API may change before it
+receives the same stability guarantees as the Frame and scoped-store contracts. See the
+[terminology map](./ATLAS_TERMINOLOGY.md).
 
 ## Historical Frames can become stale or hostile
 

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -167,12 +167,15 @@ that pin through their normal Lex/Lex-MCP compatibility review.
 
 Once configured, the following MCP tools are available:
 
+Legacy compatibility names are classified in the
+[Atlas terminology ownership map](./ATLAS_TERMINOLOGY.md).
+
 - `frame_create` - Store a deliberate Frame
 - `frame_search` - Search past Frames
 - `frame_get` - Retrieve a specific frame
 - `frame_list` - List recent frames
 - `frame_validate` - Validate frame input
-- `atlas_analyze` - Analyze code dependencies
+- `atlas_analyze` - Compatibility name for experimental Code Index dependency analysis
 - `timeline_show` - Show work timeline
 - `hints_get` - Get hint details
 - `help` - Get usage guidance

--- a/docs/MIND_PALACE.md
+++ b/docs/MIND_PALACE.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-The **Mind Palace** system extends Lex's Frame-based memory with **reference points** and **Atlas Frames** to enable human-like recall without replaying full history or re-indexing entire codebases.
+The **Mind Palace** system extends Lex's Frame-based memory with **reference points** and optional
+**Policy Neighborhoods** to enable human-like recall without replaying full history or re-indexing
+entire codebases.
 
 Instead of searching through all past work, you recall a **reference point** ("that auth bug when the Add User button was disabled") and the system expands only the relevant adjacent context.
 
@@ -25,16 +27,18 @@ Reference points are:
 - **Situation-specific** - tied to a concrete problem or feature
 - **Stable** - don't change as you iterate on the problem
 
-### 2. Atlas Frames
+### 2. Policy Neighborhoods
 
-An **Atlas Frame** is a structural snapshot of the module neighborhood relevant to your work. It captures:
+A **Policy Neighborhood** is a bounded view of the policy modules relevant to your work. It
+captures:
 
 - **Module coordinates** - spatial positions from LexMap policy
 - **Adjacency graph** - which modules can/cannot talk to each other
 - **Policy boundaries** - allowed vs forbidden edges
 - **Fold radius** - controlled context expansion (typically 1-hop from reference module)
 
-Together, reference points and Atlas Frames enable **instant, policy-aware context recall** without token-heavy re-indexing.
+Together, reference points and Policy Neighborhoods enable **instant, policy-aware context
+recall** without token-heavy re-indexing.
 
 ## How Reference Points Work
 
@@ -80,7 +84,7 @@ Or simply tell your assistant:
 
 The system:
 1. Finds the most recent Frame matching that reference point (fuzzy match)
-2. Retrieves the associated Atlas Frame
+2. Generates the current Policy Neighborhood when policy is available
 3. Returns both with full context
 
 ## Using `/recall` Effectively
@@ -109,7 +113,7 @@ The system:
 When you recall, the system returns:
 
 1. **Frame metadata** - what you were doing, next action, blockers
-2. **Atlas Frame** - visual map of relevant modules and boundaries
+2. **Policy Neighborhood** - visual map of relevant modules and boundaries
 3. **Policy context** - which edges are allowed/forbidden
 4. **Timeline** - when you captured this, which branch
 
@@ -170,9 +174,10 @@ Your assistant can now answer:
 
 > "You left off in `ui/user-admin-panel`. The Add User button is still disabled because that module was calling `services/auth-core` directly, which is forbidden by policy. The allowed path is through `services/user-access-api`. Your next action was to reroute through that API. Here's the visual map of those modules and their boundaries."
 
-## Understanding Atlas Frames
+## Understanding Policy Neighborhoods
 
-An Atlas Frame is **not** a full architecture diagram. It's a **controlled slice** of the structural context that matters for your recall.
+A Policy Neighborhood is **not** a full architecture diagram. It is a **controlled slice** of the
+structural context that matters for your recall.
 
 ### Fold Radius
 
@@ -199,12 +204,13 @@ NOT included:
 
 ### Policy Boundaries
 
-Atlas Frames show **allowed** and **forbidden** edges:
+Policy Neighborhoods show **allowed** and **forbidden** edges:
 
 - ✅ **Allowed edge**: You can call this module according to policy
 - ❌ **Forbidden edge**: Policy blocks this call (useful for explaining blockers)
 
-This is the key insight: the Atlas Frame doesn't just show structure, it shows **why something is blocked**.
+This is the key insight: the Policy Neighborhood does not just show structure, it shows **why
+something is blocked**.
 
 ### Coordinates and Layers
 
@@ -328,7 +334,9 @@ You:
 lex recall "Add User button"
 ```
 
-Even if you don't remember the exact details, the reference point anchors you. The Atlas Frame shows which modules were involved, and you can see if the current bug is hitting the same policy boundary.
+Even if you do not remember the exact details, the reference point anchors you. The Policy
+Neighborhood shows which modules were involved, and you can see if the current bug is hitting the
+same policy boundary.
 
 ### Workflow 4: Policy-Aware Reasoning
 
@@ -340,12 +348,12 @@ Even if you don't remember the exact details, the reference point anchors you. T
 
 **System returns:**
 - Frame showing you already tried that path
-- Atlas Frame showing `ui/user-admin-panel → services/auth-core` is forbidden
+- Policy Neighborhood showing `ui/user-admin-panel → services/auth-core` is forbidden
 - Policy says you must go through `user-access-api`
 
 **Assistant:** "Ah, I see the policy boundary. That edge is forbidden. The correct path is through user-access-api. Let me suggest that instead."
 
-The Atlas Frame prevents policy violations by making boundaries visible.
+The Policy Neighborhood helps prevent policy violations by making boundaries visible.
 
 ## Tips for Mind Palace Success
 
@@ -412,7 +420,8 @@ Mind Palace is not:
 
 ### Token Efficiency vs Completeness
 
-Atlas Frames deliberately **exclude** distant modules to save tokens. If you need fuller context, use LexMap's full policy export.
+Policy Neighborhoods deliberately **exclude** distant modules to save tokens. If you need fuller
+context, use the full policy export.
 
 The trade-off:
 - ✅ **Efficient recall** - get exactly the context that matters
@@ -426,11 +435,15 @@ Reference point recall uses fuzzy matching:
 
 Be specific enough to avoid false matches.
 
-### Stale Atlas Frames
+### Stale Policy Neighborhood inputs
 
-Atlas Frames snapshot policy **at capture time**. If policy changes, old Atlas Frames may be outdated.
+Policy Neighborhoods are generated from the policy available at recall time. A persisted
+`atlas_frame_id` is a legacy opaque reference and does not prove that its policy snapshot is
+current.
 
-Best practice: When policy changes significantly, recapture Frames for active work.
+Best practice: recall again after a policy change. Recapturing a Frame is neither required nor
+sufficient to refresh recall-time enrichment. Update a Frame only when its policy-backed
+`module_scope` IDs themselves were renamed or removed.
 
 ## Integration with Existing Lex Features
 
@@ -456,9 +469,12 @@ Reference points are added to existing Frame metadata:
 
 THE CRITICAL RULE still applies:
 
-> Every module name in `module_scope` MUST match the module IDs defined in LexMap's `lexmap.policy.json`.
+> Every policy-backed module name in `module_scope` MUST match a module ID defined in LexMap's
+> `lexmap.policy.json`.
 
-Atlas Frames rely on this rule. If module IDs drift, Atlas Frames break.
+When no policy-backed module applies, the write contract permits the exact singleton fallback
+`["workspace/unscoped"]`. It cannot be mixed with policy-backed IDs. Policy Neighborhoods rely on
+valid policy-backed IDs; if those IDs drift, neighborhood enrichment fails.
 
 ### LexMap Integration
 
@@ -467,18 +483,19 @@ Mind Palace requires LexMap for:
 - Adjacency graphs
 - Policy boundaries
 
-Without LexMap, you still get basic recall (via keywords/tickets), but **no Atlas Frames**.
+Without policy, you still get core recall via keywords and metadata, but no Policy Neighborhood.
 
 ## Privacy and Data Storage
 
 Mind Palace follows Lex's local-first principles:
 
 - **Reference points** - stored in local database (e.g. `/srv/lex-brain/thoughts.db`)
-- **Atlas Frames** - stored alongside Frames, same local database
+- **Policy Neighborhoods** - generated from authorized policy; not durable Frame data by default
 - **No upload by default** - everything stays on your machine
 - **Intentional capture** - you control when reference points are created
 
-If you enable optional sync (e.g. to your own S3 bucket), reference points and Atlas Frames are included in the backup.
+If you back up or migrate Frames, legacy `atlas_frame_id` values round-trip as opaque compatibility
+data. The policy used to generate a neighborhood must be managed separately.
 
 ## Next Steps
 

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -289,7 +289,7 @@ lex/
 │   │   └── scanners/    # Language-specific code scanners
 │   └── shared/          # Cross-cutting utilities
 │       ├── aliases/     # Module ID aliasing and resolution
-│       ├── atlas/       # Fold-radius graph computation
+│       ├── atlas/       # Policy Neighborhood + Frame Graph compatibility code
 │       ├── cli/         # CLI commands
 │       ├── git/         # Git integration utilities
 │       ├── module_ids/  # Module ID validation
@@ -358,8 +358,9 @@ The memory card renderer doesn't have to be pretty; it has to be legible and con
 ## Next Steps
 
 - Read the [Adoption Guide](./ADOPTION_GUIDE.md) to roll out Lex in phases
-- Read the [Mind Palace Guide](./MIND_PALACE.md) to learn about reference points and Atlas Frames
-- Read the [Code Atlas Documentation](./atlas/README.md) for spatial memory and code intelligence
+- Read the [Mind Palace Guide](./MIND_PALACE.md) to learn about reference points and Policy Neighborhoods
+- Read the [Policy Neighborhood and Code Index guide](./atlas/README.md)
+- Read the [Atlas terminology map](./ATLAS_TERMINOLOGY.md) for compatibility ownership
 - Read the [Architecture Loop](./ARCHITECTURE_LOOP.md) to understand the full explainability story
 - Read the [FAQ](./FAQ.md) for privacy, security, and compliance questions
 - Read [Contributing](../CONTRIBUTING.md) to extend Lex safely

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -99,7 +99,7 @@ Current test execution times:
 | **Memory Store** | 32 tests | ~360ms | 95% |
 | **Database Encryption** | 13 tests | ~550ms | 100% |
 | **Policy Enforcement** | 18 tests | ~200ms | 92% |
-| **Atlas Generation** | 15 tests | ~150ms | 88% |
+| **Policy Neighborhood generation** | 15 tests | ~150ms | 88% |
 | **Total** | 123+ tests | ~2.5s | 89.2% |
 
 ---

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -24,9 +24,9 @@ and compiles imports for every declaration path.
 | `@smartergpt/lex/runtime-scope` | Trusted identity, authority, binding, and diagnostics |
 | `@smartergpt/lex/errors` | AXError schemas, codes, and hints |
 | `@smartergpt/lex/policy` | Policy loading and validation |
-| `@smartergpt/lex/atlas` | Atlas generation and graph operations |
+| `@smartergpt/lex/atlas` | Legacy compatibility barrel for Policy Neighborhood, Frame Graph, and Code Index |
 | `@smartergpt/lex/atlas/code-unit` | Code-unit schemas and validation |
-| `@smartergpt/lex/atlas/schemas` | Atlas persistence schemas |
+| `@smartergpt/lex/atlas/schemas` | Code Index run and policy-seed schemas |
 | `@smartergpt/lex/module-ids` | Module identifier validation |
 | `@smartergpt/lex/aliases` | Module alias resolution |
 | `@smartergpt/lex/store` | Legacy FrameStore and authorized scoped persistence adapters |
@@ -49,10 +49,14 @@ and compiles imports for every declaration path.
 | `@smartergpt/lex/schemas/profile.schema.json` | Lex profile JSON Schema |
 
 The export path itself is stable once declared. Individual symbols may carry a narrower explicit
-status: `@smartergpt/lex/lexsona` and Code Atlas persistence currently identify experimental
+status: `@smartergpt/lex/lexsona` and Code Index persistence currently identify experimental
 behavior in their source contracts. Consumers should not infer full behavioral stabilization from
 path availability alone; promoting or breaking those experimental symbols still requires an
 explicit contract decision and release note.
+
+The `atlas` package path is a compatibility umbrella, not one subsystem. Its current symbol
+families and migration order are classified in the
+[Atlas terminology map](./ATLAS_TERMINOLOGY.md).
 
 ## Trusted storage boundary
 

--- a/docs/RECALL_QUALITY.md
+++ b/docs/RECALL_QUALITY.md
@@ -200,9 +200,9 @@ lex recall --list
 lex recall --list 20
 ```
 
-### Atlas Frame Configuration
+### Policy Neighborhood configuration
 
-**Fold Radius**: Controls how many "hops" away from module scope to include in Atlas Frame
+**Fold Radius**: Controls how many policy-graph hops away from module scope to include
 
 ```bash
 # Default radius (1 hop)

--- a/docs/STORE_CONTRACTS.md
+++ b/docs/STORE_CONTRACTS.md
@@ -176,10 +176,10 @@ The ordinary runtime binder and standard MCP server expose none of these adminis
 PostgreSQL read-only mode is an application-level no-write contract rather than a replacement for
 database permissions.
 
-## CodeAtlasStore (@experimental)
+## Code Index store (`CodeAtlasStore`, @experimental)
 
-Experimental interface for Code Atlas data. It does not yet carry the stability guarantees of the
-Frame and scope-bound store contracts.
+Experimental interface for Code Index data. The type keeps its legacy compatibility name and does
+not yet carry the stability guarantees of the Frame and scope-bound store contracts.
 
 ## Extension Points
 
@@ -189,4 +189,4 @@ for testing).
 ## See Also
 
 - `src/memory/store/frame-store.ts` — Interface definition
-- `src/memory/store/code-atlas-store.ts` — Experimental Atlas interface
+- `src/memory/store/code-atlas-store.ts` — Experimental Code Index interface

--- a/docs/agent-evaluation.md
+++ b/docs/agent-evaluation.md
@@ -29,7 +29,7 @@ Lex is a durable context and repository-policy layer for coding agents:
   branches or tickets, and module scope.
 - Recall retrieves prior checkpoints.
 - Context produces bounded, prompt-safe, read-only agent bootstrap material.
-- Optional policy and Atlas features add repository boundaries and nearby module context.
+- Optional policy and Policy Neighborhood features add repository boundaries and nearby context.
 - SQLite is the default local store. PostgreSQL and trusted tenant/workspace authority are advanced,
   explicit deployment choices.
 
@@ -73,7 +73,7 @@ Evaluate capabilities independently:
 | One meaningful checkpoint survives sessions | Frame remember/recall with local SQLite |
 | Bounded session-start context | `lex context` |
 | Repository module boundaries | Policy |
-| Nearby dependency/dependent context | Atlas |
+| Nearby dependency/dependent context | Policy Neighborhood |
 | Host-specific assistant instruction projection | Instructions |
 | MCP client access | Lex-MCP |
 | Shared cross-host or tenant-scoped storage | PostgreSQL and trusted runtime scope |

--- a/docs/atlas/README.md
+++ b/docs/atlas/README.md
@@ -1,11 +1,12 @@
-# Atlas
+# Policy Neighborhood and Code Index
 
-Atlas gives an agent a bounded view of the code around the work it recalled. Instead of loading a
-whole dependency graph, Lex starts with the Frame's module scope and expands only the nearby
-relationships declared by repository policy.
+This compatibility guide covers two independent systems whose existing APIs still use Atlas
+names. A **Policy Neighborhood** gives an agent bounded nearby-module context around recalled
+work. The experimental **Code Index** extracts source symbols and provenance. The historical
+**Frame Graph** is a third system and is not part of either workflow below.
 
-Atlas is optional. Frame capture and recall still work when no policy exists; the result simply
-does not include a policy-backed architectural neighborhood.
+Policy Neighborhood enrichment is optional. Frame capture and recall still work when no policy
+exists; the result simply does not include policy-backed nearby-module context.
 
 ## Policy-backed Frame context
 
@@ -22,7 +23,8 @@ lex remember \
   --modules "services/auth,api/middleware"
 ```
 
-Recall expands the module scope into an Atlas Frame:
+Recall expands the module scope into a Policy Neighborhood. Current output and APIs retain the
+legacy `AtlasFrame` name:
 
 ```bash
 lex recall "authentication"
@@ -36,12 +38,12 @@ lex recall "authentication" --auto-radius --max-tokens 5000
 - `--auto-radius` selects a radius using Lex's approximate token estimate.
 
 When the policy is missing or unreadable, recall reports that state and returns the core Frame
-without pretending an Atlas neighborhood was validated.
+without pretending a Policy Neighborhood was validated.
 
-## Code Atlas extraction
+## Code Index extraction
 
-The `code-atlas` command is a separate static-analysis surface. It discovers source units and can
-emit a policy seed for review:
+The legacy-named `code-atlas` command is a separate, experimental Code Index surface. It discovers
+source units and can emit a policy seed for review:
 
 ```bash
 lex code-atlas --repo . --max-files 500 --out ./code-atlas.json
@@ -52,8 +54,8 @@ The extractor currently recognizes TypeScript/JavaScript and Python source patte
 output is evidence, not authority: review ownership, module names, and relationships before using
 a seed as repository policy.
 
-`CodeUnit` and `CodeAtlasRun` are provenance schemas for extraction. They do not by themselves
-grant access or enforce module boundaries.
+`CodeUnit` and `CodeAtlasRun` retain compatibility names as provenance schemas for extraction. They
+do not by themselves grant access or enforce module boundaries.
 
 ## Programmatic use
 
@@ -91,20 +93,29 @@ const run = parseCodeAtlasRun(serializedRun);
 console.log(neighborhood.modules.length, unit.name, run);
 ```
 
-`@smartergpt/lex/atlas` contains policy-graph and CodeUnit APIs.
-`@smartergpt/lex/atlas/schemas` contains the extraction-run and policy-seed schemas. Historical
-source imports such as `@smartergpt/lex/shared/atlas` are not public.
+`@smartergpt/lex/atlas` is a legacy compatibility barrel containing Policy Neighborhood, Frame
+Graph, and Code Index symbols. `@smartergpt/lex/atlas/schemas` contains Code Index extraction-run
+and policy-seed schemas. Historical source imports such as `@smartergpt/lex/shared/atlas` are not
+public.
+
+## Frame Graph boundary
+
+The Frame Graph derives relationships among historical Frames. Its existing `rebuildAtlas`,
+validation, queue, and manager APIs are compatibility surfaces with no identified first-party
+production caller. It is unrelated to policy-neighborhood enrichment and Code Index extraction;
+see the [terminology map](../ATLAS_TERMINOLOGY.md) before using those APIs.
 
 ## Security boundary
 
-Atlas describes nearby architecture; it does not authorize tenant, workspace, repository, or
-filesystem access. A trusted host must first resolve an `AuthorizedScope` and an authorized policy
-snapshot, then generate Atlas context from that request-local input. It must not fall back to
-ambient paths or process-global policy when serving multiple workspaces.
+Policy Neighborhood, Code Index, and Frame Graph data describes or derives context; none authorizes
+tenant, workspace, repository, or filesystem access. A trusted host must first resolve an
+`AuthorizedScope` and authorized request-local inputs. It must not fall back to ambient paths or
+process-global policy when serving multiple workspaces.
 
 ## See also
 
 - [Repository Policy Guide](../API_USAGE.md)
+- [Terminology and compatibility map](../ATLAS_TERMINOLOGY.md)
 - [Runtime Scope Contract](../RUNTIME_SCOPE_CONTRACT.md)
 - [Public Package API](../PUBLIC_API.md)
 - [Current Limitations](../LIMITATIONS.md)

--- a/docs/atlas/api-reference.md
+++ b/docs/atlas/api-reference.md
@@ -1,4 +1,4 @@
-# Code Atlas API Reference
+# Code Index API Reference
 
 **Version:** v0  
 **Base URL:** `http://localhost:3000` (default)
@@ -7,12 +7,16 @@
 
 ## Overview
 
-Code Atlas provides two API interfaces:
+The experimental Code Index provides two API interfaces whose routes, tools, and types retain
+legacy Atlas names:
 
 1. **MCP (Model Context Protocol)** — For AI assistant integration via stdio
 2. **HTTP REST API** — For programmatic access from external tools
 
 Both interfaces use the same underlying storage and validation logic.
+
+Policy Neighborhood enrichment on Frame recall is separate, and the historical Frame Graph has no
+HTTP or MCP endpoint. See the [terminology map](../ATLAS_TERMINOLOGY.md).
 
 ---
 
@@ -42,11 +46,11 @@ MCP over stdio does not require authentication (runs locally).
 
 ## HTTP Endpoints
 
-### Create Frame with Atlas Context
+### Create Frame with Policy Neighborhood context
 
 `POST /api/frames`
 
-Creates a new Frame with module scope for Atlas Frame generation.
+Creates a new Frame with module scope for optional Policy Neighborhood generation.
 
 **Request:**
 ```json
@@ -126,7 +130,7 @@ curl http://localhost:3000/health
 
 ### lex.remember
 
-Store a new Frame with Atlas context.
+Store a new Frame with optional Policy Neighborhood context.
 
 **Request:**
 ```json
@@ -162,9 +166,10 @@ Store a new Frame with Atlas context.
 }
 ```
 
-### lex.recall
+### lex.recall with Policy Neighborhood context
 
-Search Frames and return with Atlas Frame context.
+Search Frames and return optional Policy Neighborhood context. The current response label remains
+`Atlas Frame` for compatibility.
 
 **Request:**
 ```json
@@ -319,7 +324,7 @@ if (result.success) {
 }
 ```
 
-### Atlas Frame Generation
+### Policy Neighborhood generation
 
 ```typescript
 import { 
@@ -331,7 +336,7 @@ import {
   estimateTokens
 } from '@smartergpt/lex/shared/atlas';
 
-// Generate Atlas Frame
+// Generate a Policy Neighborhood through the legacy function name
 const frame = generateAtlasFrame(
   ['services/auth', 'api/middleware'],  // seed modules
   1,                                     // fold radius

--- a/docs/atlas/code-atlas-v0.md
+++ b/docs/atlas/code-atlas-v0.md
@@ -1,5 +1,11 @@
 # Code Atlas v0 Specification
 
+> **Compatibility note:** This versioned historical specification combines what current
+> terminology calls **Code Index** extraction and **Policy Neighborhood** recall. Its
+> `code-atlas-v0`, `CodeAtlasRun`, and `AtlasFrame` spellings remain serialization/API
+> compatibility names. It does not specify the historical **Frame Graph**. See the
+> [terminology map](../ATLAS_TERMINOLOGY.md).
+
 **Version:** code-atlas-v0  
 **Status:** Implemented  
 **Last Updated:** November 2025
@@ -521,9 +527,10 @@ console.log(`Used radius ${result.radiusUsed} (${result.tokensUsed} tokens)`);
 
 ## Integration
 
-### With LexRunner
+### With LexRunner (Policy Neighborhood experiment)
 
-LexRunner orchestration can use Code Atlas for policy-aware task distribution:
+LexRunner may consume a Policy Neighborhood during task-packet construction. This is an
+experiment, not a current production Code Index consumer:
 
 ```typescript
 // Generate Atlas Frame for merge conflict context
@@ -539,9 +546,10 @@ if (forbiddenEdges.length > 0) {
 }
 ```
 
-### Policy Seeding
+### Policy generation and legacy seed evidence
 
-Atlas can seed initial policy from directory structure:
+Deterministic mixed-language policy generation is a separate subsystem. The `lex init --policy`
+surface produces repository policy; Code Index `PolicySeed` remains experimental evidence:
 
 ```bash
 # Generate seed policy

--- a/docs/atlas/examples.md
+++ b/docs/atlas/examples.md
@@ -1,6 +1,10 @@
-# Code Atlas Examples
+# Code Index and Policy Neighborhood examples
 
-Practical examples for using Code Atlas in various scenarios.
+The extraction examples use the experimental Code Index through legacy `code-atlas` names. The
+recall examples use Policy Neighborhoods through legacy `AtlasFrame` APIs. They are independent;
+see the [terminology map](../ATLAS_TERMINOLOGY.md).
+
+Practical examples for Code Index extraction and Policy Neighborhood recall.
 
 ---
 
@@ -9,8 +13,8 @@ Practical examples for using Code Atlas in various scenarios.
 1. [Extract Local Repository](#1-extract-local-repository)
 2. [Ingest via HTTP API](#2-ingest-via-http-api)
 3. [Query Code Units](#3-query-code-units)
-4. [Generate Atlas Frame](#4-generate-atlas-frame)
-5. [Policy-Aware Recall](#5-policy-aware-recall)
+4. [Generate a Policy Neighborhood](#4-generate-a-policy-neighborhood)
+5. [Recall with a Policy Neighborhood](#5-recall-with-a-policy-neighborhood)
 6. [Auto-Tune Token Limits](#6-auto-tune-token-limits)
 7. [Integration with LexRunner](#7-integration-with-lexrunner)
 
@@ -211,14 +215,14 @@ echo '{
 
 ---
 
-## 4. Generate Atlas Frame
+## 4. Generate a Policy Neighborhood
 
 ### Basic Generation
 
 ```typescript
 import { generateAtlasFrame } from '@smartergpt/lex/shared/atlas';
 
-// Generate Atlas Frame with 1-hop radius
+// Generate a Policy Neighborhood with 1-hop radius
 const atlasFrame = generateAtlasFrame(
   ['ui/user-admin-panel'],  // seed modules
   1                          // fold radius
@@ -282,15 +286,15 @@ console.log(JSON.stringify(atlasFrame, null, 2));
 
 ---
 
-## 5. Policy-Aware Recall
+## 5. Recall with a Policy Neighborhood
 
-### CLI Recall with Atlas Context
+### CLI recall with Policy Neighborhood context
 
 ```bash
 # Basic recall (1-hop radius by default)
 lex recall "auth middleware"
 
-# Output includes Atlas Frame:
+# Compatibility output includes the legacy Atlas Frame label:
 # 📌 Found 1 frame matching 'auth middleware'
 # 
 # Reference: implementing auth middleware
@@ -334,14 +338,14 @@ const frames = await searchFrames(db, {
 if (frames.length > 0) {
   const frame = frames[0];
   
-  // Generate Atlas Frame for the recalled frame
+  // Generate a Policy Neighborhood for the recalled Frame
   const atlasFrame = generateAtlasFrame(
     frame.moduleScope,
     1  // fold radius
   );
   
   console.log('Recalled frame:', frame.referencePoint);
-  console.log('Atlas neighborhood:', atlasFrame.modules.map(m => m.id));
+  console.log('Policy Neighborhood:', atlasFrame.modules.map(m => m.id));
   
   // Check for forbidden edges
   const forbidden = atlasFrame.edges.filter(e => !e.allowed);
@@ -387,7 +391,7 @@ const result = autoTuneRadius(
 
 console.log(`Final radius: ${result.radiusUsed}`);
 console.log(`Tokens used: ${result.tokensUsed}`);
-console.log(`Atlas Frame:`, result.atlasFrame);
+console.log(`Policy Neighborhood:`, result.atlasFrame);
 
 // Manual token estimation
 const frame = generateAtlasFrame(['services/auth'], 2);
@@ -416,7 +420,11 @@ console.log(`Actual tokens: ${actualTokens}`);
 
 ---
 
-## 7. Integration with LexRunner
+## 7. Experimental LexRunner Policy Neighborhood integration
+
+These examples are design sketches, not evidence of a production consumer. The bounded task-packet
+experiment is tracked in
+[Guffawaffle/lexrunner#858](https://github.com/Guffawaffle/lexrunner/issues/858).
 
 ### Merge Conflict Resolution
 
@@ -429,7 +437,7 @@ interface ConflictContext {
 }
 
 async function analyzeConflict(conflict: ConflictContext) {
-  // Generate Atlas Frame for conflicting modules
+  // Generate a Policy Neighborhood for conflicting modules
   const atlasFrame = generateAtlasFrame(conflict.modules, 1);
   
   // Check for policy violations
@@ -550,7 +558,7 @@ async function completeWorkflow() {
     
     console.log(`✅ Frame captured: ${frameId}`);
     
-    // 2. Recall with Atlas context
+    // 2. Recall with Policy Neighborhood context
     const frames = await searchFrames(db, {
       referencePoint: 'payment webhook',
     });
@@ -558,14 +566,14 @@ async function completeWorkflow() {
     if (frames.length > 0) {
       const frame = frames[0];
       
-      // 3. Generate auto-tuned Atlas Frame
+      // 3. Generate an auto-tuned Policy Neighborhood
       const result = autoTuneRadius(
         (r) => generateAtlasFrame(frame.moduleScope, r),
         2,     // Start with radius 2
         3000   // Fit in 3000 tokens
       );
       
-      console.log(`\n📊 Atlas Frame (radius: ${result.radiusUsed})`);
+      console.log(`\n📊 Policy Neighborhood (radius: ${result.radiusUsed})`);
       console.log(`   Tokens: ${result.tokensUsed}`);
       console.log(`   Modules: ${result.atlasFrame.modules.length}`);
       console.log(`   Edges: ${result.atlasFrame.edges.length}`);
@@ -593,7 +601,8 @@ completeWorkflow().catch(console.error);
 
 ## See Also
 
-- [Quick Start](./README.md) — Get started with Code Atlas
+- [Compatibility guide](./README.md) — Choose Policy Neighborhood or Code Index
+- [Terminology map](../ATLAS_TERMINOLOGY.md) — Understand legacy Atlas names
 - [Full Specification](./code-atlas-v0.md) — Schema and algorithm details
 - [API Reference](./api-reference.md) — Endpoint documentation
 - [CLI Reference](../CLI_OUTPUT.md) — Command-line options

--- a/docs/contract/YELLOW_BRICK.md
+++ b/docs/contract/YELLOW_BRICK.md
@@ -191,7 +191,7 @@ A developer or agent can:
 1. **Discover** Lex from the MCP registry
 2. **Execute** with one command (`npx @smartergpt/lex-mcp`)
 3. **Trust** outputs (clear provenance + constraints)
-4. **Use** Frames + Atlas + policy checks to reduce drift
+4. **Use** Frames + Policy Neighborhoods + policy checks to reduce drift
 
 For fanout specifically:
 

--- a/docs/control-stack/index.md
+++ b/docs/control-stack/index.md
@@ -75,5 +75,5 @@ For the full story—told from a model's perspective—read the essay:
 ## Related Reading
 
 - [Lex Architecture](../ARCHITECTURE.md) — How Lex structures memory and policy
-- [Frames & Atlas](../research/) — The episodic memory model underlying receipts
+- [Frames and derived context](../research/) — The episodic memory model underlying receipts
 - [Policy Files](../specs/) — How boundaries are encoded in Lex

--- a/docs/control-stack/pilot/integrate.md
+++ b/docs/control-stack/pilot/integrate.md
@@ -22,7 +22,7 @@ If the intent is out of scope, Integrate does **not** silently widen—it escala
 
 Let:
 - $\vec{I}$ = `PerceivedIntent` from Perceive
-- $\mathcal{L}$ = Lex state (Frames, Atlas, Receipts)
+- $\mathcal{L}$ = Lex state (Frames, derived context, Receipts)
 - $\mathcal{S}$ = LexSona rules (house rules, permissions)
 - $\mathcal{C}$ = Active version contract (if bound)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smartergpt/lex",
   "version": "4.0.0",
-  "description": "MIT-licensed memory, policy, and atlas framework with MCP server. For local dev and private automation.",
+  "description": "MIT-licensed memory, policy, and continuity framework with MCP server. For local dev and private automation.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/public-api-contract.mjs
+++ b/scripts/public-api-contract.mjs
@@ -39,7 +39,7 @@ export const PUBLIC_EXPORT_CONTRACT = Object.freeze([
   },
   {
     subpath: "./atlas",
-    purpose: "Atlas generation and graph operations",
+    purpose: "Legacy compatibility barrel for Policy Neighborhood, Frame Graph, and Code Index",
     anchors: ["generateAtlasFrame", "buildPolicyGraph"],
   },
   {
@@ -49,7 +49,7 @@ export const PUBLIC_EXPORT_CONTRACT = Object.freeze([
   },
   {
     subpath: "./atlas/schemas",
-    purpose: "Atlas persistence schemas",
+    purpose: "Code Index run and policy-seed schemas",
     anchors: ["CodeAtlasRunSchema", "parseCodeAtlasRun"],
   },
   {

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -343,6 +343,67 @@ if (!foundLexbrain) {
   pass('No outdated "lexbrain" references found');
 }
 
+section("Atlas Terminology Ownership");
+const atlasTerminology = readFile("docs/ATLAS_TERMINOLOGY.md");
+for (const required of [
+  "### Policy Neighborhood",
+  "### Code Index",
+  "### Frame Graph",
+  "@smartergpt/lex/atlas",
+  "`lex code-atlas`",
+  "`atlas_analyze`",
+  "`POST /api/atlas/ingest`",
+  "`atlas_frame_id`",
+  "`src/shared/atlas/rebuild.ts`",
+  "issues/733",
+  "issues/804",
+  "lexrunner/issues/858",
+  "issues/806",
+  "issues/807",
+  "issues/808",
+]) {
+  if (atlasTerminology?.includes(required)) {
+    pass(`Atlas terminology map classifies ${required}`);
+  } else {
+    error(`docs/ATLAS_TERMINOLOGY.md must classify ${required}`);
+  }
+}
+
+for (const [path, content] of [
+  ["README.mcp.md", publicMcpReadme],
+  ["docs/MCP_CONFIG.md", readFile("docs/MCP_CONFIG.md")],
+  ["docs/FAQ.md", readFile("docs/FAQ.md")],
+  ["docs/CONTRACT_SURFACE.md", readFile("docs/CONTRACT_SURFACE.md")],
+  ["docs/PUBLIC_API.md", readFile("docs/PUBLIC_API.md")],
+  ["docs/atlas/README.md", readFile("docs/atlas/README.md")],
+]) {
+  if (content?.includes("ATLAS_TERMINOLOGY.md")) {
+    pass(`${path} links the Atlas terminology map`);
+  } else {
+    error(`${path} must link docs/ATLAS_TERMINOLOGY.md`);
+  }
+}
+
+if (
+  registryManifest.description.includes("Policy Neighborhoods") &&
+  !/\bAtlas\b/.test(registryManifest.description)
+) {
+  pass("server.json uses owned Policy Neighborhood terminology");
+} else {
+  error("server.json must use owned terminology instead of an unqualified Atlas label");
+}
+
+const mcpConfig = readFile("docs/MCP_CONFIG.md");
+if (
+  mcpConfig?.includes(
+    "`atlas_analyze` - Compatibility name for experimental Code Index dependency analysis"
+  )
+) {
+  pass("docs/MCP_CONFIG.md classifies atlas_analyze as Code Index compatibility");
+} else {
+  error("docs/MCP_CONFIG.md must classify atlas_analyze as Code Index compatibility");
+}
+
 // Check MCP tool naming conventions
 section("MCP Tool Naming Conventions");
 const toolsFile = readFile("src/memory/mcp_server/tools.ts");

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "dev.smartergpt/lex",
   "title": "Lex",
-  "description": "Episodic memory and architectural policy for AI agents. Frames, Atlas, and Policy.",
+  "description": "Episodic memory and architectural policy for AI agents. Frames, Policy Neighborhoods, and policy enforcement.",
   "repository": {
     "url": "https://github.com/Guffawaffle/lex",
     "source": "github"

--- a/src/atlas/index.ts
+++ b/src/atlas/index.ts
@@ -1,5 +1,5 @@
 /**
- * Atlas Schemas - Code Atlas schema definitions and validation
+ * Code Index schemas through legacy Code Atlas names
  */
 
 export type { CodeAtlasRun, Limits } from "./schemas/code-atlas-run.js";

--- a/src/atlas/policy-seed-generator.ts
+++ b/src/atlas/policy-seed-generator.ts
@@ -1,5 +1,5 @@
 /**
- * Policy Seed Generator - Generate seed policy from Code Atlas data
+ * Experimental policy-seed evidence generated from Code Index data
  *
  * Part of Code Atlas Epic (CA-010) - Layer 4: Policy Integration (Stretch Goal)
  *

--- a/src/atlas/schemas/code-atlas-run.ts
+++ b/src/atlas/schemas/code-atlas-run.ts
@@ -1,7 +1,7 @@
 /**
- * CodeAtlasRun Schema - Provenance record for Code Atlas extraction runs
+ * CodeAtlasRun schema - provenance record for Code Index extraction runs
  *
- * This schema defines the structure for tracking Code Atlas extraction runs,
+ * This compatibility schema tracks Code Index extraction runs,
  * including metadata about what was scanned, limits applied, and the strategy used.
  */
 

--- a/src/atlas/schemas/code-unit.ts
+++ b/src/atlas/schemas/code-unit.ts
@@ -1,5 +1,5 @@
 /**
- * CodeUnit Schema - Atomic unit of the Code Atlas
+ * CodeUnit schema - atomic unit of the experimental Code Index
  *
  * Zod schema with TypeScript type exports for code discovery and indexing.
  * Part of Code Atlas Epic (CA-001) - Layer 0: Schema

--- a/src/atlas/schemas/index.ts
+++ b/src/atlas/schemas/index.ts
@@ -1,7 +1,7 @@
 /**
- * Code Atlas Schemas Export
+ * Code Index schema exports through legacy Code Atlas names
  *
- * Layer 0: Schema definitions for Code Atlas
+ * Layer 0: schema definitions for the experimental Code Index
  */
 
 export {

--- a/src/atlas/schemas/policy-seed.ts
+++ b/src/atlas/schemas/policy-seed.ts
@@ -1,5 +1,5 @@
 /**
- * PolicySeed Schema - Seed policy module definitions from Code Atlas data
+ * PolicySeed schema - experimental seed module definitions from Code Index data
  *
  * Part of Code Atlas Epic (CA-010) - Layer 4: Policy Integration (Stretch Goal)
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export { FRAME_SCHEMA_VERSION, validateFrameMetadata } from "./shared/types/fram
 export type { Policy, PolicyModule, PolicyEdge } from "./shared/types/policy.js";
 export { validatePolicyModule } from "./shared/types/policy.js";
 
-// Atlas types - spatial neighborhood for context generation
+// Policy Neighborhood types through legacy AtlasFrame names
 export type { AtlasFrame, AtlasModuleData, AtlasEdge } from "./shared/atlas/types.js";
 
 // Validation types - module ID validation results
@@ -80,7 +80,7 @@ export type {
 } from "./memory/batch.js";
 
 // =============================================================================
-// POLICY & ATLAS HELPERS (1.0.0 Contract)
+// POLICY AND LEGACY ATLAS COMPATIBILITY HELPERS (1.0.0 Contract)
 // =============================================================================
 
 // Policy loading with precedence rules
@@ -90,11 +90,11 @@ export { loadPolicy, clearPolicyCache } from "./shared/policy/loader.js";
 export { validateModuleIds } from "./shared/module_ids/validator.js";
 export { resolveModuleId } from "./shared/aliases/resolver.js";
 
-// Atlas Frame generation for token-efficient context
+// Policy Neighborhood generation for token-efficient context
 export { generateAtlasFrame } from "./shared/atlas/atlas-frame.js";
 export { autoTuneRadius, estimateTokens } from "./shared/atlas/auto-tune.js";
 
-// Atlas rebuild trigger API (LEX-108: Batch Operations)
+// Frame Graph rebuild trigger API through legacy Atlas names (LEX-108)
 export {
   triggerAtlasRebuild,
   onRebuildComplete,

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -83,8 +83,8 @@ lex remember --branch custom-branch ...
 
 When you `/recall` a Frame, the system:
 1. Retrieves the Frame from `store/`
-2. Calls `shared/atlas/` to get the fold-radius neighborhood for `module_scope`
-3. Returns both the Frame (temporal anchor) and Atlas Frame (spatial anchor)
+2. Calls the Policy Neighborhood compatibility code in `shared/atlas/` for `module_scope`
+3. Returns both the Frame (temporal anchor) and optional Policy Neighborhood (spatial anchor)
 4. Optionally renders a visual memory card with embedded images
 
 This gives context with receipts: "here's what you were doing + here's the policy boundaries that were blocking you."
@@ -147,7 +147,7 @@ When you create a Frame with `/remember`, the system:
 Without strict validation, vocabulary drift occurs:
 - Frame says `["auth-core"]`
 - Policy defines `"services/auth-core"`
-- `/recall` fails because Atlas Frame can't find the module in the policy graph
+- Policy Neighborhood enrichment fails because the module is absent from the policy graph
 
 Validation enforces a **single source of truth** for module naming.
 

--- a/src/memory/batch.ts
+++ b/src/memory/batch.ts
@@ -39,12 +39,13 @@ export interface BatchOptions {
 
   /**
    * Optional callback to trigger after successful batch ingestion.
-   * This is commonly used to schedule Atlas rebuilds after external writes.
+   * This is commonly used to schedule Frame Graph rebuilds after external writes.
    * The callback receives the batch result and is only called on success.
    *
    * @example
    * ```typescript
    * import { insertFramesBatch } from '@smartergpt/lex/memory';
+   * // Legacy compatibility name for the Frame Graph rebuild trigger:
    * import { triggerAtlasRebuild } from '@smartergpt/lex/atlas';
    *
    * const result = await insertFramesBatch(store, frames, {

--- a/src/memory/frames/types.ts
+++ b/src/memory/frames/types.ts
@@ -109,7 +109,7 @@ export const Frame = z.object({
   reference_point: z.string(), // Human-memorable anchor phrase
   status_snapshot: FrameStatusSnapshot,
   keywords: z.array(z.string()).optional(),
-  atlas_frame_id: z.string().optional(), // Link to Atlas Frame (spatial neighborhood)
+  atlas_frame_id: z.string().optional(), // Legacy Policy Neighborhood snapshot reference
   feature_flags: z.array(z.string()).optional(),
   permissions: z.array(z.string()).optional(),
   module_attribution: ModuleAttribution.optional(),

--- a/src/memory/mcp_server/README.md
+++ b/src/memory/mcp_server/README.md
@@ -45,7 +45,7 @@ exactly fourteen canonical `resource_action` names:
 | `frame_list` | List recent Frames with bounded filters |
 | `policy_check` | Check paths or changes against repository policy |
 | `timeline_show` | Return a chronological work timeline |
-| `atlas_analyze` | Analyze bounded code-neighborhood context |
+| `atlas_analyze` | Build the experimental Code Index (legacy tool name) |
 | `system_introspect` | Report runtime capabilities and credential-free store identity |
 | `help` | Return task-oriented tool guidance |
 | `hints_get` | Return focused usage hints |
@@ -71,6 +71,11 @@ exact fallback payload as structured remediation; it is never silently rewritten
 Accepted legacy aliases are compatibility inputs only. They are not advertised tools and must not
 appear as the preferred name in current consumer documentation. Alias mappings and capability
 coverage live in [`../../shared/runtime-scope/capabilities.ts`](../../shared/runtime-scope/capabilities.ts).
+
+`atlas_analyze` itself is a legacy-named Code Index command. It does not generate the
+policy-backed Policy Neighborhood returned with Frame recall and does not rebuild the historical
+Frame Graph. See the
+[`Atlas` terminology map](../../../docs/ATLAS_TERMINOLOGY.md).
 
 Any tool addition, removal, or rename must update together:
 

--- a/src/memory/mcp_server/TESTING.md
+++ b/src/memory/mcp_server/TESTING.md
@@ -111,7 +111,7 @@ Based on the issue requirements:
 | Metric | Before (Exact Only) | After (With Fuzzy) | Target |
 |--------|---------------------|-------------------|--------|
 | Validation time | ~0.5ms | ~0.5ms (exact path) | <5% regression |
-| Atlas Frame generation | ~10ms | ~10ms (unchanged) | <5% regression |
+| Policy Neighborhood generation | ~10ms | ~10ms (unchanged) | <5% regression |
 | Memory overhead | None | ~10KB (policy cache) | <50KB |
 | Fuzzy fallback | N/A | ~2ms worst case | <5ms |
 

--- a/src/memory/mcp_server/routes/atlas.ts
+++ b/src/memory/mcp_server/routes/atlas.ts
@@ -1,5 +1,5 @@
 /**
- * Atlas API Routes
+ * Code Index API routes through the legacy /api/atlas path
  *
  * HTTP API endpoints for ingesting and querying code units and atlas runs.
  * Part of Code Atlas Epic (CA-006, CA-007) - Layer 2: API
@@ -215,7 +215,7 @@ export function createAtlasRouter(db: Database.Database): Router {
           unitsSkipped: result.unitsSkipped,
           durationMs,
         },
-        "Atlas data ingested"
+        "Code Index data ingested"
       );
 
       const response: AtlasIngestResponse = {
@@ -228,7 +228,7 @@ export function createAtlasRouter(db: Database.Database): Router {
       res.status(201).json(response);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.error({ error: errorMessage }, "Atlas ingest failed");
+      logger.error({ error: errorMessage }, "Code Index ingest failed");
 
       const errorResponse: AtlasApiErrorResponse = {
         error: "internal_error",
@@ -415,7 +415,7 @@ export function createAtlasRouter(db: Database.Database): Router {
       if (!run) {
         return res.status(404).json({
           error: "NOT_FOUND",
-          message: `Atlas run with id '${runId}' not found`,
+          message: `Code Index run with id '${runId}' not found`,
           code: 404,
         } as AtlasApiErrorResponse);
       }

--- a/src/memory/mcp_server/server.ts
+++ b/src/memory/mcp_server/server.ts
@@ -585,7 +585,7 @@ export class MCPServer {
       if (!context.policy) {
         throw new MCPError(
           MCPErrorCode.POLICY_NOT_FOUND,
-          "Atlas enrichment is unavailable because this workspace has no policy."
+          "Policy Neighborhood enrichment is unavailable because this workspace has no policy."
         );
       }
       return generateAtlasFrameFromPolicy(moduleScope, context.policy);
@@ -1103,13 +1103,13 @@ export class MCPServer {
       await frameStore.saveFrame(frame);
     }
 
-    // Generate Atlas Frame for the module scope (skip if no policy available)
+    // Generate Policy Neighborhood context (skip if no policy is available)
     let atlasOutput = "";
     try {
       const atlasFrame = this.atlasFrameForContext(canonicalModuleScope, context);
       atlasOutput = formatAtlasFrame(atlasFrame);
     } catch {
-      // Atlas frame generation requires policy — skip gracefully
+      // Policy Neighborhood generation requires policy — skip gracefully
       if (process.env.LEX_DEBUG) {
         logger.error(`[LEX] Skipping atlas frame generation (no policy available)`);
       }
@@ -1398,7 +1398,7 @@ export class MCPServer {
   }
 
   /**
-   * Handle mcp_lex_frame_recall tool - search Frames with Atlas Frame
+   * Handle mcp_lex_frame_recall tool with optional Policy Neighborhood context
    */
   private async handleRecall(
     args: Record<string, unknown>,
@@ -1523,7 +1523,7 @@ export class MCPServer {
       };
     }
 
-    // Format results with Atlas Frame for each (full format)
+    // Format results with a Policy Neighborhood for each (full format)
     const results = frames
       .map((f: Frame, idx: number) => {
         const nextAction = f.status_snapshot?.next_action || "None specified";
@@ -1531,7 +1531,7 @@ export class MCPServer {
         const mergeBlockers = f.status_snapshot?.merge_blockers || [];
         const testsFailing = f.status_snapshot?.tests_failing || [];
 
-        // Generate Atlas Frame for this Frame's modules (skip if no policy)
+        // Generate a Policy Neighborhood for this Frame's modules (skip without policy)
         let atlasOutput = "";
         try {
           const atlasFrame = this.atlasFrameForContext(f.module_scope, context);
@@ -1636,7 +1636,7 @@ export class MCPServer {
       `${frame.keywords ? `🏷️  Keywords: ${frame.keywords.join(", ")}\n` : ""}` +
       `${frame.atlas_frame_id ? `🗺️  Atlas: ${frame.atlas_frame_id}\n` : ""}`;
 
-    // Include Atlas Frame if requested (skip if no policy)
+    // Include Policy Neighborhood context if requested (skip without policy)
     if (include_atlas) {
       try {
         const atlasFrame = this.atlasFrameForContext(frame.module_scope, context);
@@ -1761,7 +1761,7 @@ export class MCPServer {
       };
     }
 
-    // Format results with Atlas Frame for each (full format)
+    // Format results with Policy Neighborhood context for each (full format)
     const results = frames
       .map((f: Frame, idx: number) => {
         let atlasOutput = "";
@@ -2161,7 +2161,7 @@ export class MCPServer {
       if (!result.success || !result.output) {
         throw new MCPError(
           MCPErrorCode.INTERNAL_ERROR,
-          `Code atlas generation failed: ${result.error ?? "unknown error"}`,
+          `Code Index generation failed: ${result.error ?? "unknown error"}`,
           { path: repoPath }
         );
       }
@@ -2170,7 +2170,7 @@ export class MCPServer {
 
       // Format the output for MCP response
       const summary =
-        `🗺️  Code Atlas Generated\n` +
+        `🗺️  Code Index Generated\n` +
         `📍 Repository: ${run.repoId}\n` +
         `📁 Files scanned: ${run.filesScanned.length}${
           run.truncated ? ` (truncated from ${run.filesRequested.length})` : ""
@@ -2217,7 +2217,7 @@ export class MCPServer {
         ],
       };
     } catch (error: unknown) {
-      // Handle errors from code atlas generation
+      // Handle errors from Code Index generation
       if (error instanceof MCPError) {
         throw error;
       }
@@ -2225,7 +2225,7 @@ export class MCPServer {
       const errorMessage = error instanceof Error ? error.message : String(error);
       throw new MCPError(
         MCPErrorCode.INTERNAL_ERROR,
-        `Failed to generate code atlas: ${errorMessage}`,
+        `Failed to generate Code Index: ${errorMessage}`,
         { path: requestPath, error: errorMessage }
       );
     }
@@ -2764,7 +2764,7 @@ export class MCPServer {
       },
       frame_search: {
         description:
-          "Search Frames by reference point, branch, or Jira ticket. Returns matching Frames with Atlas neighborhoods.",
+          "Search Frames by reference point, branch, or Jira ticket. Returns matching Frames with optional Policy Neighborhoods.",
         requiredFields: [],
         optionalFields: ["reference_point", "jira", "branch", "limit"],
         examples: [
@@ -2810,7 +2810,7 @@ export class MCPServer {
             input: { frame_id: "frame-abc123" },
           },
           {
-            description: "Get frame without Atlas neighborhood",
+            description: "Get frame without Policy Neighborhood context",
             input: { frame_id: "frame-abc123", include_atlas: false },
           },
         ],
@@ -3106,7 +3106,7 @@ export class MCPServer {
         description: "Understand code structure and dependencies",
         steps: [
           "Use `system_introspect` to see available modules",
-          "Use `atlas_analyze` to visualize dependencies",
+          "Use legacy-named `atlas_analyze` to extract the experimental Code Index",
           "Use `policy_check` to validate boundaries",
         ],
         tools: ["system_introspect", "atlas_analyze", "policy_check"],

--- a/src/memory/mcp_server/tools.ts
+++ b/src/memory/mcp_server/tools.ts
@@ -2,7 +2,7 @@
  * MCP Tools for Frame Memory
  *
  * Defines the tools exposed via Model Context Protocol for AI assistants.
- * Each tool can search, create, or list Frames with Atlas Frame neighborhoods.
+ * Frame tools can include an optional Policy Neighborhood through legacy AtlasFrame fields.
  */
 
 export interface MCPTool {
@@ -71,7 +71,7 @@ export const MCP_TOOLS: MCPTool[] = [
         },
         atlas_frame_id: {
           type: "string",
-          description: "Reference to Atlas Frame (fold radius snapshot)",
+          description: "Legacy reference to a Policy Neighborhood snapshot",
         },
         images: {
           type: "array",
@@ -149,7 +149,7 @@ export const MCP_TOOLS: MCPTool[] = [
         },
         atlas_frame_id: {
           type: "string",
-          description: "Reference to Atlas Frame (fold radius snapshot)",
+          description: "Legacy reference to a Policy Neighborhood snapshot",
         },
         images: {
           type: "array",
@@ -175,7 +175,7 @@ export const MCP_TOOLS: MCPTool[] = [
   {
     name: "frame_search",
     description:
-      "Search Frames by reference point, branch, or Jira ticket. Returns Frame + Atlas Frame neighborhood. Alias: recall (deprecated)",
+      "Search Frames by reference point, branch, or Jira ticket. Returns a Frame plus optional Policy Neighborhood. Alias: recall (deprecated)",
     inputSchema: {
       type: "object",
       properties: {
@@ -226,7 +226,7 @@ export const MCP_TOOLS: MCPTool[] = [
         },
         include_atlas: {
           type: "boolean",
-          description: "Include Atlas Frame neighborhood in response (default: true)",
+          description: "Include Policy Neighborhood context (legacy field; default: true)",
           default: true,
         },
         format: {
@@ -241,7 +241,7 @@ export const MCP_TOOLS: MCPTool[] = [
   {
     name: "frame_list",
     description:
-      "List recent Frames, optionally filtered by branch or module. Returns Frame + Atlas Frame for each result. Alias: list_frames (deprecated)",
+      "List recent Frames, optionally filtered by branch or module. Returns each Frame plus optional Policy Neighborhood. Alias: list_frames (deprecated)",
     inputSchema: {
       type: "object",
       properties: {
@@ -329,8 +329,7 @@ export const MCP_TOOLS: MCPTool[] = [
   },
   {
     name: "atlas_analyze",
-    description:
-      "Analyze code structure and dependencies across modules. Alias: code_atlas (deprecated)",
+    description: "Extract the experimental Code Index. Legacy name; alias: code_atlas (deprecated)",
     inputSchema: {
       type: "object",
       properties: {

--- a/src/memory/renderer/GRAPH_RENDERER.md
+++ b/src/memory/renderer/GRAPH_RENDERER.md
@@ -1,6 +1,7 @@
-# Graph Renderer for Atlas Frames
+# Graph Renderer for Policy Neighborhoods
 
-Visual rendering of Atlas Frames as interactive SVG/Canvas graphs showing module dependencies and policy constraints.
+Visual rendering of Policy Neighborhood compatibility shapes (`AtlasFrame`) as interactive
+SVG/Canvas graphs showing module dependencies and policy constraints.
 
 ## Features
 
@@ -42,7 +43,7 @@ Visual rendering of Atlas Frames as interactive SVG/Canvas graphs showing module
 import { renderAtlasFrameGraph, exportGraphAsPNG } from './graph.js';
 import { generateAtlasFrame } from '../../shared/atlas/atlas-frame.js';
 
-// Generate an Atlas Frame
+// Generate a Policy Neighborhood through the legacy API
 const atlasFrame = generateAtlasFrame(['ui/admin-panel'], 1);
 
 // Render as SVG
@@ -143,7 +144,8 @@ Tests cover:
 
 ## Integration with Memory Cards
 
-The graph renderer integrates with the memory card system to provide visual Atlas Frame representations:
+The graph renderer integrates with the memory card system to provide visual Policy Neighborhood
+representations:
 
 ```typescript
 import { renderMemoryCard } from './card.js';
@@ -161,7 +163,7 @@ const frame = {
   },
 };
 
-// Generate Atlas Frame for the module scope
+// Generate a Policy Neighborhood for the module scope
 const atlasFrame = generateAtlasFrame(frame.module_scope, 1);
 
 // Render memory card with embedded graph
@@ -172,10 +174,10 @@ const card = await renderMemoryCard(frame, atlasFrame);
 
 ### `renderAtlasFrameGraph(atlasFrame, options?): string`
 
-Renders an Atlas Frame as SVG.
+Renders a Policy Neighborhood (`AtlasFrame`) as SVG.
 
 **Parameters**:
-- `atlasFrame: AtlasFrame` - The Atlas Frame to render
+- `atlasFrame: AtlasFrame` - The Policy Neighborhood compatibility value to render
 - `options?: GraphRenderOptions` - Rendering options
 
 **Returns**: SVG markup as string

--- a/src/memory/renderer/README.md
+++ b/src/memory/renderer/README.md
@@ -209,7 +209,7 @@ Each rendered memory card includes:
 5. **Keywords** (if present)
 
 6. **Optional Fields**
-   - Atlas Frame ID (if present)
+   - Legacy Policy Neighborhood reference (if present)
    - Raw context (logs, diffs, etc.)
 
 ## Default Dimensions

--- a/src/memory/renderer/graph-example.ts
+++ b/src/memory/renderer/graph-example.ts
@@ -6,7 +6,7 @@ import { join } from "path";
 
 const logger = getLogger("memory:renderer:graph-example");
 
-// Create example Atlas Frame based on the test policy
+// Create an example Policy Neighborhood based on the test policy
 const exampleAtlasFrame: AtlasFrame = {
   atlas_timestamp: new Date().toISOString(),
   seed_modules: ["ui/admin-panel"],

--- a/src/memory/renderer/graph.ts
+++ b/src/memory/renderer/graph.ts
@@ -1,5 +1,5 @@
 /**
- * Graph rendering for Atlas Frames
+ * Graph rendering for Policy Neighborhoods through legacy AtlasFrame shapes
  * Generates SVG visualizations showing module nodes, dependency edges,
  * and visual indicators for allowed vs forbidden connections.
  */
@@ -119,7 +119,7 @@ function calculateNodeRadius(module: AtlasModule, edges: AtlasEdge[]): number {
 }
 
 /**
- * Render Atlas Frame as SVG graph
+ * Render a Policy Neighborhood as an SVG graph
  */
 export function renderAtlasFrameGraph(
   atlasFrame: AtlasFrame,

--- a/src/memory/store/README.md
+++ b/src/memory/store/README.md
@@ -152,7 +152,7 @@ closeDb();
 | reference_point | TEXT NOT NULL | Human-memorable anchor phrase |
 | status_snapshot | TEXT NOT NULL | JSON object with next_action, blockers |
 | keywords | TEXT | JSON array of keywords |
-| atlas_frame_id | TEXT | Link to Atlas Frame |
+| atlas_frame_id | TEXT | Opaque legacy Policy Neighborhood reference |
 | feature_flags | TEXT | JSON array of feature flags |
 | permissions | TEXT | JSON array of permissions |
 
@@ -161,7 +161,7 @@ closeDb();
 - `idx_frames_timestamp` - Descending timestamp for recent frames
 - `idx_frames_branch` - Branch queries
 - `idx_frames_jira` - Jira/ticket queries
-- `idx_frames_atlas_frame_id` - Atlas Frame links
+- `idx_frames_atlas_frame_id` - Legacy Policy Neighborhood references
 
 ### FTS5 Virtual Table
 

--- a/src/memory/store/code-atlas-runs.ts
+++ b/src/memory/store/code-atlas-runs.ts
@@ -1,5 +1,5 @@
 /**
- * Code Atlas Runs storage queries
+ * Code Index run storage queries through legacy CodeAtlasRun names
  *
  * CRUD operations for CodeAtlasRun provenance records.
  */

--- a/src/memory/store/code-atlas-store.ts
+++ b/src/memory/store/code-atlas-store.ts
@@ -1,5 +1,5 @@
 /**
- * CodeAtlasStore — persistence contract for Code Atlas data
+ * CodeAtlasStore — legacy-named persistence contract for Code Index data
  *
  * @experimental
  * This interface is EXPERIMENTAL for 1.0.0. It may change in 1.0.x or 1.1
@@ -11,7 +11,7 @@ import type { CodeAtlasRun } from "../../atlas/schemas/code-atlas-run.js";
 
 /**
  * @experimental
- * CodeAtlasStore — persistence contract for Code Atlas data.
+ * CodeAtlasStore — legacy-named persistence contract for Code Index data.
  *
  * This interface is EXPERIMENTAL for 1.0.0. It may change in 1.0.x or 1.1
  * without semver breakage guarantees.

--- a/src/memory/store/db.ts
+++ b/src/memory/store/db.ts
@@ -860,7 +860,7 @@ function applyMigrationV4(db: Database.Database): void {
 }
 
 /**
- * Migration V5: Add code_units table for Code Atlas
+ * Migration V5: Add code_units table for the experimental Code Index
  *
  * Stores CodeUnit records for code discovery and indexing.
  * Schema aligned with src/atlas/schemas/code-unit.ts (CA-001).
@@ -919,12 +919,12 @@ function applyMigrationV5(db: Database.Database): void {
 }
 
 /**
- * Migration V6: Add code_atlas_runs table for Code Atlas provenance records
+ * Migration V6: Add code_atlas_runs table for Code Index provenance records
  *
  * Schema aligned with CodeAtlasRun type from src/atlas/schemas/code-atlas-run.ts
  */
 function applyMigrationV6(db: Database.Database): void {
-  // Create code_atlas_runs table for Code Atlas extraction provenance
+  // Create code_atlas_runs table for Code Index extraction provenance
   db.exec(`
     CREATE TABLE IF NOT EXISTS code_atlas_runs (
       run_id TEXT PRIMARY KEY,

--- a/src/policy/check/README.md
+++ b/src/policy/check/README.md
@@ -127,7 +127,8 @@ Detects anti-patterns that are scheduled for removal.
 
 ### Text Format (Default)
 
-Human-readable output with Atlas Frame context showing relevant policy neighborhood.
+Human-readable output with Policy Neighborhood context. The current output label remains
+`Atlas Frame` for compatibility.
 
 ```
 ❌ Found 2 violation(s):
@@ -191,9 +192,10 @@ Formatted report suitable for PR comments and documentation.
   - Module ui/admin-panel calls services/auth-core but is forbidden
 ```
 
-## Atlas Frame Context
+## Policy Neighborhood context
 
-Each violation report includes Atlas Frame context, showing the relevant policy neighborhood around the violating module. This helps developers understand:
+Each violation report includes bounded Policy Neighborhood context around the violating module.
+This helps developers understand:
 
 - Which modules are involved
 - What the policy relationships are
@@ -249,4 +251,4 @@ The test suite includes 19 test cases covering:
 
 - Depends on: `src/shared/types/` (TypeScript type definitions)
 - Depends on: `src/policy/merge/` (Scanner merge output types)
-- Depends on: `src/shared/atlas/` (Atlas Frame generation)
+- Depends on: `src/shared/atlas/` (Policy Neighborhood generation)

--- a/src/policy/check/reporter.ts
+++ b/src/policy/check/reporter.ts
@@ -107,13 +107,13 @@ function formatAsText(violations: Violation[], policy?: Policy): string {
   for (const [moduleId, moduleViolations] of Object.entries(byModule)) {
     output += `📦 Module: ${moduleId}\n`;
 
-    // Include Atlas Frame context with error handling
+    // Include Policy Neighborhood context with error handling
     try {
       const atlasFrame = generateAtlasFrame([moduleId], 1);
       const atlasContext = formatAtlasFrame(atlasFrame);
       output += atlasContext;
     } catch {
-      // If Atlas Frame generation fails, continue without it
+      // If Policy Neighborhood generation fails, continue without it
       output += `\n⚠️  Atlas Frame context unavailable\n`;
     }
 
@@ -187,7 +187,7 @@ function formatAsMarkdown(violations: Violation[], policy?: Policy): string {
   for (const [moduleId, moduleViolations] of Object.entries(byModule)) {
     output += `### 📦 Module: \`${moduleId}\`\n\n`;
 
-    // Include Atlas Frame context with error handling
+    // Include Policy Neighborhood context with error handling
     try {
       const atlasFrame = generateAtlasFrame([moduleId], 1);
       output += "**Atlas Frame Context:**\n";

--- a/src/policy/merge/README.md
+++ b/src/policy/merge/README.md
@@ -124,7 +124,7 @@ The merged output feeds into the policy checker (`policy/check/`), which:
 3. Checks `allowed_callers` vs. actual dependencies
 4. Reports policy violations
 
-### With Atlas Frames
+### With Policy Neighborhoods
 
 Module edges can be used to:
 - Generate architectural diagrams

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -6,17 +6,17 @@ This directory contains the shared types, utilities, and logic that both `memory
 
 ## Subdirectories
 
-- **`atlas/`** — Fold radius logic + Atlas Frame exporter (spatial neighborhood around `module_scope`)
+- **`atlas/`** — Legacy compatibility location for Policy Neighborhood and Frame Graph logic
 - **`module_ids/`** — THE CRITICAL RULE enforcement (module IDs must match policy)
 - **`aliases/`** — Future: alias table for fuzzy matching / historical names (strict CI, loose recall)
-- **`types/`** — Canonical schemas for Frame metadata, Atlas Frame structure, and policy module shape
+- **`types/`** — Canonical schemas for Frame metadata, Policy Neighborhood compatibility shapes, and policy modules
 - **`cli/`** — User-facing commands (`lex remember`, `lex recall`, `lex check`) that orchestrate both subsystems
 
 ## Why this exists
 
 Without `shared/`, `memory/` and `policy/` would be two separate tools that happen to live in one repo. With `shared/`, they're one system with explicit contracts:
 
-- **Atlas Frame export** (in `shared/atlas/`) is called by:
+- **Policy Neighborhood export** (legacy `AtlasFrame` APIs in `shared/atlas/`) is called by:
   - `memory/recall` — to get the spatial neighborhood when returning a Frame
   - `policy/check` — to show the relevant policy context around a violation
 
@@ -26,7 +26,7 @@ Without `shared/`, `memory/` and `policy/` would be two separate tools that happ
 
 - **CLI** (in `shared/cli/`) provides one surface:
   - `lex remember` → calls `memory/frames/` + validates against `shared/module_ids/`
-  - `lex recall` → calls `memory/store/` + `shared/atlas/` to return Frame + Atlas Frame
+  - `lex recall` → calls `memory/store/` + `shared/atlas/` to return a Frame plus optional Policy Neighborhood
   - `lex check` → calls `policy/check/` to enforce policy in CI
 
 This is the integration layer. This is what makes Lex one system instead of two glued tools.
@@ -38,7 +38,7 @@ This is the integration layer. This is what makes Lex one system instead of two 
 ```
 shared/
 ├── aliases/      # Module alias resolution
-├── atlas/        # Fold radius logic + Atlas Frame export
+├── atlas/        # Policy Neighborhood + Frame Graph compatibility code
 ├── cli/          # User-facing commands
 ├── config/       # Configuration loading
 ├── git/          # Git integration (feature-flagged via LEX_GIT_MODE)

--- a/src/shared/aliases/MIGRATION_GUIDE.md
+++ b/src/shared/aliases/MIGRATION_GUIDE.md
@@ -64,7 +64,7 @@ Old Frames still have `module_scope: ["services/user-access-api"]`. This ID no l
 
 **Impact:**
 - ✅ Frames are still searchable by keyword, ticket ID, reference point
-- ❌ Atlas Frame generation might fail (module not in current policy)
+- ❌ Policy Neighborhood generation might fail (module not in current policy)
 - ❌ Policy-aware queries won't work for those Frames
 
 **When to use:** Short-term refactors, or when you don't need policy reasoning on old work.
@@ -88,7 +88,7 @@ Add an alias to map old → new:
 
 **Impact:**
 - ✅ Old Frames now resolve to current module
-- ✅ Atlas Frame generation works
+- ✅ Policy Neighborhood generation works
 - ✅ Policy-aware queries work
 - ✅ No Frame data modification needed
 - ⚠️  Users typing old name get deprecation warning

--- a/src/shared/atlas/README.md
+++ b/src/shared/atlas/README.md
@@ -1,8 +1,11 @@
-# Fold Radius & Atlas Frame Export
+# Policy Neighborhood compatibility implementation
 
 **Spatial neighborhood extraction from policy graph**
 
 This module computes the "map page" around a set of modules — the minimal policy-aware context needed to understand what's happening in a Frame.
+Its public types and functions retain `AtlasFrame` compatibility names. The separate rebuild
+implementation later in this file is a historical **Frame Graph**, not policy context. See the
+[terminology map](../../../docs/ATLAS_TERMINOLOGY.md).
 
 ## Problem
 
@@ -18,7 +21,8 @@ That's **fold radius = 1**.
 ### Core Functions
 
 #### `generateAtlasFrame(seedModules, foldRadius, policyPath?)`
-Main entry point for generating an Atlas Frame. Loads the policy graph, performs BFS traversal to extract the N-hop neighborhood, generates coordinates, and returns a complete Atlas Frame with modules and edges.
+Main entry point for generating a Policy Neighborhood. It loads the policy graph, performs BFS
+traversal, generates coordinates, and returns the legacy `AtlasFrame` compatibility shape.
 
 **Parameters:**
 - `seedModules: string[]` - Module IDs from Frame.module_scope  
@@ -68,7 +72,7 @@ Implements a force-directed graph layout algorithm to assign 2D coordinates to m
 - **`fold_radius`** (number, default 1): How many hops to expand from seed modules
 - **`policy`** (object): The full `lexmap.policy.json` loaded in memory
 
-## Output: Atlas Frame
+## Output: Policy Neighborhood (`AtlasFrame` compatibility shape)
 
 ```json
 {
@@ -152,7 +156,7 @@ Tested with 100+ module policies, performs acceptably (< 1 second for typical qu
 ## Integration
 
 Called by:
-- **`memory/mcp_server`** — when returning a Frame via `/recall`, also exports Atlas Frame for `module_scope`
+- **`memory/mcp_server`** — when returning a Frame via `/recall`, also exports a Policy Neighborhood for `module_scope`
 - **`policy/check`** (future) — when showing a violation, export the neighborhood around the offending edge
 
 ## Testing
@@ -160,7 +164,7 @@ Called by:
 Run tests with:
 ```bash
 cd shared/atlas
-node atlas-frame.test.mjs  # Atlas Frame generation tests (16 tests)
+node atlas-frame.test.mjs  # Policy Neighborhood generation tests (16 tests)
 node cache.test.mjs        # Cache functionality tests (8 tests)
 node auto-tune.test.mjs    # Auto-tuning tests (12 tests)
 ```
@@ -182,7 +186,8 @@ All 36 tests passing (16 + 8 + 12).
 
 ## Caching
 
-Atlas Frames are automatically cached by `(module_scope, radius)` key to avoid redundant graph traversals.
+Policy Neighborhoods are automatically cached by `(module_scope, radius)` key through the
+legacy-named `AtlasFrameCache`.
 
 **Features:**
 - **LRU Eviction**: When cache is full, least recently used entries are evicted
@@ -218,7 +223,7 @@ lex recall TICKET-123 --cache-stats
 Automatically adjust fold radius to fit within token limits for LLM context windows.
 
 **Features:**
-- **Token Estimation**: Estimates tokens in Atlas Frame (1 token ≈ 4 chars JSON)
+- **Token Estimation**: Estimates Policy Neighborhood tokens (1 token ≈ 4 chars JSON)
 - **Adaptive Radius**: Starts at requested radius, reduces until fits in limit
 - **Logging**: Reports adjustments when radius is reduced
 
@@ -252,10 +257,10 @@ lex recall TICKET-123 --fold-radius 3 --auto-radius --max-tokens 3000
 
 ## Future work
 
-- ~~Cache Atlas Frames by `(module_scope, fold_radius)` key to avoid recomputation~~ ✅ **Implemented**
+- ~~Cache Policy Neighborhoods by `(module_scope, fold_radius)` key~~ ✅ **Implemented**
 - ~~Support variable fold radius (radius 2 for deeper context, radius 0 for just seed modules)~~ ✅ **Implemented**
 - ~~Auto-tune radius based on context window limits~~ ✅ **Implemented**
-- Render Atlas Frame as visual graph (SVG/Canvas) for memory card inclusion
+- Render a Policy Neighborhood as SVG/Canvas for memory-card inclusion
 - Optimize coordinate generation for very large graphs (> 100 modules)
 - Support different layout algorithms (hierarchical, circular, etc.)
 
@@ -310,9 +315,11 @@ The fold radius algorithm is now complete with:
 
 ---
 
-# Atlas Rebuild System (Frame Knowledge Graph)
+# Frame Graph compatibility implementation
 
-The Atlas rebuild system constructs a knowledge graph from work session snapshots (Frames), connecting them based on module scope overlap, temporal proximity, and branch relationships.
+The Frame Graph rebuild system constructs a derived graph from work session snapshots (Frames),
+connecting them based on module scope overlap, temporal proximity, and branch relationships.
+Its exported APIs currently retain `Atlas` rebuild names.
 
 ## Components
 
@@ -320,10 +327,10 @@ The Atlas rebuild system constructs a knowledge graph from work session snapshot
 Core rebuild logic with deterministic graph construction.
 
 **Key Function:**
-- `rebuildAtlas(frames: Frame[]): Atlas` - Rebuilds the complete Atlas graph from Frames
-- **Determinism Guarantee**: Same input Frames → Identical Atlas structure (regardless of input order)
+- `rebuildAtlas(frames: Frame[]): Atlas` - Rebuilds the Frame Graph through legacy names
+- **Determinism Guarantee**: Same input Frames → identical Frame Graph regardless of input order
 
-**Atlas Structure:**
+**Legacy `Atlas` shape:**
 ```typescript
 interface Atlas {
   nodes: AtlasNode[];  // Frame nodes with module_scope
@@ -343,7 +350,7 @@ interface Atlas {
 - Edge created if total weight > 0.1 (10% threshold)
 
 ### `validate.ts`
-Integrity validation for Atlas graphs.
+Integrity validation for Frame Graph values.
 
 **Key Functions:**
 - `validateAtlas(atlas: Atlas): ValidationResult` - Validates graph integrity
@@ -423,7 +430,7 @@ The rebuild algorithm ensures identical output for identical input:
 4. No timestamps or random values in graph structure
 5. All operations order-independent
 
-**Verified by tests:** Same Frames in different order → Identical Atlas ✅
+**Verified by tests:** Same Frames in different order → Identical Frame Graph ✅
 
 ## Integration Example
 
@@ -458,12 +465,12 @@ async function insertFrameWithAtlasUpdate(frame) {
 ## Future Enhancements
 
 Possible improvements (not part of current scope):
-- Persistent Atlas storage (SQLite or JSON files)
+- Persistent Frame Graph storage (SQLite or JSON files)
 - Incremental updates (add/remove single Frame without full rebuild)
 - Graph analytics (centrality, clustering, communities)
-- Time-based graph slicing (Atlas at specific point in time)
+- Time-based Frame Graph slicing
 - Export formats (GraphML, DOT, JSON-LD)
-- Web UI for Atlas visualization
+- Web UI for Frame Graph visualization
 
 ---
 

--- a/src/shared/atlas/atlas-frame.ts
+++ b/src/shared/atlas/atlas-frame.ts
@@ -1,8 +1,9 @@
 /**
- * Atlas Frame - Spatial neighborhood extraction from policy graph
+ * Policy Neighborhood - spatial neighborhood extraction from a policy graph
  *
  * Computes the "map page" around a set of modules with fold radius.
  * Implements full policy graph traversal with N-hop neighborhood extraction.
+ * Public symbols retain AtlasFrame compatibility names.
  */
 
 import { loadPolicy } from "../policy/loader.js";
@@ -38,7 +39,7 @@ export interface AtlasEdge {
 }
 
 /**
- * Generate Atlas Frame for a set of seed modules
+ * Generate a Policy Neighborhood for a set of seed modules
  *
  * Implements full fold radius algorithm with policy graph traversal:
  * - Loads policy graph from lexmap.policy.json
@@ -57,7 +58,7 @@ export interface AtlasEdge {
  * @param seedModules - Module IDs from Frame.module_scope
  * @param foldRadius - How many hops to expand (default: 1)
  * @param policyPath - Optional custom policy path
- * @returns Atlas Frame with neighborhood context
+ * @returns Policy Neighborhood through the AtlasFrame compatibility shape
  */
 export function generateAtlasFrame(
   seedModules: string[],
@@ -69,7 +70,7 @@ export function generateAtlasFrame(
 }
 
 /**
- * Generate an Atlas Frame from an already authorized policy snapshot.
+ * Generate a Policy Neighborhood from an already authorized policy snapshot.
  * Trusted multi-workspace hosts use this form so policy resolution remains
  * request-local and cannot fall back to process environment or cwd.
  */
@@ -154,7 +155,7 @@ export function generateAtlasFrameFromPolicy(
 }
 
 /**
- * Format Atlas Frame for display in MCP response
+ * Format a Policy Neighborhood using the legacy Atlas Frame response label
  */
 export function formatAtlasFrame(atlasFrame: AtlasFrame): string {
   const { seed_modules, fold_radius, modules, edges } = atlasFrame;

--- a/src/shared/atlas/auto-tune.ts
+++ b/src/shared/atlas/auto-tune.ts
@@ -1,19 +1,19 @@
 /**
- * Token Estimation for Atlas Frames
+ * Token estimation for Policy Neighborhoods through legacy AtlasFrame shapes
  *
- * Estimates the token count of an Atlas Frame for LLM context window management.
+ * Estimates Policy Neighborhood size for LLM context-window management.
  * Uses simple heuristics based on JSON serialization size.
  */
 
 import type { AtlasFrame } from "./types.js";
 
 /**
- * Estimate the number of tokens in an Atlas Frame
+ * Estimate the number of tokens in a Policy Neighborhood
  *
  * Uses a simple heuristic: 1 token ≈ 4 characters in JSON
  * This is approximate but sufficient for auto-tuning decisions.
  *
- * @param atlasFrame - The Atlas Frame to estimate
+ * @param atlasFrame - Policy Neighborhood in the legacy AtlasFrame shape
  * @returns Estimated token count
  */
 export function estimateTokens(atlasFrame: AtlasFrame): number {
@@ -27,13 +27,13 @@ export function estimateTokens(atlasFrame: AtlasFrame): number {
  * Auto-tune fold radius to fit within token limit
  *
  * Starts with the requested radius and reduces it if the resulting
- * Atlas Frame exceeds the token limit. Stops at radius 0 (seed only).
+ * Policy Neighborhood exceeds the token limit. Stops at radius 0 (seed only).
  *
- * @param generateFn - Function that generates an Atlas Frame for a given radius
+ * @param generateFn - Function that generates a Policy Neighborhood for a radius
  * @param initialRadius - Starting radius to try
  * @param maxTokens - Maximum token count allowed
  * @param onAdjustment - Optional callback when radius is adjusted
- * @returns Object with the final Atlas Frame and radius used
+ * @returns Object with the final Policy Neighborhood and radius used
  */
 export function autoTuneRadius(
   generateFn: (radius: number) => AtlasFrame,

--- a/src/shared/atlas/cache.ts
+++ b/src/shared/atlas/cache.ts
@@ -1,7 +1,7 @@
 /**
- * Atlas Frame Caching
+ * Policy Neighborhood caching through legacy AtlasFrame names
  *
- * Caches computed Atlas Frames by (module_scope, radius) key to avoid
+ * Caches computed Policy Neighborhoods by (module_scope, radius) key to avoid
  * redundant graph traversals. Tracks cache hits/misses for performance monitoring.
  */
 
@@ -24,7 +24,7 @@ export interface CacheStats {
 }
 
 /**
- * In-memory cache for Atlas Frames
+ * In-memory cache for Policy Neighborhoods
  *
  * Uses LRU eviction when cache size exceeds maxSize.
  * Cache keys are based on sorted module_scope + radius for consistency.
@@ -41,7 +41,7 @@ export class AtlasFrameCache {
   };
 
   /**
-   * Create a new Atlas Frame cache
+   * Create a new Policy Neighborhood cache
    *
    * @param maxSize - Maximum number of entries to cache (default: 100)
    */
@@ -61,7 +61,7 @@ export class AtlasFrameCache {
   }
 
   /**
-   * Get cached Atlas Frame if available
+   * Get a cached Policy Neighborhood if available
    *
    * @param moduleScope - Module IDs to look up
    * @param radius - Fold radius
@@ -84,11 +84,11 @@ export class AtlasFrameCache {
   }
 
   /**
-   * Store Atlas Frame in cache
+   * Store a Policy Neighborhood in cache
    *
    * @param moduleScope - Module IDs
    * @param radius - Fold radius
-   * @param frame - Computed Atlas Frame
+   * @param frame - Computed Policy Neighborhood
    */
   set(moduleScope: string[], radius: number, frame: AtlasFrame): void {
     const key = this.getCacheKey(moduleScope, radius);
@@ -177,7 +177,7 @@ export class AtlasFrameCache {
 /**
  * Global cache instance
  *
- * Shared across all Atlas Frame generation calls.
+ * Shared across all Policy Neighborhood generation calls.
  * Can be disabled by setting enableCache = false.
  */
 let globalCache: AtlasFrameCache | null = new AtlasFrameCache();

--- a/src/shared/atlas/fold-radius.ts
+++ b/src/shared/atlas/fold-radius.ts
@@ -156,7 +156,7 @@ export function computeFoldRadius(
     }
   }
 
-  // Create Atlas Frame
+  // Create the Policy Neighborhood compatibility value
   const atlasFrame: AtlasFrame = {
     atlas_timestamp: new Date().toISOString(),
     seed_modules: seedModules,

--- a/src/shared/atlas/graph.ts
+++ b/src/shared/atlas/graph.ts
@@ -2,7 +2,7 @@
  * Graph Algorithms for Policy Graph Traversal
  *
  * Provides BFS/DFS traversal with hop limiting for fold radius computation.
- * Used by Atlas Frame generation to extract module neighborhoods.
+ * Used by Policy Neighborhood generation to extract nearby policy modules.
  */
 
 import type { Policy, PolicyModule } from "../types/policy.js";

--- a/src/shared/atlas/index.ts
+++ b/src/shared/atlas/index.ts
@@ -1,8 +1,8 @@
 /**
- * Atlas Frame Export - Spatial neighborhood extraction from policy graph
+ * Legacy Atlas compatibility barrel
  *
- * This module provides the core functionality for extracting policy-aware
- * spatial neighborhoods using the fold radius algorithm.
+ * This module currently combines Policy Neighborhood, Frame Graph, and Code Index
+ * surfaces. New code should use those conceptual names while preserving these exports.
  */
 
 // Export types
@@ -21,7 +21,7 @@ export { buildPolicyGraph, getNeighbors } from "./graph.js";
 // Export fold radius algorithm
 export { computeFoldRadius } from "./fold-radius.js";
 
-// Export Atlas Frame generation
+// Export Policy Neighborhood generation through legacy AtlasFrame names
 export { generateAtlasFrame } from "./atlas-frame.js";
 
 // Export cache utilities
@@ -37,7 +37,7 @@ export {
 // Export auto-tuning utilities
 export { estimateTokens, autoTuneRadius, estimateTokensBeforeGeneration } from "./auto-tune.js";
 
-// Export Atlas rebuild queue (LEX-108: Batch Operations)
+// Export Frame Graph rebuild queue through legacy Atlas names (LEX-108)
 export {
   AtlasRebuildQueue,
   createAtlasRebuildQueue,
@@ -45,7 +45,7 @@ export {
   type AtlasRebuildQueueConfig,
 } from "./queue.js";
 
-// Export Atlas rebuild trigger API (LEX-108: Batch Operations)
+// Export Frame Graph rebuild trigger API through legacy Atlas names (LEX-108)
 export {
   AtlasRebuildManager,
   initAtlasRebuildManager,
@@ -59,11 +59,11 @@ export {
   type AtlasRebuildManagerConfig,
 } from "./trigger.js";
 
-// Export Atlas rebuild and validation utilities
+// Export Frame Graph rebuild and validation utilities
 export { rebuildAtlas, type Atlas, type AtlasNode } from "./rebuild.js";
 export { validateAtlas, checkReachability, type ValidationResult } from "./validate.js";
 
-// Export Code Atlas schemas (Layer 0)
+// Export Code Index schemas through legacy Code Atlas names (Layer 0)
 export {
   CodeUnitSchema,
   CodeUnitKindSchema,

--- a/src/shared/atlas/queue.ts
+++ b/src/shared/atlas/queue.ts
@@ -1,8 +1,9 @@
 /**
- * Atlas Rebuild Queue - Async rebuild infrastructure
+ * Frame Graph rebuild queue - async rebuild infrastructure
  *
- * Provides event-driven Atlas rebuild with debouncing to handle
+ * Provides event-driven Frame Graph rebuild with debouncing to handle
  * rapid Frame ingestion without blocking operations.
+ * Public symbols retain legacy Atlas compatibility names.
  *
  * Features:
  * - Event-driven: Frame ingestion triggers rebuild via callbacks
@@ -16,7 +17,7 @@ import { rebuildAtlas, type Atlas } from "./rebuild.js";
 import { validateAtlas } from "./validate.js";
 
 /**
- * Callback functions for Atlas rebuild events
+ * Callback functions for Frame Graph rebuild events
  */
 export interface AtlasRebuildCallbacks {
   onFrameIngested?: (frame: Frame) => void;
@@ -32,7 +33,7 @@ export interface AtlasRebuildQueueConfig {
   /** Debounce interval in milliseconds (default: 5000 = 5s) */
   debounceMs?: number;
 
-  /** Whether to validate Atlas after rebuild (default: true) */
+  /** Whether to validate the Frame Graph after rebuild (default: true) */
   validateAfterRebuild?: boolean;
 
   /** Callback to fetch all frames for rebuild */
@@ -43,9 +44,9 @@ export interface AtlasRebuildQueueConfig {
 }
 
 /**
- * Atlas Rebuild Queue
+ * Frame Graph rebuild queue through a legacy class name
  *
- * Manages async Atlas rebuilds triggered by Frame ingestion events.
+ * Manages async Frame Graph rebuilds triggered by Frame ingestion events.
  * Implements debouncing to batch rapid Frame ingestions.
  *
  * Usage:
@@ -122,7 +123,7 @@ export class AtlasRebuildQueue {
       // Fetch all frames
       const frames = await Promise.resolve(this.config.fetchFrames());
 
-      // Rebuild Atlas
+      // Rebuild the Frame Graph
       const atlas = rebuildAtlas(frames);
 
       // Validate if configured
@@ -169,14 +170,14 @@ export class AtlasRebuildQueue {
 }
 
 /**
- * Create a simple Atlas rebuild queue
+ * Create a simple Frame Graph rebuild queue
  *
  * Convenience factory function for creating a queue with sensible defaults.
  *
  * @param fetchFrames - Function to fetch all frames
  * @param debounceMs - Debounce interval in milliseconds (default: 5000)
  * @param callbacks - Event callbacks
- * @returns Atlas rebuild queue
+ * @returns Frame Graph rebuild queue through the legacy AtlasRebuildQueue shape
  */
 export function createAtlasRebuildQueue(
   fetchFrames: () => Promise<Frame[]> | Frame[],

--- a/src/shared/atlas/rebuild.ts
+++ b/src/shared/atlas/rebuild.ts
@@ -1,15 +1,14 @@
 /**
- * Atlas Rebuild - Deterministic graph construction from Frames
+ * Frame Graph rebuild - deterministic graph construction from Frames
  *
- * Rebuilds the Atlas graph structure deterministically when new Frames are ingested.
- * Atlas represents the knowledge graph connecting work sessions (Frames) based on
- * module scope overlap and temporal proximity.
+ * Rebuilds a historical Frame Graph deterministically when Frames are ingested.
+ * Public symbols retain legacy Atlas compatibility names.
  */
 
 import type { Frame } from "../types/frame.js";
 
 /**
- * Atlas node representing a Frame in the knowledge graph
+ * Legacy AtlasNode name for a Frame Graph node
  */
 export interface AtlasNode {
   frameId: string;
@@ -19,7 +18,7 @@ export interface AtlasNode {
 }
 
 /**
- * Atlas edge representing relationship between two Frames
+ * Legacy AtlasEdge name for a Frame Graph relationship
  */
 export interface AtlasEdge {
   from: string; // Frame ID
@@ -29,7 +28,7 @@ export interface AtlasEdge {
 }
 
 /**
- * Atlas graph structure - the complete knowledge graph of Frames
+ * Legacy Atlas name for the complete historical Frame Graph
  */
 export interface Atlas {
   nodes: AtlasNode[];
@@ -42,7 +41,7 @@ export interface Atlas {
 }
 
 /**
- * Rebuild Atlas graph from a collection of Frames
+ * Rebuild a Frame Graph from a collection of Frames
  *
  * Algorithm:
  * 1. Sort Frames by ID for deterministic ordering
@@ -51,12 +50,12 @@ export interface Atlas {
  *    - Module scope overlap (shared modules)
  *    - Temporal proximity (frames close in time)
  *    - Branch relationships (same branch)
- * 4. Return deterministic Atlas structure
+ * 4. Return the deterministic Frame Graph through the legacy Atlas shape
  *
- * Deterministic guarantee: Same input Frames (regardless of order) → Identical Atlas
+ * Deterministic guarantee: same input Frames (regardless of order) → identical Frame Graph
  *
- * @param frames - Array of Frames to build Atlas from
- * @returns Atlas graph structure
+ * @param frames - Array of Frames from which to build the Frame Graph
+ * @returns Frame Graph through the legacy Atlas shape
  */
 export function rebuildAtlas(frames: Frame[]): Atlas {
   // Sort frames by ID for deterministic ordering

--- a/src/shared/atlas/trigger.ts
+++ b/src/shared/atlas/trigger.ts
@@ -1,8 +1,9 @@
 /**
- * Atlas Rebuild Trigger API
+ * Frame Graph rebuild trigger API
  *
- * Provides external API for triggering Atlas rebuilds and receiving notifications.
+ * Provides an API for triggering Frame Graph rebuilds and receiving notifications.
  * This is the public interface for LexRunner and other external callers.
+ * Public symbols retain legacy Atlas compatibility names.
  *
  * Features:
  * - triggerAtlasRebuild(): Promise-based trigger that resolves on completion
@@ -17,14 +18,14 @@ import { rebuildAtlas, type Atlas } from "./rebuild.js";
 import { validateAtlas, type ValidationResult } from "./validate.js";
 
 /**
- * Result of an Atlas rebuild operation
+ * Result of a Frame Graph rebuild operation
  */
 export interface RebuildResult {
   /** Whether the rebuild completed successfully */
   success: boolean;
-  /** The rebuilt Atlas (only present on success) */
+  /** The rebuilt Frame Graph under its legacy Atlas property/type */
   atlas?: Atlas;
-  /** Validation result from Atlas integrity check */
+  /** Validation result from the Frame Graph integrity check */
   validation?: ValidationResult;
   /** Error message (only present on failure) */
   error?: string;
@@ -47,16 +48,16 @@ export type RebuildCallback = (result: RebuildResult) => void;
 export interface AtlasRebuildManagerConfig {
   /** Debounce interval in milliseconds (default: 1000 = 1s) */
   debounceMs?: number;
-  /** Whether to validate Atlas after rebuild (default: true) */
+  /** Whether to validate the Frame Graph after rebuild (default: true) */
   validateAfterRebuild?: boolean;
   /** Callback to fetch all frames for rebuild */
   fetchFrames: () => Promise<Frame[]> | Frame[];
 }
 
 /**
- * Atlas Rebuild Manager
+ * Frame Graph rebuild manager through a legacy class name
  *
- * Singleton manager for Atlas rebuilds with Promise-based trigger API,
+ * Singleton manager for Frame Graph rebuilds with Promise-based trigger API,
  * callback registration, and rate-limiting via debounce.
  *
  * Usage:
@@ -98,7 +99,7 @@ export class AtlasRebuildManager {
   }
 
   /**
-   * Trigger an Atlas rebuild
+   * Trigger a Frame Graph rebuild
    *
    * If a rebuild is already in progress or pending, this call will join
    * the existing operation and receive the same result. Multiple rapid
@@ -145,7 +146,7 @@ export class AtlasRebuildManager {
       const frames = await Promise.resolve(this.config.fetchFrames());
       frameCount = frames.length;
 
-      // Rebuild Atlas
+      // Rebuild the Frame Graph
       const atlas = rebuildAtlas(frames);
 
       // Validate if configured
@@ -283,7 +284,7 @@ export class AtlasRebuildManager {
 let globalManager: AtlasRebuildManager | null = null;
 
 /**
- * Initialize the global Atlas rebuild manager
+ * Initialize the global Frame Graph rebuild manager
  *
  * Must be called before using triggerAtlasRebuild() or onRebuildComplete().
  *
@@ -299,7 +300,7 @@ export function initAtlasRebuildManager(config: AtlasRebuildManagerConfig): Atla
 }
 
 /**
- * Get the global Atlas rebuild manager
+ * Get the global Frame Graph rebuild manager
  *
  * @throws Error if manager has not been initialized
  */
@@ -311,7 +312,7 @@ export function getAtlasRebuildManager(): AtlasRebuildManager {
 }
 
 /**
- * Trigger an Atlas rebuild using the global manager
+ * Trigger a Frame Graph rebuild using the global manager
  *
  * Convenience function that delegates to the global manager.
  *

--- a/src/shared/atlas/types.ts
+++ b/src/shared/atlas/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for Atlas Frame and Policy Graph
+ * Legacy AtlasFrame type definitions for Policy Neighborhoods and policy graphs
  *
  * These types represent the spatial neighborhood extraction from policy graphs.
  */
@@ -40,7 +40,7 @@ export interface Graph {
 }
 
 /**
- * Module data in Atlas Frame output
+ * Module data in Policy Neighborhood output
  */
 export interface AtlasModuleData {
   id: string;
@@ -53,7 +53,7 @@ export interface AtlasModuleData {
 }
 
 /**
- * Edge data in Atlas Frame output
+ * Edge data in Policy Neighborhood output
  */
 export interface AtlasEdge {
   from: string;
@@ -63,7 +63,7 @@ export interface AtlasEdge {
 }
 
 /**
- * Atlas Frame - spatial neighborhood around seed modules
+ * Policy Neighborhood compatibility shape around seed modules
  */
 export interface AtlasFrame {
   atlas_timestamp: string; // ISO 8601

--- a/src/shared/atlas/validate.ts
+++ b/src/shared/atlas/validate.ts
@@ -1,7 +1,8 @@
 /**
- * Atlas Integrity Validation
+ * Frame Graph integrity validation
  *
- * Validates the structural integrity of Atlas graphs to ensure:
+ * Validates the structural integrity of historical Frame Graphs.
+ * Public symbols retain legacy Atlas compatibility names.
  * - No orphaned nodes (all nodes reachable from at least one other node or are roots)
  * - No dangling edges (all edge endpoints exist in node set)
  * - Edge weights within valid range [0, 1]
@@ -21,14 +22,14 @@ export interface ValidationResult {
 }
 
 /**
- * Validate Atlas integrity
+ * Validate Frame Graph integrity
  *
  * Performs comprehensive validation checks:
  * 1. No dangling edges (all edge endpoints exist in node set)
  * 2. No orphaned nodes (every node is reachable from at least one other node, or is a root)
  * 3. Edge weights within valid range [0, 1]
  *
- * @param atlas - Atlas graph to validate
+ * @param atlas - Frame Graph in the legacy Atlas shape
  * @returns Validation result with errors and warnings
  */
 export function validateAtlas(atlas: Atlas): ValidationResult {
@@ -102,12 +103,12 @@ export function validateAtlas(atlas: Atlas): ValidationResult {
 }
 
 /**
- * Check if all nodes in Atlas are reachable from at least one root node
+ * Check whether all Frame Graph nodes are reachable from at least one root
  *
  * A root node is a node with no incoming edges (only outgoing edges or isolated).
  * This performs a graph traversal to ensure no nodes are unreachable from the root set.
  *
- * @param atlas - Atlas graph to check
+ * @param atlas - Frame Graph in the legacy Atlas shape
  * @returns True if all nodes are reachable from roots, false otherwise
  */
 export function checkReachability(atlas: Atlas): boolean {

--- a/src/shared/cli/README.md
+++ b/src/shared/cli/README.md
@@ -81,8 +81,8 @@ lex recall "that auth deadlock"
 **Implementation:**
 1. Search `memory/store/` for Frame matching input (exact ticket ID or fuzzy `reference_point`)
 2. Retrieve Frame metadata
-3. Call `shared/atlas/` to export fold-radius neighborhood for Frame's `module_scope`
-4. Return both Frame (temporal) + Atlas Frame (spatial)
+3. Call the Policy Neighborhood compatibility code in `shared/atlas/` for the Frame's `module_scope`
+4. Return both Frame (temporal) + optional Policy Neighborhood (spatial)
 5. Optionally render as JSON, markdown, or visual card
 
 **Output example:**
@@ -96,7 +96,7 @@ Next action: Reroute through user-access-api
 Blockers:
   - Direct call to auth-core forbidden by policy
 
-Atlas Frame (fold radius 1):
+Policy Neighborhood (legacy `AtlasFrame`, fold radius 1):
   Modules touched:
     - ui/user-admin-panel [beta_user_admin]
     - services/auth-core

--- a/src/shared/cli/code-atlas.ts
+++ b/src/shared/cli/code-atlas.ts
@@ -1,5 +1,5 @@
 /**
- * CLI Command: lex code-atlas
+ * CLI command for the experimental Code Index (legacy `lex code-atlas` name)
  *
  * Extract code units from a repository using static analysis.
  * Outputs CodeAtlasOutput JSON with run metadata and extracted code units.
@@ -38,7 +38,7 @@ function policySeedToYaml(seed: PolicySeed): string {
   };
 
   const lines: string[] = [
-    "# Policy Seed - Auto-generated from Code Atlas",
+    "# Policy Seed - Auto-generated from the experimental Code Index",
     "# This is a SEED for human refinement, not a final policy.",
     "# Review and customize before using.",
     "",
@@ -608,7 +608,7 @@ export async function codeAtlas(options: CodeAtlasOptions = {}): Promise<CodeAtl
   }
 
   if (options.trustedProjectRoot && (options.out || options.policySeed)) {
-    const errorMsg = "Trusted in-process Code Atlas does not permit filesystem output options.";
+    const errorMsg = "Trusted in-process Code Index does not permit filesystem output options.";
     if (emitOutput) output.error(errorMsg);
     return { success: false, error: errorMsg };
   }
@@ -751,7 +751,7 @@ export async function codeAtlas(options: CodeAtlasOptions = {}): Promise<CodeAtl
           durationSeconds: parseFloat(duration),
         });
       } else if (emitOutput) {
-        output.success(`\n✅ Code Atlas extraction complete`);
+        output.success(`\n✅ Code Index extraction complete`);
         output.info(`Output written to: ${outPath}`);
         output.info(
           `Files scanned: ${filesToScan.length}${truncated ? ` (limited from ${allFiles.length})` : ""}`
@@ -772,7 +772,7 @@ export async function codeAtlas(options: CodeAtlasOptions = {}): Promise<CodeAtl
         output.raw(JSON.stringify(atlasOutput, null, 2));
       } else if (emitOutput) {
         // Human-readable summary first, then JSON
-        output.success(`\n✅ Code Atlas extraction complete`);
+        output.success(`\n✅ Code Index extraction complete`);
         output.info(
           `Files scanned: ${filesToScan.length}${truncated ? ` (limited from ${allFiles.length})` : ""}`
         );
@@ -793,7 +793,7 @@ export async function codeAtlas(options: CodeAtlasOptions = {}): Promise<CodeAtl
     if (emitOutput && options.json) {
       output.json({ success: false, error: errorMsg });
     } else if (emitOutput) {
-      output.error(`\n❌ Code Atlas extraction failed: ${errorMsg}`);
+      output.error(`\n❌ Code Index extraction failed: ${errorMsg}`);
     }
     return { success: false, error: errorMsg };
   }

--- a/src/shared/cli/index.ts
+++ b/src/shared/cli/index.ts
@@ -207,11 +207,11 @@ export function createProgram(programOptions: CreateProgramOptionsV1 = {}): Comm
     )
     .option("-q, --query <text>", "Search query (alternative to positional argument)")
     .option("--list [limit]", "List recent frames (optionally limit to N results)", parseInt)
-    .option("--fold-radius <number>", "Fold radius for Atlas Frame neighborhood", parseInt)
+    .option("--fold-radius <number>", "Fold radius for Policy Neighborhood context", parseInt)
     .option("--auto-radius", "Auto-tune radius based on token limits")
     .option(
       "--max-tokens <number>",
-      "Maximum tokens for Atlas Frame (use with --auto-radius)",
+      "Maximum tokens for Policy Neighborhood context (use with --auto-radius)",
       parseInt
     )
     .option("--cache-stats", "Show cache statistics")

--- a/src/shared/cli/recall.ts
+++ b/src/shared/cli/recall.ts
@@ -1,7 +1,7 @@
 /**
  * CLI Command: lex recall
  *
- * Searches Frames via query, returns Frame + Atlas Frame with pretty output.
+ * Searches Frames and returns optional Policy Neighborhood context through legacy AtlasFrame data.
  */
 
 import type { Frame } from "../types/frame.js";
@@ -37,7 +37,7 @@ export interface RecallOptions {
 
 /**
  * Execute the 'lex recall' command
- * Searches for Frames and displays results with Atlas Frame context, or lists recent frames
+ * Searches for Frames and displays results with optional Policy Neighborhood context.
  *
  * @param query - Search query string (optional when using --list)
  * @param options - Command options
@@ -170,7 +170,7 @@ export async function recall(
           const compactResult = compactFrameList(frames);
           json(compactResult);
         } else {
-          // For search mode, include frames and their Atlas Frames
+          // For search mode, include Frames and their Policy Neighborhoods
           const results = [];
           for (const frame of frames) {
             const atlasResult = await generateAtlasFrameWithAutoTune(frame, options);
@@ -216,7 +216,7 @@ export async function recall(
           output.info("");
         }
       } else {
-        // Search mode: show full frame details with Atlas
+        // Search mode: show full Frame details with Policy Neighborhood context
         for (let i = 0; i < frames.length; i++) {
           if (i > 0) {
             output.info("\n" + "─".repeat(80) + "\n");
@@ -252,7 +252,7 @@ export async function recall(
 }
 
 /**
- * Display a Frame with Atlas Frame context
+ * Display a Frame with Policy Neighborhood context
  */
 async function displayFrame(frame: Frame, options: RecallOptions): Promise<void> {
   output.info(`\n📋 Frame: ${frame.jira || frame.id}`);
@@ -288,7 +288,7 @@ async function displayFrame(frame: Frame, options: RecallOptions): Promise<void>
     output.info(`\n   Keywords: ${frame.keywords.join(", ")}`);
   }
 
-  // Generate Atlas Frame with auto-tuning if enabled
+  // Generate the Policy Neighborhood with auto-tuning if enabled
   const atlasResult = await generateAtlasFrameWithAutoTune(frame, options);
 
   if (atlasResult.autoTuned) {
@@ -337,7 +337,7 @@ async function displayFrame(frame: Frame, options: RecallOptions): Promise<void>
 }
 
 /**
- * Generate Atlas Frame with auto-tuning support
+ * Generate a Policy Neighborhood with auto-tuning support
  */
 async function generateAtlasFrameWithAutoTune(
   frame: Frame,
@@ -402,7 +402,7 @@ async function generateAtlasFrameWithAutoTune(
       autoTuned: false,
     };
   } catch (error) {
-    // If Atlas Frame generation fails, continue without it
+    // If Policy Neighborhood generation fails, continue without it
     const warning = formatAtlasWarning(error);
     output.warn(warning.message, warning.data, warning.code, warning.hint);
     return {
@@ -423,7 +423,7 @@ function formatAtlasWarning(error: unknown): {
 } {
   if (isAXErrorException(error) && error.axError.code === "POLICY_NOT_FOUND") {
     return {
-      message: "Atlas policy unavailable; returning recall results without Atlas context",
+      message: "Policy unavailable; returning recall results without Policy Neighborhood context",
       code: "ATLAS_POLICY_NOT_FOUND",
       data: error.axError,
       hint: "Create .smartergpt/lex/lexmap.policy.json in the caller workspace or set LEX_POLICY_PATH.",
@@ -432,7 +432,7 @@ function formatAtlasWarning(error: unknown): {
 
   const message = error instanceof Error ? error.message : String(error);
   return {
-    message: "Could not generate Atlas Frame; returning recall results without Atlas context",
+    message: "Could not generate Policy Neighborhood; returning recall results without enrichment",
     code: "ATLAS_GEN_FAILED",
     data: { message },
     hint: message,

--- a/src/shared/module_ids/README.md
+++ b/src/shared/module_ids/README.md
@@ -21,7 +21,7 @@ When you `/recall TICKET-123`, the system:
 1. Retrieves the Frame from `memory/store/`
 2. Extracts `module_scope` from the Frame
 3. Calls `shared/atlas/` to get the fold-radius neighborhood from policy
-4. Returns both Frame (temporal) + Atlas Frame (spatial)
+4. Returns both the Frame (temporal) and optional Policy Neighborhood (spatial)
 
 If `module_scope` references a module that doesn't exist in policy, step 3 fails.
 

--- a/src/shared/types/POLICY.md
+++ b/src/shared/types/POLICY.md
@@ -16,7 +16,7 @@ Each module has a unique ID (e.g., `"ui/user-admin-panel"`, `"services/auth-core
 ### Optional fields (policy boundaries)
 
 - **`coords`** (array of 2 numbers): Spatial coordinates for visual layout (e.g., `[0, 2]`)
-  - Used by `shared/atlas/` to render Atlas Frames with proper positioning
+  - Used by `shared/atlas/` to render Policy Neighborhoods with proper positioning
 
 - **`allowed_callers`** (array of strings): Module IDs that are allowed to call this module
   - Empty array `[]` means no one can call this (e.g., UI components should not be called by backend)

--- a/src/shared/types/frame-schema.ts
+++ b/src/shared/types/frame-schema.ts
@@ -182,7 +182,7 @@ export const FrameSchema = z.object({
   /** Searchable keywords for recall */
   keywords: z.array(z.string()).optional(),
 
-  /** CodeAtlas reference */
+  /** Opaque reference to a legacy Policy Neighborhood snapshot */
   atlas_frame_id: z.string().optional(),
 
   /** Active feature flags */

--- a/src/shared/types/policy.ts
+++ b/src/shared/types/policy.ts
@@ -82,7 +82,7 @@ export interface PolicyModule {
 
   /**
    * Spatial coordinates for visual layout [x, y]
-   * Used by shared/atlas/ to render Atlas Frames with proper positioning
+   * Used by shared/atlas/ to render Policy Neighborhoods with proper positioning
    */
   coords?: [number, number];
 


### PR DESCRIPTION
Closes #805

## What changed

- Added a canonical terminology and ownership map for Policy Neighborhood, Code Index, and Frame Graph.
- Updated active documentation and human-facing descriptions to use the owning concept instead of the overloaded “Atlas” umbrella.
- Classified mixed legacy source surfaces without renaming public symbols, package paths, CLI/MCP/HTTP routes, schemas, or serialized fields.
- Added documentation validation that guards the concept map, ownership links, compatibility surfaces, and follow-up issues.
- Opened additive compatibility follow-ups #806, #807, and #808.

## Why

“Atlas” described three independent systems with different owners, consumers, and failure behavior. That made runner integration and maintenance discussions ambiguous and encouraged accidental coupling.

## Impact

New work has precise vocabulary while existing integrations remain compatible. Policy Neighborhood is the runner-relevant enrichment path; Code Index remains experimental; Frame Graph remains the historical relationship implementation.

## Validation

- focused MCP/CLI/policy behavior suite — 83 tests passed
- full repository test suite passed
- `npm run lint`
- `npm run type-check`
- `npm run validate-docs` with the new terminology drift guard
- `npm run check:public-api`
- signed commit verified locally