### PR TITLE
feat(policy): generate deterministic native maps

### DIFF
--- a/src/shared/cli/README.md
+++ b/src/shared/cli/README.md
@@ -17,10 +17,13 @@ lex init
 # PostgreSQL-only initialization (does not create or open memory.db)
 lex init --store postgres --yes
 
-# Generate seed policy from directory structure
+# Generate a deterministic structural policy
 lex init --policy
-# Scans src/ for TypeScript/JavaScript modules
+# Scans first-party code directories across the repository
 # Generates .smartergpt/lex/lexmap.policy.json with discovered modules
+
+# Constrain discovery for a legacy layout
+lex init --policy --src-dir packages/server/src
 
 # Force overwrite existing workspace
 lex init --force --policy
@@ -30,9 +33,10 @@ lex init --force --policy
 1. Create `.smartergpt/` workspace directory
 2. Copy canon prompts to `.smartergpt/prompts/`
 3. If `--policy` flag is set:
-   - Scan `src/` directory for TypeScript/JavaScript files
-   - Generate module IDs from directory paths (e.g., `src/memory/store/` → `memory/store`)
-   - Create policy file with discovered modules and match patterns
+   - Scan first-party TypeScript, JavaScript, Python, C/C++, Objective-C++, Swift, and protobuf directories
+   - Exclude dependency, cache, generated-output, and build roots
+   - Pair equivalent `src/` and `include/` directories under stable module IDs
+   - Create canonical, non-overlapping `owns_paths` entries
 4. Otherwise, copy example policy or create minimal policy
 5. Select SQLite by default, or PostgreSQL from `--store`, `LEX_STORE`, or a configured `LEX_DATABASE_URL`
 6. Non-destructive and idempotent: create missing bootstrap files and preserve existing files unless `--force`
@@ -40,7 +44,8 @@ lex init --force --policy
 **Options:**
 - `--force` — Overwrite existing files
 - `--store <backend>` — Select `sqlite` or `postgres` for initialization
-- `--policy` — Generate seed policy from src/ directory structure
+- `--policy` — Generate a deterministic structural policy
+- `--src-dir <dir>` — Constrain structural discovery to one repository-relative subtree
 - `--prompts-dir <path>` — Custom prompts directory (default: .smartergpt/prompts)
 
 ### `lex remember`
@@ -271,6 +276,22 @@ lex policy check --match --src-dir lib
 
 **Status:** ✅ Implemented
 
+### `lex policy generate`
+
+Generate the same deterministic structural policy independently of workspace
+initialization.
+
+```bash
+lex policy generate
+lex policy generate --root /path/to/repo --output policy.json
+lex policy generate --src-dir packages/native/src
+lex policy generate --force
+```
+
+The default output is `.smartergpt/lex/lexmap.policy.json`. Existing output is
+preserved unless `--force` is explicit. Module IDs and `owns_paths` are sorted,
+path-normalized, timestamp-free, and byte-stable for an unchanged tree.
+
 **Commands available:**
 - ✅ `lex init` — Initialize workspace with prompts and policy (with `--policy` for auto-generation)
 - ✅ `lex remember` — Capture work session frames
@@ -278,6 +299,7 @@ lex policy check --match --src-dir lib
 - ✅ `lex check` — Enforce policy in CI
 - ✅ `lex timeline` — Visualize frame evolution
 - ✅ `lex policy check` — Validate policy file syntax and module-codebase mapping
+- ✅ `lex policy generate` — Generate scanner-compatible structural ownership
 
 **Depends on:**
 - ✅ `memory/frames/`, `memory/store/`, `memory/recall` implementations

--- a/src/shared/cli/index.ts
+++ b/src/shared/cli/index.ts
@@ -35,6 +35,7 @@ import {
 } from "./db.js";
 import { policyCheck, type PolicyCheckOptions } from "./policy-check.js";
 import { policyAddModule, type PolicyAddModuleOptions } from "./policy-add-module.js";
+import { policyGenerate, type PolicyGenerateOptions } from "./policy-generate.js";
 import { codeAtlas, type CodeAtlasOptions } from "./code-atlas.js";
 import {
   instructionsInit,
@@ -126,7 +127,8 @@ export function createProgram(programOptions: CreateProgramOptionsV1 = {}): Comm
     .description("Initialize .smartergpt/ workspace with prompts, policy, and instructions")
     .option("--force", "Overwrite existing files")
     .option("--store <backend>", "Storage backend for initialization (sqlite or postgres)")
-    .option("--policy", "Generate seed policy from src/ directory structure")
+    .option("--policy", "Generate a structural seed policy from repository code")
+    .option("--src-dir <dir>", "Constrain policy discovery to a repository-relative directory")
     .option("--prompts-dir <path>", "Custom prompts directory (default: .smartergpt/prompts)")
     .option("--no-instructions", "Skip creating canonical instructions file")
     .option("--mcp", "Generate .vscode/mcp.json for MCP server configuration")
@@ -138,6 +140,7 @@ export function createProgram(programOptions: CreateProgramOptionsV1 = {}): Comm
         force: cmdOptions.force || false,
         store: cmdOptions.store,
         policy: cmdOptions.policy || false,
+        srcDir: cmdOptions.srcDir,
         json: globalOptions.json || false,
         promptsDir: cmdOptions.promptsDir,
         instructions: cmdOptions.instructions,
@@ -531,6 +534,26 @@ export function createProgram(programOptions: CreateProgramOptionsV1 = {}): Comm
 
   // lex policy command group
   const policyCommand = program.command("policy").description("Policy file operations");
+
+  // lex policy generate
+  policyCommand
+    .command("generate")
+    .description("Generate a deterministic structural policy for a mixed-language repository")
+    .option("--root <path>", "Repository root (default: current directory)")
+    .option("--src-dir <dir>", "Constrain discovery to a repository-relative directory")
+    .option("--output <path>", "Output path (default: .smartergpt/lex/lexmap.policy.json)")
+    .option("--force", "Overwrite an existing output file")
+    .action(async (cmdOptions) => {
+      const globalOptions = program.opts();
+      const options: PolicyGenerateOptions = {
+        rootDir: cmdOptions.root,
+        srcDir: cmdOptions.srcDir,
+        policyPath: cmdOptions.output,
+        force: cmdOptions.force || false,
+        json: globalOptions.json || false,
+      };
+      await policyGenerate(options);
+    });
 
   // lex policy check
   policyCommand

--- a/src/shared/cli/init.ts
+++ b/src/shared/cli/init.ts
@@ -24,6 +24,7 @@ export interface InitOptions {
   store?: string; // Explicit FrameStore backend for initialization
   promptsDir?: string; // Optional: custom prompts directory
   policy?: boolean; // Generate seed policy from directory structure
+  srcDir?: string; // Optional constrained discovery root for policy generation
   instructions?: boolean; // Create canonical instructions file (default: true)
   mcp?: boolean; // Generate .vscode/mcp.json for MCP server configuration
   yes?: boolean; // Non-interactive mode (skip prompts)
@@ -205,7 +206,7 @@ export async function init(options: InitOptions = {}): Promise<InitResult> {
     if (!fs.existsSync(policyPath) || options.force) {
       if (options.policy) {
         // Generate seed policy from directory structure
-        const modules = discoverModules({ rootDir: baseDir });
+        const modules = discoverModules({ rootDir: baseDir, srcDir: options.srcDir });
         modulesDiscovered = modules.length;
 
         if (modules.length > 0) {

--- a/src/shared/cli/policy-generate.ts
+++ b/src/shared/cli/policy-generate.ts
@@ -1,0 +1,77 @@
+/**
+ * CLI Command: lex policy generate
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { dirname, isAbsolute, resolve } from "path";
+import { AXErrorException } from "../errors/ax-error.js";
+import { POLICY_ERROR_CODES } from "../errors/error-codes.js";
+import { validatePolicySchema } from "../policy/schema.js";
+import * as output from "./output.js";
+import { discoverModules, generatePolicyFile } from "./policy-generator.js";
+
+const DEFAULT_POLICY_PATH = ".smartergpt/lex/lexmap.policy.json";
+
+export interface PolicyGenerateOptions {
+  rootDir?: string;
+  srcDir?: string;
+  policyPath?: string;
+  force?: boolean;
+  json?: boolean;
+}
+
+export interface PolicyGenerateResult {
+  success: true;
+  rootDir: string;
+  policyPath: string;
+  modulesDiscovered: number;
+  moduleIds: string[];
+}
+
+export async function policyGenerate(
+  options: PolicyGenerateOptions = {}
+): Promise<PolicyGenerateResult> {
+  const rootDir = resolve(options.rootDir ?? process.cwd());
+  const configuredPath = options.policyPath ?? DEFAULT_POLICY_PATH;
+  const policyPath = isAbsolute(configuredPath) ? configuredPath : resolve(rootDir, configuredPath);
+
+  if (existsSync(policyPath) && !options.force) {
+    throw new AXErrorException(
+      POLICY_ERROR_CODES.POLICY_ALREADY_EXISTS,
+      `Policy file already exists: ${policyPath}`,
+      ["Pass --force to replace it, or select another path with --output."],
+      { policyPath }
+    );
+  }
+
+  const modules = discoverModules({ rootDir, srcDir: options.srcDir });
+  const policy = generatePolicyFile(modules);
+  const validation = validatePolicySchema(policy);
+  if (!validation.valid) {
+    throw new AXErrorException(
+      POLICY_ERROR_CODES.POLICY_INVALID,
+      "Generated policy failed canonical validation.",
+      ["Inspect the generated module IDs and ownership paths."],
+      { errors: validation.errors }
+    );
+  }
+
+  mkdirSync(dirname(policyPath), { recursive: true });
+  writeFileSync(policyPath, `${JSON.stringify(policy, null, 2)}\n`, "utf8");
+
+  const result: PolicyGenerateResult = {
+    success: true,
+    rootDir,
+    policyPath,
+    modulesDiscovered: modules.length,
+    moduleIds: modules.map((module) => module.id),
+  };
+
+  if (options.json) {
+    output.json(result);
+  } else {
+    output.success(`Generated ${policyPath}`);
+    output.info(`Discovered ${modules.length} module${modules.length === 1 ? "" : "s"}.`);
+  }
+  return result;
+}

--- a/src/shared/cli/policy-generator.ts
+++ b/src/shared/cli/policy-generator.ts
@@ -1,32 +1,30 @@
 /**
- * Policy Generator - Scan directory structure and generate seed policy
+ * Deterministic structural policy generator.
+ *
+ * The generator intentionally discovers directory ownership, not symbols. It
+ * gives scanners stable module IDs for mixed-language repositories while
+ * leaving semantic extraction to language-specific tooling.
  */
 
 import * as fs from "fs";
 import * as path from "path";
+import { AXErrorException } from "../errors/ax-error.js";
+import { POLICY_ERROR_CODES } from "../errors/error-codes.js";
 
 export interface PolicyGeneratorOptions {
-  /**
-   * Root directory to scan (default: process.cwd())
-   */
+  /** Repository root to scan (default: process.cwd()). */
   rootDir?: string;
-
-  /**
-   * Source directory to scan for modules (default: "src")
-   */
+  /** Optional repository-relative subtree for constrained/legacy discovery. */
   srcDir?: string;
-
-  /**
-   * Schema version for the policy file
-   */
+  /** Schema version for the generated policy file. */
   schemaVersion?: string;
 }
 
 export interface DiscoveredModule {
   id: string;
   description: string;
-  match: string[];
-  sourcePath: string;
+  ownsPaths: string[];
+  sourcePaths: string[];
 }
 
 export interface PolicyFile {
@@ -35,126 +33,288 @@ export interface PolicyFile {
     string,
     {
       description: string;
-      match: string[];
+      owns_paths: string[];
     }
   >;
 }
 
-/**
- * Directories to exclude from module scanning
- */
-const EXCLUDED_DIRECTORIES = ["node_modules", "dist", "build", ".git", "vendor"];
+const CODE_EXTENSIONS = new Set([
+  // TypeScript and JavaScript (legacy generator support).
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".py",
+  // C, C++, Objective-C++, headers, templates, and module interfaces.
+  ".c",
+  ".cc",
+  ".cpp",
+  ".cxx",
+  ".c++",
+  ".h",
+  ".hh",
+  ".hpp",
+  ".hxx",
+  ".h++",
+  ".inc",
+  ".inl",
+  ".ipp",
+  ".tpp",
+  ".m",
+  ".mm",
+  ".ixx",
+  ".cppm",
+  ".mpp",
+  ".ccm",
+  ".cxxm",
+  // Common first-party neighbors in native repositories.
+  ".proto",
+  ".swift",
+]);
 
-/**
- * Check if a directory should be excluded from scanning
- */
-function isExcludedDirectory(name: string): boolean {
-  return EXCLUDED_DIRECTORIES.includes(name) || name.startsWith(".");
+const EXCLUDED_DIRECTORIES = new Set(
+  [
+    "node_modules",
+    "vendor",
+    "vendors",
+    "deps",
+    "dependencies",
+    "third_party",
+    "third-party",
+    "external",
+    "xmake-packages",
+    "vcpkg_installed",
+    "build",
+    "builds",
+    "dist",
+    "out",
+    "output",
+    "target",
+    "bin",
+    "obj",
+    "coverage",
+    "generated",
+    "cmakefiles",
+    "_deps",
+    "cache",
+    "caches",
+    "tmp",
+    "temp",
+    "__pycache__",
+  ].map((entry) => entry.toLowerCase())
+);
+
+function stableCompare(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
-/**
- * Check if a directory contains TypeScript or JavaScript files
- */
-function hasCodeFiles(dirPath: string): boolean {
+function normalizePath(value: string): string {
+  return value
+    .split(path.sep)
+    .join("/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/+/g, "/");
+}
+
+function isExcludedDirectory(name: string): boolean {
+  return name.startsWith(".") || EXCLUDED_DIRECTORIES.has(name.toLowerCase());
+}
+
+function isCodeFile(name: string): boolean {
+  return CODE_EXTENSIONS.has(path.extname(name).toLowerCase());
+}
+
+function directCodeFiles(dirPath: string): string[] {
   try {
-    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
-    return entries.some((entry) => {
-      if (entry.isFile()) {
-        const ext = path.extname(entry.name).toLowerCase();
-        return ext === ".ts" || ext === ".js" || ext === ".tsx" || ext === ".jsx";
-      }
-      return false;
-    });
+    return fs
+      .readdirSync(dirPath, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && isCodeFile(entry.name))
+      .map((entry) => entry.name)
+      .sort(stableCompare);
   } catch {
-    return false;
+    return [];
   }
 }
 
+function sanitizeModuleSegment(segment: string): string {
+  const normalized = segment
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-");
+  let start = 0;
+  let end = normalized.length;
+
+  while (start < end && normalized[start] === "-") {
+    start += 1;
+  }
+  while (end > start && normalized[end - 1] === "-") {
+    end -= 1;
+  }
+
+  return normalized.slice(start, end);
+}
+
 /**
- * Recursively scan directory for modules
+ * Remove structural src/include markers so equivalent public and private trees
+ * resolve to one module ID.
  */
-function scanDirectory(
-  dirPath: string,
-  srcDir: string,
+function moduleIdForDirectory(
   rootDir: string,
-  modules: DiscoveredModule[]
-): void {
-  try {
-    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  scanRoot: string,
+  directory: string,
+  constrained: boolean
+): string {
+  const relativePath = normalizePath(path.relative(constrained ? scanRoot : rootDir, directory));
+  const rawSegments = relativePath ? relativePath.split("/") : [];
+  const structuralSegments = constrained
+    ? rawSegments
+    : rawSegments.filter(
+        (segment) => segment.toLowerCase() !== "src" && segment.toLowerCase() !== "include"
+      );
+  const normalizedSegments = structuralSegments.map(sanitizeModuleSegment).filter(Boolean);
+  return normalizedSegments.join("/") || "root";
+}
+
+function scanCodeDirectories(scanRoot: string): string[] {
+  const directories: string[] = [];
+
+  function visit(directory: string): void {
+    if (directCodeFiles(directory).length > 0) {
+      directories.push(directory);
+    }
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs
+        .readdirSync(directory, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
+        .sort((left, right) => stableCompare(left.name, right.name));
+    } catch {
+      return;
+    }
 
     for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
+      if (!isExcludedDirectory(entry.name)) {
+        visit(path.join(directory, entry.name));
       }
-
-      const fullPath = path.join(dirPath, entry.name);
-
-      // Skip excluded directories
-      if (isExcludedDirectory(entry.name)) {
-        continue;
-      }
-
-      // Check if this directory or its subdirectories contain code files
-      if (hasCodeFiles(fullPath)) {
-        // Generate module ID from path
-        const relativePath = path.relative(srcDir, fullPath);
-        const moduleId = relativePath.split(path.sep).join("/");
-
-        modules.push({
-          id: moduleId,
-          description: `Auto-detected from ${path.relative(rootDir, fullPath)}/`,
-          match: [`${path.relative(rootDir, fullPath)}/**`],
-          sourcePath: fullPath,
-        });
-      }
-
-      // Recursively scan subdirectories
-      scanDirectory(fullPath, srcDir, rootDir, modules);
     }
-  } catch {
-    // Skip directories we can't read
   }
+
+  visit(scanRoot);
+  return directories;
+}
+
+function isPathContained(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+}
+
+function resolveScanRoot(
+  rootDir: string,
+  srcDir: string | undefined
+): {
+  scanRoot: string;
+  constrained: boolean;
+} {
+  if (!srcDir) {
+    return { scanRoot: rootDir, constrained: false };
+  }
+
+  const fail = (): never => {
+    throw new AXErrorException(
+      POLICY_ERROR_CODES.POLICY_SOURCE_DIR_OUTSIDE_ROOT,
+      `Policy source directory must stay inside the repository: ${srcDir}`,
+      ["Use a repository-relative --src-dir that does not escape the repository root."],
+      { rootDir, srcDir }
+    );
+  };
+
+  if (path.isAbsolute(srcDir)) {
+    return fail();
+  }
+
+  const scanRoot = path.resolve(rootDir, srcDir);
+  if (!isPathContained(rootDir, scanRoot)) {
+    return fail();
+  }
+
+  if (fs.existsSync(rootDir) && fs.existsSync(scanRoot)) {
+    const physicalRoot = fs.realpathSync(rootDir);
+    const physicalScanRoot = fs.realpathSync(scanRoot);
+    if (!isPathContained(physicalRoot, physicalScanRoot)) {
+      return fail();
+    }
+  }
+
+  return { scanRoot, constrained: true };
 }
 
 /**
- * Discover modules from directory structure
+ * Discover direct code-bearing directories across a repository.
+ *
+ * Ownership uses `directory/*`, not `directory/**`, so a parent module never
+ * swallows a nested module. Equivalent `src` and `include` directories are
+ * paired by normalized module ID.
  */
 export function discoverModules(options: PolicyGeneratorOptions = {}): DiscoveredModule[] {
-  const rootDir = options.rootDir || process.cwd();
-  const srcDirName = options.srcDir || "src";
-  const srcDir = path.join(rootDir, srcDirName);
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const { scanRoot, constrained } = resolveScanRoot(rootDir, options.srcDir);
 
-  if (!fs.existsSync(srcDir)) {
+  if (!fs.existsSync(scanRoot) || !fs.statSync(scanRoot).isDirectory()) {
     return [];
   }
 
-  const modules: DiscoveredModule[] = [];
-  scanDirectory(srcDir, srcDir, rootDir, modules);
+  const grouped = new Map<string, { ownsPaths: Set<string>; sourcePaths: Set<string> }>();
 
-  // Sort modules by ID for consistent output
-  modules.sort((a, b) => a.id.localeCompare(b.id));
+  for (const directory of scanCodeDirectories(scanRoot)) {
+    const id = moduleIdForDirectory(rootDir, scanRoot, directory, constrained);
+    const relativeDirectory = normalizePath(path.relative(rootDir, directory));
+    const ownershipPattern = relativeDirectory ? `${relativeDirectory}/*` : "*";
+    const group = grouped.get(id) ?? { ownsPaths: new Set(), sourcePaths: new Set() };
+    group.ownsPaths.add(ownershipPattern);
+    group.sourcePaths.add(directory);
+    grouped.set(id, group);
+  }
 
-  return modules;
+  return [...grouped.entries()]
+    .sort(([left], [right]) => stableCompare(left, right))
+    .map(([id, group]) => {
+      const ownsPaths = [...group.ownsPaths].sort(stableCompare);
+      const detectedDirectories = ownsPaths.map((entry) =>
+        entry === "*" ? "." : entry.replace(/\/\*$/, "")
+      );
+      return {
+        id,
+        description: `Auto-detected from ${detectedDirectories
+          .map((directory) => `${directory}/`)
+          .join(", ")}`,
+        ownsPaths,
+        sourcePaths: [...group.sourcePaths].sort(stableCompare),
+      };
+    });
 }
 
-/**
- * Generate policy file content from discovered modules
- */
+/** Generate canonical, byte-stable policy data from discovered modules. */
 export function generatePolicyFile(
   modules: DiscoveredModule[],
   options: PolicyGeneratorOptions = {}
 ): PolicyFile {
-  const schemaVersion = options.schemaVersion || "1.0.0";
-
   const policy: PolicyFile = {
-    schemaVersion,
+    schemaVersion: options.schemaVersion ?? "1.0.0",
     modules: {},
   };
 
-  for (const module of modules) {
+  for (const module of [...modules].sort((left, right) => stableCompare(left.id, right.id))) {
     policy.modules[module.id] = {
       description: module.description,
-      match: module.match,
+      owns_paths: [...module.ownsPaths].sort(stableCompare),
     };
   }
 

--- a/src/shared/errors/error-codes.ts
+++ b/src/shared/errors/error-codes.ts
@@ -31,6 +31,10 @@ export const CONFIG_ERROR_CODES = {
 export const POLICY_ERROR_CODES = {
   /** No policy file found in any search path */
   POLICY_NOT_FOUND: "POLICY_NOT_FOUND",
+  /** A policy output already exists and overwrite was not explicit */
+  POLICY_ALREADY_EXISTS: "POLICY_ALREADY_EXISTS",
+  /** A constrained policy source directory resolves outside the repository */
+  POLICY_SOURCE_DIR_OUTSIDE_ROOT: "POLICY_SOURCE_DIR_OUTSIDE_ROOT",
   /** Policy file exists but has invalid JSON */
   POLICY_PARSE_ERROR: "POLICY_PARSE_ERROR",
   /** Policy file fails schema validation */

--- a/src/shared/runtime-scope/capabilities.ts
+++ b/src/shared/runtime-scope/capabilities.ts
@@ -37,6 +37,7 @@ export type TrustedCliOperation =
   | "db:encrypt"
   | "db:stats"
   | "policy:check"
+  | "policy:generate"
   | "policy:add-module"
   | "instructions:init"
   | "instructions:generate"
@@ -84,6 +85,7 @@ const CLI_CAPABILITIES: Readonly<Record<TrustedCliOperation, readonly Capability
     "db:encrypt": Object.freeze([RUNTIME_OPERATION_CAPABILITIES.FRAME_ADMIN]),
     "db:stats": Object.freeze([RUNTIME_OPERATION_CAPABILITIES.FRAME_READ]),
     "policy:check": Object.freeze([]),
+    "policy:generate": Object.freeze([]),
     "policy:add-module": Object.freeze([]),
     "instructions:init": Object.freeze([]),
     "instructions:generate": Object.freeze([]),

--- a/test/shared/cli/init.test.ts
+++ b/test/shared/cli/init.test.ts
@@ -93,9 +93,9 @@ test("init: with --policy flag generates seed policy from src/ directory", async
       "Should have correct description"
     );
     assert.deepStrictEqual(
-      policyContent.modules["memory/store"].match,
-      ["src/memory/store/**"],
-      "Should have correct match pattern"
+      policyContent.modules["memory/store"].owns_paths,
+      ["src/memory/store/*"],
+      "Should have canonical direct-directory ownership"
     );
   } finally {
     process.chdir(originalCwd);
@@ -240,6 +240,59 @@ test("init: --policy supports JavaScript files", async () => {
     const policyContent = JSON.parse(readFileSync(policyPath, "utf-8"));
 
     assert.ok(policyContent.modules["utils"], "Should have utils module");
+  } finally {
+    process.chdir(originalCwd);
+    cleanup();
+  }
+});
+
+test("init: --policy discovers nested C++ source roots", async () => {
+  setupTest();
+  const originalCwd = process.cwd();
+
+  try {
+    process.chdir(testDir);
+    mkdirSync(join(testDir, "mods/src/patches"), { recursive: true });
+    mkdirSync(join(testDir, "mods/include/patches"), { recursive: true });
+    writeFileSync(join(testDir, "mods/src/patches/patch.cc"), "// implementation");
+    writeFileSync(join(testDir, "mods/include/patches/patch.hpp"), "// interface");
+
+    const result = await init({ policy: true, json: true });
+    const policyPath = join(testDir, ".smartergpt/lex/lexmap.policy.json");
+    const policyContent = JSON.parse(readFileSync(policyPath, "utf-8"));
+
+    assert.strictEqual(result.modulesDiscovered, 1);
+    assert.deepStrictEqual(policyContent.modules["mods/patches"].owns_paths, [
+      "mods/include/patches/*",
+      "mods/src/patches/*",
+    ]);
+  } finally {
+    process.chdir(originalCwd);
+    cleanup();
+  }
+});
+
+test("init: --policy forwards constrained --src-dir discovery", async () => {
+  setupTest();
+  const originalCwd = process.cwd();
+
+  try {
+    process.chdir(testDir);
+    mkdirSync(join(testDir, "packages/native/src/core"), { recursive: true });
+    mkdirSync(join(testDir, "elsewhere/src/ignored"), { recursive: true });
+    writeFileSync(join(testDir, "packages/native/src/core/main.cpp"), "// native");
+    writeFileSync(join(testDir, "elsewhere/src/ignored/main.cpp"), "// ignored");
+
+    const result = await init({
+      policy: true,
+      srcDir: "packages/native/src",
+      json: true,
+    });
+    const policyPath = join(testDir, ".smartergpt/lex/lexmap.policy.json");
+    const policyContent = JSON.parse(readFileSync(policyPath, "utf-8"));
+
+    assert.strictEqual(result.modulesDiscovered, 1);
+    assert.deepStrictEqual(Object.keys(policyContent.modules), ["core"]);
   } finally {
     process.chdir(originalCwd);
     cleanup();

--- a/test/shared/cli/policy-generator.test.ts
+++ b/test/shared/cli/policy-generator.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AXErrorException } from "../../../src/shared/errors/ax-error.js";
+import { policyGenerate } from "../../../src/shared/cli/policy-generate.js";
+import { discoverModules, generatePolicyFile } from "../../../src/shared/cli/policy-generator.js";
+import { validatePolicySchema } from "../../../src/shared/policy/schema.js";
+
+const roots: string[] = [];
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "lex-policy-generator-"));
+  roots.push(root);
+  return root;
+}
+
+function code(root: string, relativePath: string, content = "// fixture\n"): void {
+  const target = join(root, relativePath);
+  mkdirSync(join(target, ".."), { recursive: true });
+  writeFileSync(target, content);
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("discovers legacy TypeScript and JavaScript modules", () => {
+  const root = fixture();
+  code(root, "src/api/index.ts");
+  code(root, "src/scripts/tool.py");
+  code(root, "src/web/index.jsx");
+
+  assert.deepEqual(
+    discoverModules({ rootDir: root }).map((module) => module.id),
+    ["api", "scripts", "web"]
+  );
+});
+
+test("recognizes C and C++ implementation and header extensions", () => {
+  const root = fixture();
+  for (const extension of [
+    "c",
+    "cc",
+    "cpp",
+    "cxx",
+    "c++",
+    "h",
+    "hh",
+    "hpp",
+    "hxx",
+    "h++",
+    "inc",
+    "inl",
+    "ipp",
+    "tpp",
+  ]) {
+    code(root, `native/src/core/file.${extension}`);
+  }
+
+  const [module] = discoverModules({ rootDir: root });
+  assert.equal(module.id, "native/core");
+  assert.deepEqual(module.ownsPaths, ["native/src/core/*"]);
+});
+
+test("recognizes Objective-C++ and C++ module interfaces", () => {
+  const root = fixture();
+  for (const extension of ["m", "mm", "ixx", "cppm", "mpp", "ccm", "cxxm"]) {
+    code(root, `platform/src/bridge/file.${extension}`);
+  }
+
+  assert.deepEqual(
+    discoverModules({ rootDir: root }).map((module) => module.id),
+    ["platform/bridge"]
+  );
+});
+
+test("retains Swift and protobuf neighbors in mixed native repositories", () => {
+  const root = fixture();
+  code(root, "launcher/src/view-model/state.swift");
+  code(root, "mods/src/protocol/events.proto");
+
+  assert.deepEqual(
+    discoverModules({ rootDir: root }).map((module) => module.id),
+    ["launcher/view-model", "mods/protocol"]
+  );
+});
+
+test("discovers nested repository roots instead of assuming root src", () => {
+  const root = fixture();
+  code(root, "mods/src/patches/patch.cc");
+  code(root, "win-proxy-dll/src/main.cc");
+  code(root, "tests/tools/decode.cc");
+
+  assert.deepEqual(
+    discoverModules({ rootDir: root }).map((module) => module.id),
+    ["mods/patches", "tests/tools", "win-proxy-dll"]
+  );
+});
+
+test("pairs equivalent src and include directories", () => {
+  const root = fixture();
+  code(root, "engine/src/math/vector.cpp");
+  code(root, "engine/include/math/vector.hpp");
+
+  const [module] = discoverModules({ rootDir: root });
+  assert.equal(module.id, "engine/math");
+  assert.deepEqual(module.ownsPaths, ["engine/include/math/*", "engine/src/math/*"]);
+  assert.equal(module.description, "Auto-detected from engine/include/math/, engine/src/math/");
+});
+
+test("uses non-overlapping direct-directory ownership for nested modules", () => {
+  const root = fixture();
+  code(root, "mods/src/patches/root.cc");
+  code(root, "mods/src/patches/parts/nested.cc");
+
+  const policy = generatePolicyFile(discoverModules({ rootDir: root }));
+  assert.deepEqual(policy.modules["mods/patches"].owns_paths, ["mods/src/patches/*"]);
+  assert.deepEqual(policy.modules["mods/patches/parts"].owns_paths, ["mods/src/patches/parts/*"]);
+  assert.ok(!policy.modules["mods/patches"].owns_paths[0].includes("**"));
+});
+
+test("excludes dependency, build, cache, and generated-output roots", () => {
+  const root = fixture();
+  code(root, "src/owned/main.cpp");
+  for (const excluded of [
+    "node_modules",
+    "vendor",
+    "deps",
+    "third_party",
+    "external",
+    "xmake-packages",
+    "vcpkg_installed",
+    "build",
+    "dist",
+    "out",
+    "target",
+    "coverage",
+    "generated",
+    "_deps",
+    "cache",
+    "tmp",
+  ]) {
+    code(root, `${excluded}/foreign/file.cpp`);
+  }
+
+  assert.deepEqual(
+    discoverModules({ rootDir: root }).map((module) => module.id),
+    ["owned"]
+  );
+});
+
+test("excludes hidden roots", () => {
+  const root = fixture();
+  code(root, ".cache/native/file.cpp");
+  code(root, ".private/file.cpp");
+  code(root, "src/public/file.cpp");
+
+  assert.deepEqual(
+    discoverModules({ rootDir: root }).map((module) => module.id),
+    ["public"]
+  );
+});
+
+test("ignores documentation and configuration-only directories", () => {
+  const root = fixture();
+  code(root, "docs/README.md");
+  code(root, "config/settings.json", "{}");
+
+  assert.deepEqual(discoverModules({ rootDir: root }), []);
+});
+
+test("normalizes uppercase and punctuation in module IDs", () => {
+  const root = fixture();
+  code(root, "MacOS Launcher/src/View Model/main.mm");
+
+  const [module] = discoverModules({ rootDir: root });
+  assert.equal(module.id, "macos-launcher/view-model");
+  assert.deepEqual(module.ownsPaths, ["MacOS Launcher/src/View Model/*"]);
+});
+
+test("trims repeated edge punctuation in linear time", () => {
+  const root = fixture();
+  code(root, "----Native API----/src/----Core----/main.cpp");
+
+  const [module] = discoverModules({ rootDir: root });
+  assert.equal(module.id, "native-api/core");
+  assert.deepEqual(module.ownsPaths, ["----Native API----/src/----Core----/*"]);
+});
+
+test("constrained src-dir discovery preserves legacy relative IDs", () => {
+  const root = fixture();
+  code(root, "packages/native/src/core/main.cpp");
+  code(root, "elsewhere/src/ignored/main.cpp");
+
+  const modules = discoverModules({ rootDir: root, srcDir: "packages/native/src" });
+  assert.deepEqual(
+    modules.map((module) => module.id),
+    ["core"]
+  );
+  assert.deepEqual(modules[0].ownsPaths, ["packages/native/src/core/*"]);
+});
+
+test("missing constrained src-dir produces an empty policy", () => {
+  const root = fixture();
+  assert.deepEqual(discoverModules({ rootDir: root, srcDir: "missing" }), []);
+});
+
+test("rejects an absolute constrained src-dir", () => {
+  const root = fixture();
+  const absoluteSource = join(root, "src");
+
+  assert.throws(
+    () => discoverModules({ rootDir: root, srcDir: absoluteSource }),
+    (error: unknown) =>
+      error instanceof AXErrorException &&
+      error.toAXError().code === "POLICY_SOURCE_DIR_OUTSIDE_ROOT"
+  );
+});
+
+test("rejects a constrained src-dir that escapes the repository", () => {
+  const root = fixture();
+
+  assert.throws(
+    () => discoverModules({ rootDir: root, srcDir: "../outside" }),
+    (error: unknown) =>
+      error instanceof AXErrorException &&
+      error.toAXError().code === "POLICY_SOURCE_DIR_OUTSIDE_ROOT"
+  );
+});
+
+test("rejects a constrained src-dir symlink that escapes the repository", () => {
+  const root = fixture();
+  const outside = fixture();
+  code(outside, "src/core/main.cpp");
+  symlinkSync(
+    join(outside, "src"),
+    join(root, "linked-src"),
+    process.platform === "win32" ? "junction" : "dir"
+  );
+
+  assert.throws(
+    () => discoverModules({ rootDir: root, srcDir: "linked-src" }),
+    (error: unknown) =>
+      error instanceof AXErrorException &&
+      error.toAXError().code === "POLICY_SOURCE_DIR_OUTSIDE_ROOT"
+  );
+});
+
+test("direct root code uses a stable root module", () => {
+  const root = fixture();
+  code(root, "main.cpp");
+
+  const [module] = discoverModules({ rootDir: root });
+  assert.equal(module.id, "root");
+  assert.deepEqual(module.ownsPaths, ["*"]);
+  assert.equal(module.description, "Auto-detected from ./");
+});
+
+test("generated module IDs and ownership paths are byte deterministic", () => {
+  const root = fixture();
+  code(root, "zeta/src/z.cpp");
+  code(root, "alpha/src/a.cpp");
+  code(root, "alpha/include/a.hpp");
+
+  const first = `${JSON.stringify(generatePolicyFile(discoverModules({ rootDir: root })), null, 2)}\n`;
+  const second = `${JSON.stringify(generatePolicyFile(discoverModules({ rootDir: root })), null, 2)}\n`;
+  assert.equal(first, second);
+  assert.deepEqual(Object.keys(JSON.parse(first).modules), ["alpha", "zeta"]);
+});
+
+test("generated policy passes canonical runtime schema validation", () => {
+  const root = fixture();
+  code(root, "native/src/core/main.cpp");
+
+  const validation = validatePolicySchema(generatePolicyFile(discoverModules({ rootDir: root })));
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.errors, []);
+});
+
+test("standalone generation writes the canonical default output", async () => {
+  const root = fixture();
+  code(root, "native/src/core/main.cpp");
+
+  const result = await policyGenerate({ rootDir: root, json: true });
+  assert.equal(result.modulesDiscovered, 1);
+  assert.ok(existsSync(join(root, ".smartergpt/lex/lexmap.policy.json")));
+  const policy = JSON.parse(readFileSync(join(root, ".smartergpt/lex/lexmap.policy.json"), "utf8"));
+  assert.deepEqual(policy.modules["native/core"].owns_paths, ["native/src/core/*"]);
+});
+
+test("standalone generation refuses overwrite unless force is explicit", async () => {
+  const root = fixture();
+  code(root, "native/src/core/main.cpp");
+  const outputPath = join(root, "policy.json");
+  writeFileSync(outputPath, '{"sentinel":true}\n');
+
+  await assert.rejects(
+    policyGenerate({ rootDir: root, policyPath: outputPath, json: true }),
+    (error: unknown) =>
+      error instanceof AXErrorException && error.toAXError().code === "POLICY_ALREADY_EXISTS"
+  );
+  assert.equal(readFileSync(outputPath, "utf8"), '{"sentinel":true}\n');
+
+  await policyGenerate({
+    rootDir: root,
+    policyPath: outputPath,
+    force: true,
+    json: true,
+  });
+  assert.ok(JSON.parse(readFileSync(outputPath, "utf8")).modules["native/core"]);
+});
+
+test("standalone generation accepts a custom nested output", async () => {
+  const root = fixture();
+  code(root, "src/core/main.cpp");
+
+  const result = await policyGenerate({
+    rootDir: root,
+    policyPath: "artifacts/policy/generated.json",
+    json: true,
+  });
+  assert.equal(result.policyPath, join(root, "artifacts/policy/generated.json"));
+  assert.ok(existsSync(result.policyPath));
+});

--- a/test/shared/runtime-scope/capability-map.test.ts
+++ b/test/shared/runtime-scope/capability-map.test.ts
@@ -50,6 +50,7 @@ describe("trusted operation capability drift gates", () => {
     assert.deepEqual(capabilitiesForCliInvocation(["node", "lex", "--help"]), []);
     assert.deepEqual(capabilitiesForCliInvocation(["node", "lex", "--version"]), []);
     assert.deepEqual(capabilitiesForCliOperation("policy:check"), []);
+    assert.deepEqual(capabilitiesForCliOperation("policy:generate"), []);
     assert.deepEqual(capabilitiesForCliOperation("remember"), [
       RUNTIME_OPERATION_CAPABILITIES.FRAME_READ,
       RUNTIME_OPERATION_CAPABILITIES.FRAME_WRITE,


### PR DESCRIPTION
## What changed

- add `lex policy generate` as an independent structural policy builder
- reuse the same builder from `lex init --policy`, with optional `--src-dir` constrained discovery
- recognize C/C++, Objective-C++, module interfaces, TypeScript/JavaScript, Python, Swift, and protobuf neighbors
- pair equivalent `src/` and `include/` directories under stable normalized module IDs
- emit sorted, scanner-compatible `owns_paths` with direct-directory globs
- exclude dependency, cache, generated-output, and build roots
- refuse standalone overwrite unless `--force` is explicit
- register the command in the trusted runtime operation map and document the surface
- normalize untrusted path segments with linear-time edge trimming

## Why

C/C++ repositories such as STFC Mod have nested native source roots and no single root `src/`. The previous generator could therefore emit an empty or scanner-incompatible policy. This reconstructs the recorded Windows implementation checkpoint from the issue's acceptance contract after the original local commit became unreachable.

## Impact

Native and mixed-language repositories can generate a deterministic module ontology without using the experimental Code Index. Semantic C++ extraction remains explicitly out of scope.

## Validation

- canonical Lex suite: 2,413 TypeScript tests + 149 legacy/performance tests, all passing
- focused init/generator/runtime-map suite: 49/49 passing
- type-check, ESLint, build, schema validation, Prettier, and `git diff --check`: passing
- CodeQL, Snyk, alias, determinism, snapshot, schema, and lint-budget checks: passing
- STFC Mod dogfood: 16 first-party modules; two independent outputs had identical SHA-256 `1e721b986338eb3feb1cf8ad9ab929d932ab92fbd6d56d1b8147ee55dad2c0bc`
- STFC working tree was not modified

Closes #801